### PR TITLE
fix the image versions when testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ run:
 	@$(MAKE) kube-api-wait
 	@$(MAKE) run-api-only
 
-run-api-only:
+run-api-only: kore-apiserver
 	@echo "--> Starting api..."
 	@hack/bin/run-api-with-env.sh
 

--- a/hack/bin/run-api-with-env.sh
+++ b/hack/bin/run-api-with-env.sh
@@ -17,7 +17,7 @@ export \
     KORE_USER_CLAIMS \
     KORE_CLIENT_SCOPES
 
-go run cmd/kore-apiserver/*.go \
+./bin/kore-apiserver \
     --kube-api-server http://127.0.0.1:8080 \
     --verbose \
     --admin-pass password \


### PR DESCRIPTION
api server gets built properly with versions which are used for pulling oicd-proxy and clusterappman images so `go run ...` will use `latest` and not the correct image.

@bandesz Small one as reviewed.