### PR TITLE
primary reason for static binary is to run in container so should be …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ static: golang generate-clusterappman-manifests deps spelling
 	@mkdir -p bin
 	@for binary in kore-apiserver korectl auth-proxy kore-clusterappman; do \
 		echo "--> Building $${binary} binary" ; \
-		CGO_ENABLED=0 go build -ldflags "${LFLAGS}" -tags=jsoniter -o bin/$${binary} cmd/$${binary}/*.go || exit 1; \
+		GOOS=linux CGO_ENABLED=0 go build -ldflags "${LFLAGS}" -tags=jsoniter -o bin/$${binary} cmd/$${binary}/*.go || exit 1; \
 	done
 
 korectl: golang deps spelling


### PR DESCRIPTION
…linux