### PR TITLE
Kore Team

### DIFF
--- a/pkg/apiserver/filters/members.go
+++ b/pkg/apiserver/filters/members.go
@@ -20,7 +20,9 @@
 package filters
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/appvia/kore/pkg/kore/authentication"
 	"github.com/appvia/kore/pkg/utils"
@@ -50,10 +52,14 @@ func (a *MembersHandler) Filter(req *restful.Request, resp *restful.Response, ch
 	// @step: ensure the user is a member of the team
 	user := authentication.MustGetIdentity(req.Request.Context())
 	if !user.IsGlobalAdmin() {
-		if !utils.Contains(team, user.Teams()) {
-			resp.WriteHeader(http.StatusForbidden)
+		// @TODO this needs to be removed - its VERY HACKY - but we will keep until
+		// we have a proper review of the API
+		if !strings.HasSuffix(req.Request.RequestURI, fmt.Sprintf("teams/%s", team)) {
+			if !utils.Contains(team, user.Teams()) {
+				resp.WriteHeader(http.StatusForbidden)
 
-			return
+				return
+			}
 		}
 	}
 

--- a/pkg/kore/helpers.go
+++ b/pkg/kore/helpers.go
@@ -25,6 +25,8 @@ import (
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
+	"github.com/appvia/kore/pkg/kore/authentication"
+	"github.com/appvia/kore/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,6 +45,17 @@ func TeamsToList(list *orgv1.TeamList) []string {
 	}
 
 	return items
+}
+
+// HasAccessToTeam checks if the user has access to the team
+func HasAccessToTeam(ctx context.Context, team string) bool {
+	user := authentication.MustGetIdentity(ctx)
+
+	if user.IsGlobalAdmin() {
+		return true
+	}
+
+	return utils.Contains(team, user.Teams())
 }
 
 // IsGlobalTeam checks if the namespace is global

--- a/pkg/kore/users.go
+++ b/pkg/kore/users.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
+	"github.com/appvia/kore/pkg/kore/authentication"
 	"github.com/appvia/kore/pkg/services/users"
 	"github.com/appvia/kore/pkg/services/users/model"
 
@@ -179,6 +180,10 @@ func (h *usersImpl) ListInvitations(ctx context.Context, username string) (*orgv
 
 // Delete removes the user from the kore
 func (h *usersImpl) Delete(ctx context.Context, username string) (*orgv1.User, error) {
+	if !authentication.MustGetIdentity(ctx).IsGlobalAdmin() {
+		return nil, ErrUnauthorized
+	}
+
 	// @step: check the user exists
 	u, err := h.usermgr.Users().Get(ctx, username)
 	if err != nil {
@@ -214,6 +219,10 @@ func (h *usersImpl) Delete(ctx context.Context, username string) (*orgv1.User, e
 
 // Update is responsible for updating the user
 func (h *usersImpl) Update(ctx context.Context, user *orgv1.User) (*orgv1.User, error) {
+	if !authentication.MustGetIdentity(ctx).IsGlobalAdmin() {
+		return nil, ErrUnauthorized
+	}
+
 	user.Namespace = HubNamespace
 
 	// @step: we need to validate the user


### PR DESCRIPTION
At the moment only admins can create teams this PR adds the following

// @logic
// - bypass the check if the user is a admin
// - check if the team already exists
// - if they exist then only a member of that team can update it
// - if the team does not exist then any user can claim the team and added as member
// - ensure the namespace name is valid
