### PR TITLE
Add edit team command

### DIFF
--- a/pkg/cmd/korectl/clusters.go
+++ b/pkg/cmd/korectl/clusters.go
@@ -52,7 +52,8 @@ func GetClustersCommand(config *Config) cli.Command {
 						WithContext(ctx).
 						WithEndpoint("/teams/{team}/clusters").
 						PathParameter("team", true).
-						GetObject(clusters)
+						WithRuntimeObject(clusters).
+						Get()
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/korectl/clusters.go
+++ b/pkg/cmd/korectl/clusters.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
-	"github.com/appvia/kore/pkg/utils"
-
 	"github.com/urfave/cli"
 )
 
@@ -48,21 +46,17 @@ func GetClustersCommand(config *Config) cli.Command {
 					},
 				},
 				Action: func(ctx *cli.Context) error {
-					resp := NewRequest()
-					err := resp.
+					clusters := &clustersv1.KubernetesList{}
+					err := NewRequest().
 						WithConfig(config).
 						WithContext(ctx).
 						WithEndpoint("/teams/{team}/clusters").
 						PathParameter("team", true).
-						Get()
+						GetObject(clusters)
 					if err != nil {
 						return err
 					}
-					// else we need to provision the kubeconfig
-					clusters := &clustersv1.KubernetesList{}
-					if err := utils.DecodeToJSON(resp.Body(), clusters); err != nil {
-						return err
-					}
+
 					if len(clusters.Items) <= 0 {
 						fmt.Println("no clusters found in this team's namespace")
 

--- a/pkg/cmd/korectl/create.go
+++ b/pkg/cmd/korectl/create.go
@@ -26,7 +26,7 @@ import (
 func GetCreateCommand(config *Config) cli.Command {
 	return cli.Command{
 		Name:  "create",
-		Usage: "creates various objects",
+		Usage: "Creates various objects",
 
 		Subcommands: []cli.Command{
 			GetCreateTeamCommand(config),

--- a/pkg/cmd/korectl/edit.go
+++ b/pkg/cmd/korectl/edit.go
@@ -23,21 +23,13 @@ import (
 	"github.com/urfave/cli"
 )
 
-// GetCommands returns all the commands
-func GetCommands(config *Config) []cli.Command {
-	return []cli.Command{
-		GetLoginCommand(config),
-		GetProfilesCommand(config),
-		GetLocalCommand(config),
-		GetAutoCompleteCommand(config),
-		GetApplyCommand(config),
-		GetDeleteCommand(config),
-		GetClustersCommand(config),
-		GetGetCommand(config),
-		GetCreateCommand(config),
-		GetEditCommand(config),
-		GetTeamsCommands(config),
-		GetUsersCommands(config),
-		GetWhoamiCommand(config),
+func GetEditCommand(config *Config) cli.Command {
+	return cli.Command{
+		Name:  "edit",
+		Usage: "modifies various objects",
+
+		Subcommands: []cli.Command{
+			GetEditTeamCommand(config),
+		},
 	}
 }

--- a/pkg/cmd/korectl/edit.go
+++ b/pkg/cmd/korectl/edit.go
@@ -26,7 +26,7 @@ import (
 func GetEditCommand(config *Config) cli.Command {
 	return cli.Command{
 		Name:  "edit",
-		Usage: "modifies various objects",
+		Usage: "Modifies various objects",
 
 		Subcommands: []cli.Command{
 			GetEditTeamCommand(config),

--- a/pkg/cmd/korectl/localconf.go
+++ b/pkg/cmd/korectl/localconf.go
@@ -111,6 +111,10 @@ func newGcpInfoConfig() *gcpInfoConfig {
 }
 
 func (g *gcpInfoConfig) load(src string) (*gcpInfoConfig, error) {
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return g, nil
+	}
+
 	content, err := ioutil.ReadFile(src)
 	if err != nil {
 		return g, err

--- a/pkg/cmd/korectl/prompts.go
+++ b/pkg/cmd/korectl/prompts.go
@@ -10,14 +10,18 @@ type prompt struct {
 	id          string
 	labelSuffix string
 	errMsg      string
-	value       string
+	value       *string
 }
 
 func (p *prompt) do() error {
+	var value string
+	if p.value != nil {
+		value = *p.value
+	}
 	runner := promptui.Prompt{
 		Label:     p.id + " " + p.labelSuffix,
 		AllowEdit: true,
-		Default:   p.value,
+		Default:   value,
 		Validate: func(in string) error {
 			if len(in) == 0 {
 				return fmt.Errorf(p.errMsg, p.id)
@@ -31,7 +35,7 @@ func (p *prompt) do() error {
 		return err
 	}
 
-	p.value = gathered
+	*p.value = gathered
 	return nil
 }
 
@@ -44,13 +48,4 @@ func (p prompts) collect() error {
 		}
 	}
 	return nil
-}
-
-func (p prompts) getValue(id string) string {
-	for _, p := range p {
-		if p.id == id {
-			return p.value
-		}
-	}
-	return ""
 }

--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -113,7 +113,11 @@ func (c *Requestor) Get() error {
 		return err
 	}
 
-	return c.parseResponse()
+	if c.runtimeObj != nil {
+		return c.parseObjectResponse()
+	} else {
+		return c.parseResponse()
+	}
 }
 
 // Exists will perform a GET request and will return
@@ -175,17 +179,16 @@ func (c *Requestor) Delete() error {
 	return c.handleResponse(resp)
 }
 
-// parseResponse
-func (c *Requestor) parseResponse() error {
-	if c.runtimeObj != nil {
-		if c.body.Len() > 0 {
-			if err := json.NewDecoder(c.body).Decode(c.runtimeObj); err != nil {
-				return err
-			}
+func (c *Requestor) parseObjectResponse() error {
+	if c.body.Len() > 0 {
+		if err := json.NewDecoder(c.body).Decode(c.runtimeObj); err != nil {
+			return err
 		}
-		return nil
 	}
+	return nil
+}
 
+func (c *Requestor) parseResponse() error {
 	var response map[string]interface{}
 	if c.body.Len() > 0 {
 		if err := json.NewDecoder(c.body).Decode(&response); err != nil {

--- a/pkg/cmd/korectl/teams.go
+++ b/pkg/cmd/korectl/teams.go
@@ -253,14 +253,14 @@ func GetEditTeamCommand(config *Config) cli.Command {
 
 			team := &orgv1.Team{}
 
-			err := NewRequest().
+			req := NewRequest().
 				WithConfig(config).
 				WithContext(ctx).
 				PathParameter("id", true).
 				WithInject("id", teamID).
 				WithEndpoint("/teams/{id}").
-				GetObject(team)
-			if err != nil {
+				WithRuntimeObject(team)
+			if err := req.Get(); err != nil {
 				return err
 			}
 
@@ -272,15 +272,7 @@ func GetEditTeamCommand(config *Config) cli.Command {
 				return err
 			}
 
-			err = NewRequest().
-				WithConfig(config).
-				WithContext(ctx).
-				PathParameter("id", true).
-				WithInject("id", teamID).
-				WithEndpoint("/teams/{id}").
-				WithRuntimeObject(team).
-				Update()
-			if err != nil {
+			if err := req.Update(); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/korectl/teams.go
+++ b/pkg/cmd/korectl/teams.go
@@ -133,7 +133,7 @@ func GetCreateTeamCommand(config *Config) cli.Command {
 	return cli.Command{
 		Name:      "team",
 		Aliases:   []string{"teams"},
-		Usage:     "creates a team",
+		Usage:     "Creates a team",
 		ArgsUsage: "TEAM",
 		Flags: []cli.Flag{
 			cli.StringFlag{
@@ -204,7 +204,7 @@ func GetEditTeamCommand(config *Config) cli.Command {
 	return cli.Command{
 		Name:      "team",
 		Aliases:   []string{"teams"},
-		Usage:     "modifies a team",
+		Usage:     "Modifies a team",
 		ArgsUsage: "TEAM",
 		Action: func(ctx *cli.Context) error {
 			teamID := ctx.Args().First()

--- a/pkg/cmd/korectl/teams.go
+++ b/pkg/cmd/korectl/teams.go
@@ -35,48 +35,6 @@ func GetTeamsCommands(config *Config) cli.Command {
 		Usage:   "Used to interact, get, list and update teams in the kore",
 		Subcommands: []cli.Command{
 			{
-				Name:  "get",
-				Usage: "Used to retrieve the details of a team in the kore",
-				Flags: append([]cli.Flag{
-					cli.StringFlag{
-						Name:     "name,n",
-						Usage:    "The name of the team to retrieve (assumes all if not defined)",
-						Required: false,
-					},
-				}, DefaultOptions...),
-				Action: func(c *cli.Context) error {
-					return NewRequest().
-						WithConfig(config).
-						WithContext(c).
-						WithEndpoint("/teams/{name}").
-						PathParameter("name", false).
-						Render(
-							Column("Name", ".metadata.name"),
-							Column("Description", ".spec.description"),
-						).
-						Get()
-				},
-			},
-			{
-				Name:    "delete",
-				Aliases: []string{"rm"},
-				Usage:   "Used to delete a team from the kore",
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "name,n",
-						Usage: "The name of the team to remove",
-					},
-				},
-				Action: func(ctx *cli.Context) error {
-					return NewRequest().
-						WithConfig(config).
-						WithContext(ctx).
-						WithEndpoint("/teams/{name}").
-						PathParameter("name", true).
-						Delete()
-				},
-			},
-			{
 				Name:    "members",
 				Aliases: []string{"mb"},
 				Usage:   "Used to get, list, add and remove users to the team",


### PR DESCRIPTION
## What

Add command for editing a team with prompts.

```
➜  kore git:(team_cli_commands) go run cmd/korectl/main.go edit team a-team
✔ Description : Bodie, Doyle, Tiger, the Jewellery Man█
"a-team" was successfully saved

➜  kore git:(team_cli_commands) go run cmd/korectl/main.go get team a-team
Name                Description
a-team              Bodie, Doyle, Tiger, the Jewellery Man
```

### Additional changes

 * Make a prompt use a string pointer as a value, to avoid mistakes with getvalue (and easier to update struct fields)
 * Remove Body() from requestor and remove json unmarshaling from makeRequest
 * The RuntimeObject allows request reuse (get + update)