### PR TITLE
Bump Demo Version

### DIFF
--- a/hack/compose/demo.yml
+++ b/hack/compose/demo.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   kore-apiserver:
-    image: quay.io/appvia/kore-apiserver:v0.0.10
+    image: quay.io/appvia/kore-apiserver:v0.0.12
     env_file: ../../demo.env
     environment:
       KORE_ADMIN_PASS: password


### PR DESCRIPTION
- bumping the version of the demo to v0.0.12 as we have changes to the api https://github.com/appvia/kore/commit/54a3b9bf0b1ccf616c3afd1e1c6c96c46d845952 which the korectl now uses