### PR TITLE
 Add generate-clusterappman-manifests as a dependency to kore-apiserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ auth-proxy: golang deps spelling
 	@mkdir -p bin
 	go build -ldflags "${LFLAGS}" -o bin/auth-proxy cmd/auth-proxy/*.go
 
-kore-apiserver: golang deps
+kore-apiserver: golang deps generate-clusterappman-manifests
 	@echo "--> Compiling the kore-apiserver binary"
 	@mkdir -p bin
 	go build -ldflags "${LFLAGS}" -o bin/kore-apiserver cmd/kore-apiserver/*.go

--- a/pkg/clusterappman/manifests.go
+++ b/pkg/clusterappman/manifests.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Lewis Marsahll <lewis.marshall@appvia.io>
+ * Copyright (C) 2019 Appvia Ltd <info@appvia.io>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This fixes the release workflow on CircleCI for master builds.

Any reason we don't commit pkg/clusterappman/manifests_vfsdata.go in?