### PR TITLE
Prompts now trim space from gathered user input.

### DIFF
--- a/pkg/cmd/korectl/prompts.go
+++ b/pkg/cmd/korectl/prompts.go
@@ -2,6 +2,7 @@ package korectl
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/manifoldco/promptui"
 )
@@ -35,7 +36,7 @@ func (p *prompt) do() error {
 		return err
 	}
 
-	*p.value = gathered
+	*p.value = strings.TrimSpace(gathered)
 	return nil
 }
 


### PR DESCRIPTION
Closes https://github.com/appvia/kore/issues/280

This caused a bug during `korectl login` ... Client Secret had extra space, which failed IDP authentication.