### PR TITLE
Cloud Provider Check

### DIFF
--- a/cmd/kore-apiserver/options/options.go
+++ b/cmd/kore-apiserver/options/options.go
@@ -254,5 +254,10 @@ func Options() []cli.Flag {
 			Usage:  "Indicates when deleting the kubernetes cluster we should wait for the provider to delete first `BOOL`",
 			EnvVar: "ENABLE_CLOUD_DELETION_BLOCK",
 		},
+		cli.BoolTFlag{
+			Name:   "enable-cluster-provider-check",
+			Usage:  "Indicates the kubernetes controller should check the underlying provider status `BOOL`",
+			EnvVar: "ENABLE_CLUSTER_PROVIDER_CHECK",
+		},
 	}
 }

--- a/cmd/kore-apiserver/server.go
+++ b/cmd/kore-apiserver/server.go
@@ -73,6 +73,7 @@ func invoke(ctx *cli.Context) error {
 			DiscoveryURL:               strings.TrimSuffix(ctx.String("discovery-url"), ".well-known/openid-configuration"),
 			EnableClusterDeletion:      ctx.Bool("enable-cluster-deletion"),
 			EnableClusterDeletionBlock: ctx.Bool("enable-cluster-deletion-block"),
+			EnableClusterProviderCheck: ctx.Bool("enable-cluster-provider-check"),
 			HMAC:                       ctx.String("kore-hmac"),
 			PublicAPIURL:               ctx.String("api-public-url"),
 			PublicHubURL:               ctx.String("kore-public-url"),

--- a/pkg/cmd/korectl/create_cluster.go
+++ b/pkg/cmd/korectl/create_cluster.go
@@ -208,7 +208,7 @@ func GetCreateClusterCommand(config *Config) cli.Command {
 					}
 				}()
 				if err != nil {
-					return fmt.Errorf("has failed to provision, use: $ korectl get clusters %s -t %s to view status", name, team)
+					return fmt.Errorf("has failed to provision, use: $ korectl get clusters %s -t %s -o yaml to view status", name, team)
 				}
 				if ctx.Bool("show-time") {
 					fmt.Printf("Provisioning took: %s\n", time.Since(now))

--- a/pkg/kore/types.go
+++ b/pkg/kore/types.go
@@ -120,6 +120,9 @@ type Config struct {
 	// EnableClusterDeletionBlock indicates we should only delete the cluster if the cloud
 	// provider is deleted
 	EnableClusterDeletionBlock bool `json:"enable-cluster-deletion-block,omitempty"`
+	// EnableClusterProviderCheck indicate the k8s controller should check the status of the
+	// cloud provider as well
+	EnableClusterProviderCheck bool `json:"enable-cluster-provider-check,omitempty"`
 	// HMAC is the token used to sign things
 	HMAC string `json:"hmac"`
 	// PublicHubURL is the public url for the kore (the ui not the api)


### PR DESCRIPTION
The current implementation does not surface errors on the cloud provider on the CLI or UI, instead the cluster is left in a pending state. This PR (feature toggled) adds a check to the cluster to if backed by a provider is checks the status of the cloud provider and reflects any errors from downstream.

b5935f7 - adding the feature toggle for the controller to check the status of provider
93b5a57 - checking the status of the cloud provider of the cluster and surfacing any errors
acbf22a - updating the create_cluster error to display the full status

So when I add invalid credentials, where as before I stayed pending forever; we got the error: 

```shell
status:
    components:
    - detail: invalid character 'B' looking for beginning of value
      message: Failed to create GKE client, please check credentials
      name: Cluster Creator
      status: Failure
    status: Failure
```

Note: at the moment the UI still has the https://github.com/appvia/kore-ui/issues/61 bug, so until that is fixed the UI will retain the pending status and log a message: https://github.com/appvia/kore/blob/fix_k8s_wait/pkg/controllers/management/kubernetes/reconcile.go#L495

