### PR TITLE
Optional direct GIT release version as used for images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
   build:
     environment:
       GOPATH: /go
+      USE_GIT_VERSION: "true"
 
     working_directory: /go/src/github.com/appvia/kore
 


### PR DESCRIPTION
This should make managing the release version and what images are used for testing easy to control - for now.