### PR TITLE
Return the team name in the invitation handler

### DIFF
--- a/pkg/apiserver/invitations.go
+++ b/pkg/apiserver/invitations.go
@@ -35,12 +35,14 @@ func (u teamHandler) invitationSubmit(req *restful.Request, resp *restful.Respon
 		ctx := req.Request.Context()
 		token := req.PathParameter("token")
 
-		if err := u.Invitations().HandleGenerateLink(ctx, token); err != nil {
+		team, err := u.Invitations().HandleGenerateLink(ctx, token)
+		if err != nil {
 			return err
 		}
-		resp.WriteHeader(http.StatusOK)
-
-		return nil
+		result := map[string]interface{}{
+			"team": team,
+		}
+		return resp.WriteHeaderAndEntity(http.StatusOK, result)
 	})
 }
 

--- a/pkg/apiserver/invitations.go
+++ b/pkg/apiserver/invitations.go
@@ -25,6 +25,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/appvia/kore/pkg/apiserver/types"
+
 	"github.com/appvia/kore/pkg/kore"
 	restful "github.com/emicklei/go-restful"
 )
@@ -39,8 +41,8 @@ func (u teamHandler) invitationSubmit(req *restful.Request, resp *restful.Respon
 		if err != nil {
 			return err
 		}
-		result := map[string]interface{}{
-			"team": team,
+		result := &types.TeamInvitationResponse{
+			Team: team,
 		}
 		return resp.WriteHeaderAndEntity(http.StatusOK, result)
 	})

--- a/pkg/apiserver/teams.go
+++ b/pkg/apiserver/teams.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/appvia/kore/pkg/apiserver/types"
+
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
 	gke "github.com/appvia/kore/pkg/apis/gke/v1alpha1"
@@ -61,7 +63,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 		ws.PUT("/invitation/{token}").To(u.invitationSubmit).
 			Doc("Used to verify and handle the team invitation generated links").
 			Param(ws.PathParameter("token", "The generated base64 invitation token which was provided from the team")).
-			Returns(http.StatusOK, "Indicates the generated link is valid and the user has been granted access", nil).
+			Returns(http.StatusOK, "Indicates the generated link is valid and the user has been granted access", types.TeamInvitationResponse{}).
 			DefaultReturns("A generic API error containing the cause of the error", Error{}),
 	)
 

--- a/pkg/apiserver/types/types.go
+++ b/pkg/apiserver/types/types.go
@@ -28,3 +28,8 @@ type WhoAmI struct {
 	// Teams is a collection of teams your in
 	Teams []string `json:"teams,omitempty"`
 }
+
+type TeamInvitationResponse struct {
+	// Team is the name of team which the user just has been been added to
+	Team string `json:"team"`
+}


### PR DESCRIPTION
This will allow us to show a better message to the user and we can optionally take the user to the team page they have just been added to.