### PR TITLE
more appropriate timeout in advance of issue #89

### DIFF
--- a/pkg/clusterappman/clusterappman.go
+++ b/pkg/clusterappman/clusterappman.go
@@ -90,7 +90,7 @@ var (
 			},
 			Namespace:       captainNamespace,
 			EnsureNamespace: true,
-			DeployTimeOut:   3 * time.Minute,
+			DeployTimeOut:   10 * time.Minute,
 		},
 		{
 			Name: "Kore Helm Repository",
@@ -99,7 +99,7 @@ var (
 			},
 			Namespace:       KoreNamespace,
 			EnsureNamespace: false,
-			DeployTimeOut:   3 * time.Minute,
+			DeployTimeOut:   10 * time.Minute,
 		},
 	}
 )


### PR DESCRIPTION
Fixes #181
Now waits long enough for all the CRD's etc to come good:

```
$ kubectl -n kore get cm kore-cluster-status -o yaml
apiVersion: v1
data:
  components: |
    - detail: We have to assume ok as we do not have an application to track
      message: System component not checked
      name: Application Controller
      status: Success
    - message: all components ready
      name: Helm Chart Operator
      status: Success
    - message: all components ready
      name: Kore Helm Repository
      status: Success
kind: ConfigMap
metadata:
  creationTimestamp: "2020-02-27T13:03:28Z"
  name: kore-cluster-status
  namespace: kore
  resourceVersion: "360734"
  selfLink: /api/v1/namespaces/kore/configmaps/kore-cluster-status
  uid: 8bf91cd6-5961-11ea-b5f7-4201ac100006
```