### PR TITLE
Docker Volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,8 @@ demo:
 	@docker-compose \
 		--file hack/compose/kube.yml \
 		--file hack/compose/demo.yml \
-                --file hack/compose/operators.yml \
-		up --force-recreate
+		--file hack/compose/operators.yml \
+		up --force-recreate --renew-anon-volumes
 
 docker-release:
 	@echo "--> Building a release image"


### PR DESCRIPTION
- ensure the anonymous anonymous volumes go

The reason being is on demo people usually have volumes from an old demo laying around (namely mariadb)