### PR TITLE
CLI local logs

### DIFF
--- a/pkg/cmd/korectl/local.go
+++ b/pkg/cmd/korectl/local.go
@@ -34,5 +34,6 @@ func GetLocalCommand(config *Config) cli.Command {
 	}
 	cmd.Subcommands = append(cmd.Subcommands, GetLocalConfigureSubCommand(config))
 	cmd.Subcommands = append(cmd.Subcommands, GetLocalRunSubCommands(config)...)
+	cmd.Subcommands = append(cmd.Subcommands, GetLocalLogsSubCommand(config))
 	return cmd
 }

--- a/pkg/cmd/korectl/locallogs.go
+++ b/pkg/cmd/korectl/locallogs.go
@@ -30,6 +30,12 @@ import (
 
 const koreApiServer = "/kore-apiserver"
 
+var dcomposeArgs = []string{
+	"--file", "hack/compose/kube.yml",
+	"--file", "hack/compose/demo.yml",
+	"--file", "hack/compose/operators.yml",
+}
+
 func GetLocalLogsSubCommand(_ *Config) cli.Command {
 	return cli.Command{
 		Name:  "logs",
@@ -60,12 +66,8 @@ func GetLocalLogsSubCommand(_ *Config) cli.Command {
 }
 
 func isKoreStarted() (bool, error) {
-	cmd := exec.Command("docker-compose",
-		"--file", "hack/compose/kube.yml",
-		"--file", "hack/compose/demo.yml",
-		"--file", "hack/compose/operators.yml",
-		"ps",
-	)
+	ps := append(dcomposeArgs, "ps")
+	cmd := exec.Command("docker-compose", ps...)
 
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
@@ -77,26 +79,13 @@ func isKoreStarted() (bool, error) {
 }
 
 func runLogs(c *cli.Context) error {
-	var cmd *exec.Cmd
+	logs := append(dcomposeArgs, "logs")
 
-	switch c.Bool("follow") {
-	case true:
-		cmd = exec.Command("docker-compose",
-			"--file", "hack/compose/kube.yml",
-			"--file", "hack/compose/demo.yml",
-			"--file", "hack/compose/operators.yml",
-			"logs", "--follow",
-		)
-
-	case false:
-		cmd = exec.Command("docker-compose",
-			"--file", "hack/compose/kube.yml",
-			"--file", "hack/compose/demo.yml",
-			"--file", "hack/compose/operators.yml",
-			"logs",
-		)
+	if c.Bool("follow") {
+		logs = append(logs, "--follow")
 	}
 
+	cmd := exec.Command("docker-compose", logs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/pkg/cmd/korectl/locallogs.go
+++ b/pkg/cmd/korectl/locallogs.go
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2020 Appvia Ltd <info@appvia.io>
+ *
+ * This file is part of kore.
+ *
+ * kore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * kore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with kore.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package korectl
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+const koreApiServer = "/kore-apiserver"
+
+func GetLocalLogsSubCommand(_ *Config) cli.Command {
+	return cli.Command{
+		Name:  "logs",
+		Usage: "View logs from local Kore.",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:     "follow, f",
+				Usage:    "Follow log output.",
+				Required: false,
+			},
+		},
+		Action: func(c *cli.Context) error {
+			fmt.Println("...Retrieving Kore logs.")
+
+			running, err := isKoreStarted()
+			if err != nil {
+				return err
+			}
+
+			if !running {
+				fmt.Println("...No logs are available (Kore is not running).")
+				return nil
+			}
+
+			return runLogs(c)
+		},
+	}
+}
+
+func isKoreStarted() (bool, error) {
+	cmd := exec.Command("docker-compose",
+		"--file", "hack/compose/kube.yml",
+		"--file", "hack/compose/demo.yml",
+		"--file", "hack/compose/operators.yml",
+		"ps",
+	)
+
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", stdoutStderr)
+		return false, err
+	}
+
+	return strings.Contains(string(stdoutStderr), koreApiServer), nil
+}
+
+func runLogs(c *cli.Context) error {
+	var cmd *exec.Cmd
+
+	switch c.Bool("follow") {
+	case true:
+		cmd = exec.Command("docker-compose",
+			"--file", "hack/compose/kube.yml",
+			"--file", "hack/compose/demo.yml",
+			"--file", "hack/compose/operators.yml",
+			"logs", "--follow",
+		)
+
+	case false:
+		cmd = exec.Command("docker-compose",
+			"--file", "hack/compose/kube.yml",
+			"--file", "hack/compose/demo.yml",
+			"--file", "hack/compose/operators.yml",
+			"logs",
+		)
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}


### PR DESCRIPTION
This completes https://github.com/appvia/kore/issues/254

It adds a logging sub command for `korectl local`,
```
./korectl local logs --help
NAME:
   korectl local logs - View logs from local Kore.

USAGE:
   korectl local logs [command options] [arguments...]

OPTIONS:
   --follow, -f  Follow log output.
```