### PR TITLE
Validate cluster name is less than 40 chars when creating via API.

### DIFF
--- a/pkg/apiserver/helpers.go
+++ b/pkg/apiserver/helpers.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/appvia/kore/pkg/kore"
+	"github.com/appvia/kore/pkg/kore/validation"
 
 	restful "github.com/emicklei/go-restful"
 	log "github.com/sirupsen/logrus"
@@ -72,11 +73,9 @@ func handleErrors(req *restful.Request, resp *restful.Response, handler func() e
 
 		// Couple of errors have their own types, treat differently:
 		switch err := err.(type) {
-		case kore.ErrNotAllowed:
-		case *kore.ErrNotAllowed:
+		case kore.ErrNotAllowed, *kore.ErrNotAllowed:
 			code = http.StatusNotAcceptable
-		case kore.ErrValidation:
-		case *kore.ErrValidation:
+		case validation.ErrValidation, *validation.ErrValidation:
 			code = http.StatusBadRequest
 			// ErrValidation can be directly serialized to json so just return that.
 			errResponse = err

--- a/pkg/apiserver/teams.go
+++ b/pkg/apiserver/teams.go
@@ -324,6 +324,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Doc("Used to return all team resources under the team").
 			Reads(clustersv1.Kubernetes{}, "The definition for kubernetes cluster").
 			Returns(http.StatusOK, "Contains the former team definition from the kore", clustersv1.Kubernetes{}).
+			Returns(http.StatusBadRequest, "Validation error of the provided details", kore.ErrValidation{}).
 			DefaultReturns("A generic API error containing the cause of the error", Error{}),
 	)
 

--- a/pkg/apiserver/teams.go
+++ b/pkg/apiserver/teams.go
@@ -27,6 +27,7 @@ import (
 	gke "github.com/appvia/kore/pkg/apis/gke/v1alpha1"
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
 	"github.com/appvia/kore/pkg/kore"
+	"github.com/appvia/kore/pkg/kore/validation"
 	"github.com/appvia/kore/pkg/utils"
 
 	restful "github.com/emicklei/go-restful"
@@ -324,7 +325,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Doc("Used to return all team resources under the team").
 			Reads(clustersv1.Kubernetes{}, "The definition for kubernetes cluster").
 			Returns(http.StatusOK, "Contains the former team definition from the kore", clustersv1.Kubernetes{}).
-			Returns(http.StatusBadRequest, "Validation error of the provided details", kore.ErrValidation{}).
+			Returns(http.StatusBadRequest, "Validation error of the provided details", validation.ErrValidation{}).
 			DefaultReturns("A generic API error containing the cause of the error", Error{}),
 	)
 

--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -30,7 +30,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/appvia/kore/pkg/kore"
+	"github.com/appvia/kore/pkg/kore/validation"
 	"github.com/ghodss/yaml"
 	"github.com/savaki/jq"
 	log "github.com/sirupsen/logrus"
@@ -301,10 +301,9 @@ func (c Requestor) checkResponse(resp *http.Response) *RequestError {
 	}
 
 	if resp.StatusCode == http.StatusBadRequest {
-		// This is a validation error, check if we have a validation error body. If so, by
-		// parsing it as a kore.ErrValidation it directly implements Error() so can be passed
-		// directly into RequestError:
-		var valResponse kore.ErrValidation
+		// This is a validation error, check if we have a validation error body. If so,
+		// that implements Error so we can use it directly.
+		var valResponse validation.ErrValidation
 		if err := json.NewDecoder(resp.Body).Decode(&valResponse); err == nil {
 			return &RequestError{
 				statusCode: resp.StatusCode,

--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -30,6 +30,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/appvia/kore/pkg/kore"
 	"github.com/ghodss/yaml"
 	"github.com/savaki/jq"
 	log "github.com/sirupsen/logrus"
@@ -297,6 +298,19 @@ func (c *Requestor) makeValues(in io.Reader, paths []string) ([]string, error) {
 func (c Requestor) checkResponse(resp *http.Response) *RequestError {
 	if resp.StatusCode == http.StatusOK {
 		return nil
+	}
+
+	if resp.StatusCode == http.StatusBadRequest {
+		// This is a validation error, check if we have a validation error body. If so, by
+		// parsing it as a kore.ErrValidation it directly implements Error() so can be passed
+		// directly into RequestError:
+		var valResponse kore.ErrValidation
+		if err := json.NewDecoder(resp.Body).Decode(&valResponse); err == nil {
+			return &RequestError{
+				statusCode: resp.StatusCode,
+				err:        valResponse,
+			}
+		}
 	}
 
 	var response map[string]interface{}

--- a/pkg/kore/clusters.go
+++ b/pkg/kore/clusters.go
@@ -21,6 +21,7 @@ import (
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	"github.com/appvia/kore/pkg/kore/authentication"
+	"github.com/appvia/kore/pkg/kore/validation"
 	"github.com/appvia/kore/pkg/services/users"
 	"github.com/appvia/kore/pkg/store"
 
@@ -124,8 +125,8 @@ func (c *clsImpl) Update(ctx context.Context, cluster *clustersv1.Kubernetes) er
 
 	// @TODO wider validation of the supplied details.
 	if len(cluster.Name) > 40 {
-		return newErrValidation().
-			WithFieldError("cluster.name", MaxLength, "Cluster name must be 40 characters or less")
+		return validation.NewErrValidation().
+			WithFieldError("cluster.name", validation.MaxLength, "Cluster name must be 40 characters or less")
 	}
 
 	// @TODO add an entity into the audit log

--- a/pkg/kore/clusters.go
+++ b/pkg/kore/clusters.go
@@ -18,6 +18,7 @@ package kore
 
 import (
 	"context"
+	"errors"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	"github.com/appvia/kore/pkg/kore/authentication"
@@ -121,6 +122,11 @@ func (c *clsImpl) Update(ctx context.Context, cluster *clustersv1.Kubernetes) er
 	user := authentication.MustGetIdentity(ctx)
 
 	cluster.Namespace = c.team
+
+	// Validate the name - feels like there's probably a better place for this
+	if len(cluster.Name) > 40 {
+		return errors.New("Invalid cluster name")
+	}
 
 	// @TODO add an entity into the audit log
 	c.Audit().Record(ctx,

--- a/pkg/kore/clusters.go
+++ b/pkg/kore/clusters.go
@@ -18,7 +18,6 @@ package kore
 
 import (
 	"context"
-	"errors"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	"github.com/appvia/kore/pkg/kore/authentication"
@@ -123,9 +122,10 @@ func (c *clsImpl) Update(ctx context.Context, cluster *clustersv1.Kubernetes) er
 
 	cluster.Namespace = c.team
 
-	// Validate the name - feels like there's probably a better place for this
+	// @TODO wider validation of the supplied details.
 	if len(cluster.Name) > 40 {
-		return errors.New("Invalid cluster name")
+		return newErrValidation().
+			WithFieldError("cluster.name", MaxLength, "Cluster name must be 40 characters or less")
 	}
 
 	// @TODO add an entity into the audit log

--- a/pkg/kore/error_validation.go
+++ b/pkg/kore/error_validation.go
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kore
+
+import "fmt"
+
+// ErrValidation is a specific error returned when the input provided by
+// the user has failed validation somehow.
+type ErrValidation struct {
+	FieldErrors []ValidationFieldError `json:"fieldErrors"`
+}
+
+// newErrValidation returns a new api validation error
+func newErrValidation() *ErrValidation {
+	return &ErrValidation{}
+}
+
+// Error returns the details of the validation error.
+func (e ErrValidation) Error() string {
+	msg := ""
+	for ind, fe := range e.FieldErrors {
+		if ind > 0 {
+			msg += "\n"
+		}
+		msg += fmt.Sprintf("Validation error - field: %s error: %s message: %s", fe.Field, fe.ErrCode, fe.Message)
+	}
+	return msg
+}
+
+// WithFieldError adds an error for a specific field to a validation error.
+func (e *ErrValidation) WithFieldError(field string, errCode ValidationErrorCode, message string) *ErrValidation {
+	e.FieldErrors = append(e.FieldErrors, ValidationFieldError{Field: field, ErrCode: errCode, Message: message})
+	return e
+}
+
+// ValidationFieldError provides information about a validation error on a specific field.
+type ValidationFieldError struct {
+	// Field causing the error, in format x.y.z
+	Field string `json:"field"`
+	// ErrCode is the type of constraint which has been broken.
+	ErrCode ValidationErrorCode `json:"errCode"`
+	// Message is a human-readable description of the validation error.
+	Message string `json:"message"`
+}
+
+// ValidationErrorCode is the type of validation error detected.
+type ValidationErrorCode int
+
+const (
+	// MaxLength error indicates the supplied value is longer than the allowed maximum.
+	MaxLength ValidationErrorCode = iota
+)
+
+func (v ValidationErrorCode) String() string {
+	names := [...]string{
+		"maxLength",
+	}
+	if v < MaxLength || v > MaxLength {
+		return "Unknown"
+	}
+	return names[v]
+}


### PR DESCRIPTION
Adresses #292.

Introduces a structure for generalised validation error handling across the API whereby anything can throw a validation error in a way that will cause a structured validation error to be returned to callers of the API.