### PR TITLE
Fix Local Manifest Generation

### DIFF
--- a/pkg/cmd/korectl/localconf.go
+++ b/pkg/cmd/korectl/localconf.go
@@ -217,7 +217,7 @@ func (g *gcpInfoConfig) generateGcpInfo() error {
 	for path, object := range manifests {
 		doc, err := utils.EncodeRuntimeObjectToYAML(object)
 		if err != nil {
-
+			return err
 		}
 		if err := ioutil.WriteFile(path, doc, os.FileMode(0640)); err != nil {
 			return err

--- a/pkg/cmd/korectl/localconf.go
+++ b/pkg/cmd/korectl/localconf.go
@@ -26,19 +26,23 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
+
+	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
+	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
+	gke "github.com/appvia/kore/pkg/apis/gke/v1alpha1"
+	"github.com/appvia/kore/pkg/kore"
+	"github.com/appvia/kore/pkg/utils"
 
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
-	gke "github.com/appvia/kore/pkg/apis/gke/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
-	gkeCredPath          = path.Join(localManifests, "gke-credentials.yml")
-	cachedAccountKeyPath = path.Join(localManifests, "service-account-key.json")
+	gkeCredPath           = path.Join(localManifests, "gke-credentials.yml")
+	gkeCredAllocationPath = path.Join(localManifests, "gke-allocation.yml")
+	cachedAccountKeyPath  = path.Join(localManifests, "service-account-key.json")
 )
 
 func createLocalConfig(config *Config) {
@@ -151,42 +155,73 @@ func (g *gcpInfoConfig) createPrompts() prompts {
 }
 
 func (g *gcpInfoConfig) generateGcpInfo() error {
+	// @step: ensure the directory
+	if err := os.MkdirAll(localManifests, os.FileMode(0750)); err != nil {
+		return err
+	}
+
+	// @step: read in the gke credentials json
 	keyData, err := ioutil.ReadFile(filepath.Clean(g.KeyPath))
 	if err != nil {
 		return err
 	}
 
-	cred := gke.GKECredentials{
+	name := "gke"
+
+	// @step: we need to render the credentials and the allocations for all teams
+	creds := &gke.GKECredentials{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "GKECredentials",
-			APIVersion: "gke.compute.kore.appvia.io/v1alpha1",
+			APIVersion: gke.GroupVersion.String(),
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:              "gke",
-			CreationTimestamp: v1.NewTime(time.Now().UTC()),
+			Name:      name,
+			Namespace: kore.HubAdminTeam,
 		},
 		Spec: gke.GKECredentialsSpec{
 			Region:  g.Region,
 			Project: g.Project,
 			Account: string(keyData),
 		},
-		Status: gke.GKECredentialsStatus{
-			Status:   corev1.SuccessStatus,
-			Verified: true,
+	}
+
+	allocation := &configv1.Allocation{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Allocation",
+			APIVersion: configv1.GroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: kore.HubAdminTeam,
+		},
+		Spec: configv1.AllocationSpec{
+			Name:    name,
+			Summary: "Default Credentials for building a GKE Cluster",
+			Resource: corev1.Ownership{
+				Group:     gke.SchemeGroupVersion.Group,
+				Version:   gke.SchemeGroupVersion.Version,
+				Kind:      "GKECredentials",
+				Namespace: kore.HubAdminTeam,
+				Name:      name,
+			},
+			Teams: []string{"*"},
 		},
 	}
 
-	data, err := yaml.Marshal(cred)
-	if err != nil {
-		return err
+	// @step: write the files to the local manifests directory
+	manifests := map[string]runtime.Object{
+		gkeCredPath:           creds,
+		gkeCredAllocationPath: allocation,
 	}
 
-	if err := os.MkdirAll(localManifests, os.FileMode(0750)); err != nil {
-		return err
-	}
+	for path, object := range manifests {
+		doc, err := utils.EncodeRuntimeObjectToYAML(object)
+		if err != nil {
 
-	if err := ioutil.WriteFile(gkeCredPath, data, os.FileMode(0640)); err != nil {
-		return err
+		}
+		if err := ioutil.WriteFile(path, doc, os.FileMode(0640)); err != nil {
+			return err
+		}
 	}
 
 	return ioutil.WriteFile(cachedAccountKeyPath, keyData, os.FileMode(0640))

--- a/pkg/utils/marshall.go
+++ b/pkg/utils/marshall.go
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2020 Appvia Ltd <info@appvia.io>
+ *
+ * This file is part of kore.
+ *
+ * kore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * kore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with kore.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// EncodeRuntimeObjectToYAML is used to encode the object to a yaml document
+func EncodeRuntimeObjectToYAML(object runtime.Object) ([]byte, error) {
+	b := &bytes.Buffer{}
+
+	// @step: encode to json first of all
+	if err := json.NewEncoder(b).Encode(object); err != nil {
+		return []byte{}, err
+	}
+
+	return yaml.JSONToYAML(b.Bytes())
+}

--- a/pkg/utils/marshall.go
+++ b/pkg/utils/marshall.go
@@ -33,7 +33,7 @@ func EncodeRuntimeObjectToYAML(object runtime.Object) ([]byte, error) {
 
 	// @step: encode to json first of all
 	if err := json.NewEncoder(b).Encode(object); err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	return yaml.JSONToYAML(b.Bytes())

--- a/pkg/utils/marshall_test.go
+++ b/pkg/utils/marshall_test.go
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2020 Appvia Ltd <info@appvia.io>
+ *
+ * This file is part of kore.
+ *
+ * kore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * kore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with kore.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEncodeRuntimeObjectToYAML(t *testing.T) {
+	ns := &v1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hello",
+		},
+	}
+	expected := `apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: hello
+spec: {}
+status: {}
+`
+	doc, err := EncodeRuntimeObjectToYAML(ns)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(doc))
+}


### PR DESCRIPTION
The current implementation was encoding straight to yaml; this creates problems as the structs do not have yaml tags and so the encoder encodes directly (and incorrectly). This also adds the creation of the allocation of the credentials to the teams

```YAML
typemeta:
  kind: GKECredentials
  apiversion: gke.compute.kore.appvia.io/v1alpha1
objectmeta:
  name: gke
  generatename: ""
```
to

```YAML
apiVersion: config.kore.appvia.io/v1
kind: Allocation
metadata:
  creationTimestamp: null
  name: gke
  namespace: kore-admin
spec:
  name: gke
  resource:
    group: gke.compute.kore.appvia.io
    kind: GKECredentials
```
