### PR TITLE
Fix CLI behaviour for some basic use-cases

### DIFF
--- a/pkg/cmd/korectl/config.go
+++ b/pkg/cmd/korectl/config.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/ghodss/yaml"
 )
@@ -184,5 +185,12 @@ func (c *Config) Update() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(os.ExpandEnv(HubConfig), data, os.FileMode(0740))
+
+	configPath := os.ExpandEnv(HubConfig)
+
+	if err := os.MkdirAll(filepath.Dir(configPath), os.FileMode(0750)); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(configPath, data, os.FileMode(0640))
 }

--- a/pkg/cmd/korectl/helper.go
+++ b/pkg/cmd/korectl/helper.go
@@ -28,7 +28,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -237,13 +236,10 @@ func GetOrCreateClientConfiguration() (*Config, error) {
 	config := &Config{}
 	var content []byte
 
-	resolved := os.ExpandEnv(HubConfig)
+	configPath := os.ExpandEnv(HubConfig)
 
-	if err := os.MkdirAll(filepath.Dir(resolved), os.FileMode(0760)); err != nil {
-		return config, err
-	}
-	if _, err := os.Stat(resolved); err == nil {
-		content, err = ioutil.ReadFile(resolved)
+	if _, err := os.Stat(configPath); err == nil {
+		content, err = ioutil.ReadFile(configPath)
 		if err != nil {
 			return config, err
 		}
@@ -256,9 +252,8 @@ func GetOrCreateClientConfiguration() (*Config, error) {
 		return config, err
 	}
 
-	// @step: read in the configuration
-	if string(content) == "" {
-		content = []byte("server: ''")
+	if strings.TrimSpace(string(content)) == "" {
+		return config, nil
 	}
 
 	// @step: parse the configuration


### PR DESCRIPTION
## What

Basic behaviours:

1. Running `korectl` without any arguments

    It prints the help.

    Exit code: 0 (default behaviour)

1. Running `korectl` with an unknown command, e.g. `korectl foo``

    ```
    Error: unknown command "foo"

    Please run `korectl help` to see all available commands.
    ```

    Exit code: 1

1. Any usage errors, e.g. `korectl --foo`

    ```
    Error: flag provided but not defined: -foo
    ```

    Exit code: 1

The `CommandNotFound` handler wasn't called as the default action was defined.
This means the first parameter was considered as an argument instead of a command name.