### PR TITLE
Team cli commands

### DIFF
--- a/pkg/cmd/korectl/create.go
+++ b/pkg/cmd/korectl/create.go
@@ -23,20 +23,13 @@ import (
 	"github.com/urfave/cli"
 )
 
-// GetCommands returns all the commands
-func GetCommands(config *Config) []cli.Command {
-	return []cli.Command{
-		GetLoginCommand(config),
-		GetProfilesCommand(config),
-		GetLocalCommand(config),
-		GetAutoCompleteCommand(config),
-		GetApplyCommand(config),
-		GetDeleteCommand(config),
-		GetClustersCommand(config),
-		GetGetCommand(config),
-		GetCreateCommand(config),
-		GetTeamsCommands(config),
-		GetUsersCommands(config),
-		GetWhoamiCommand(config),
+func GetCreateCommand(config *Config) cli.Command {
+	return cli.Command{
+		Name:  "create",
+		Usage: "creates various objects",
+
+		Subcommands: []cli.Command{
+			GetCreateTeamCommand(config),
+		},
 	}
 }

--- a/pkg/cmd/korectl/delete.go
+++ b/pkg/cmd/korectl/delete.go
@@ -74,8 +74,11 @@ func GetDeleteCommand(config *Config) cli.Command {
 			}
 			if len(ctx.StringSlice("file")) <= 0 {
 				if ctx.NArg() != 2 {
-					return errors.New("you need to specify a resource type and ")
+					return errors.New("you need to specify a resource type and name")
 				}
+
+				resourceConfig := resourceConfigs.Get(ctx.Args().First())
+
 				req := NewRequest().
 					WithConfig(config).
 					WithContext(ctx).
@@ -84,14 +87,14 @@ func GetDeleteCommand(config *Config) cli.Command {
 
 				endpoint := "/teams/{team}/{resource}/{name}"
 
-				if IsGlobalResource(ctx.Args().First()) {
+				if IsGlobalResource(resourceConfig.APIResourceName) {
 					endpoint = "/{resource}/{name}"
 				} else {
 					req.PathParameter("team", true)
 				}
 				req.WithEndpoint(endpoint).
-					WithInject("resource", ctx.Args().First()).
-					WithInject("name", ctx.Args().Tail()[0])
+					WithInject("resource", resourceConfig.APIResourceName).
+					WithInject("name", ctx.Args()[1])
 
 				if err := req.Delete(); err != nil {
 					return err

--- a/pkg/cmd/korectl/get.go
+++ b/pkg/cmd/korectl/get.go
@@ -47,11 +47,12 @@ func GetGetCommand(config *Config) cli.Command {
 				PathParameter("resource", true).
 				PathParameter("name", false)
 
+			resourceConfig := resourceConfigs.Get(ctx.Args().First())
 			endpoint := "/teams/{team}/{resource}/{name}"
 
-			if IsGlobalResource(ctx.Args().First()) {
+			if IsGlobalResource(resourceConfig.APIResourceName) {
 				endpoint = "/{resource}/{name}"
-			} else if IsGlobalResourceOptional(ctx.Args().First()) {
+			} else if IsGlobalResourceOptional(resourceConfig.APIResourceName) {
 				if !ctx.IsSet("team") {
 					endpoint = "/{resource}/{name}"
 				} else {
@@ -62,10 +63,8 @@ func GetGetCommand(config *Config) cli.Command {
 			}
 
 			req.WithEndpoint(endpoint).
-				WithInject("resource", ctx.Args().First()).
-				Render(
-					Column("Name", ".metadata.name"),
-				)
+				WithInject("resource", resourceConfig.APIResourceName).
+				Render(resourceConfig.Columns...)
 
 			if ctx.NArg() == 2 {
 				req.WithInject("name", ctx.Args().Get(1))

--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -119,6 +119,31 @@ func (c *Requestor) Get() error {
 	return c.parseResponse()
 }
 
+// Exists will perform a GET request and will return
+//  * true on 200 response
+//  * false on 404 response
+//  * error on any other response
+func (c *Requestor) Exists() (bool, error) {
+	url, err := c.makeURI()
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := c.makeRequest(http.MethodGet, url)
+	if err != nil {
+		return false, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, c.handleResponse(resp)
+	}
+}
+
 // Edit is responsible for performing the request
 func (c *Requestor) Edit() error {
 	return nil

--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -279,7 +279,7 @@ func (c Requestor) handleResponse(resp *http.Response) error {
 	case http.StatusUnauthorized:
 		fmt.Println("[error] authorization required, please use the 'authorize' command")
 	case http.StatusNotFound:
-		fmt.Println("[error] from server (notfound): resource not found")
+		fmt.Println("[error] kind or resource does not exist")
 	case http.StatusForbidden:
 		fmt.Println("[error] request has been denied, check credentials")
 	case http.StatusBadRequest:
@@ -325,9 +325,6 @@ func (c *Requestor) makeRequest(method, url string) (*http.Response, error) {
 	resp, err := hc.Do(req)
 	if err != nil {
 		return nil, err
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, errors.New("kind or resource does not exist")
 	}
 
 	if resp.Body != nil {

--- a/pkg/cmd/korectl/resource.go
+++ b/pkg/cmd/korectl/resource.go
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2020 Appvia Ltd <info@appvia.io>
+ *
+ * This file is part of kore-apiserver.
+ *
+ * kore-apiserver is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * kore-apiserver is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with kore-apiserver.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package korectl
+
+// resourceConfig stores custom resource CLI configurations
+type resourceConfig struct {
+	Name            string
+	APIResourceName string
+	Columns         []string
+}
+
+type resourceConfigMap map[string]resourceConfig
+
+func (r resourceConfigMap) Get(name string) resourceConfig {
+	if config, ok := r[name]; ok {
+		return config
+	}
+
+	return resourceConfig{
+		Name:            name,
+		APIResourceName: name,
+		Columns: []string{
+			Column("Name", ".metadata.name"),
+		},
+	}
+}
+
+var teamResourceConfig = resourceConfig{
+	Name:            "team",
+	APIResourceName: "teams",
+	Columns: []string{
+		Column("Name", ".metadata.name"),
+		Column("Description", ".spec.description"),
+	},
+}
+
+var resourceConfigs = resourceConfigMap{
+	"team":  teamResourceConfig,
+	"teams": teamResourceConfig,
+}

--- a/pkg/cmd/korectl/teams.go
+++ b/pkg/cmd/korectl/teams.go
@@ -187,6 +187,21 @@ func GetCreateTeamCommand(config *Config) cli.Command {
 		Action: func(ctx *cli.Context) error {
 			teamID := ctx.Args().First()
 
+			exists, err := NewRequest().
+				WithConfig(config).
+				WithContext(ctx).
+				PathParameter("id", true).
+				WithInject("id", teamID).
+				WithEndpoint("/teams/{id}").
+				Exists()
+			if err != nil {
+				return err
+			}
+
+			if exists {
+				return fmt.Errorf("%q already exists", teamID)
+			}
+
 			team := &orgv1.Team{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Team",
@@ -203,7 +218,7 @@ func GetCreateTeamCommand(config *Config) cli.Command {
 				},
 			}
 
-			err := NewRequest().
+			err = NewRequest().
 				WithConfig(config).
 				WithContext(ctx).
 				PathParameter("id", true).


### PR DESCRIPTION
## What

* Add create team command (does not update an existing resource)
* Make the team commands work with singular and plural expressions
* Print custom columns for a team

### Additional changes

 * Make the requestor accept a runtime.Object instead of an unstructured one
 * Allow to register a custom response handler in Requestor
 * Add Exists method to requestor
 * Handle 404 errors in parseResponse instead of makeRequest in requestor