### PR TITLE
fix invalid label for application kind

### DIFF
--- a/pkg/clusterappman/manifests/captain/captain.yaml
+++ b/pkg/clusterappman/manifests/captain/captain.yaml
@@ -175,6 +175,7 @@ kind: Service
 metadata:
   name: captain-webhook
   labels:
+    app: captain
     service_name: captain
 spec:
   ports:


### PR DESCRIPTION
Just a wrong label - other issues with application controller but this should fix our first issue.