### PR TITLE
Add cli app wrapper to parse global flags in any position and print global help

### DIFF
--- a/cmd/auth-proxy/main.go
+++ b/cmd/auth-proxy/main.go
@@ -97,7 +97,8 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	koreCliApp := cmd.NewApp(app)
+	if err := koreCliApp.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %s\n", err)
 		os.Exit(1)
 	}

--- a/cmd/kore-apiserver/main.go
+++ b/cmd/kore-apiserver/main.go
@@ -58,7 +58,8 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	koreCliApp := cmd.NewApp(app)
+	if err := koreCliApp.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %s\n", err)
 		os.Exit(1)
 	}

--- a/cmd/kore-clusterappman/main.go
+++ b/cmd/kore-clusterappman/main.go
@@ -58,7 +58,8 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	koreCliApp := cmd.NewApp(app)
+	if err := koreCliApp.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %s\n", err)
 		os.Exit(1)
 	}

--- a/cmd/korectl/main.go
+++ b/cmd/korectl/main.go
@@ -70,7 +70,7 @@ func main() {
 
 		CommandNotFound: func(ctx *cli.Context, name string) {
 			fmt.Fprintf(os.Stderr, "Error: unknown command %q\n\n", name)
-			fmt.Fprintf(os.Stderr, "Please run `%s help` to see all available commands.\n", ctx.App.Name)
+			fmt.Fprintf(os.Stderr, "Please run `%s --help` to see all available commands.\n", ctx.App.Name)
 			os.Exit(1)
 		},
 

--- a/cmd/korectl/main.go
+++ b/cmd/korectl/main.go
@@ -104,7 +104,8 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	koreCliApp := cmd.NewApp(app)
+	if err := koreCliApp.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n\n", err)
 		os.Exit(1)
 	}

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -2,20 +2,75 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 )
 
+func init() {
+	cli.SubcommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
+
+DESCRIPTION:
+   {{if .Description}}{{.Description}}{{else}}{{.Usage}}{{end}}{{if len .VisibleCategories}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
+	cli.CommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}{{if .VisibleFlags}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{else}}
+{{end}}
+`
+}
+
+var globalOptionsTemplate = `{{if .VisibleFlags}}GLOBAL OPTIONS:
+   {{range $index, $option := .VisibleFlags}}{{if $index}}
+   {{end}}{{$option}}{{end}}
+{{end}}
+`
+
 type App struct {
-	app *cli.App
+	app                   *cli.App
+	origHelpPrinterCustom func(io.Writer, string, interface{}, map[string]interface{})
 }
 
 func NewApp(app *cli.App) *App {
-	return &App{app: app}
+	return &App{
+		app: app,
+	}
 }
 
 func (a *App) Run(args []string) error {
+	a.origHelpPrinterCustom = cli.HelpPrinterCustom
+	cli.HelpPrinterCustom = a.helpPrinterCustom
+	defer func() {
+		cli.HelpPrinterCustom = a.origHelpPrinterCustom
+	}()
+
 	orderedArgs, err := a.orderArgs(args)
 	if err != nil {
 		return err
@@ -77,4 +132,11 @@ func (a *App) parseFlagFromArgs(args []string, name string) ([]string, error) {
 		}
 	}
 	return nil, nil
+}
+
+func (a *App) helpPrinterCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
+	a.origHelpPrinterCustom(out, templ, data, customFuncs)
+	if data != a.app {
+		a.origHelpPrinterCustom(a.app.Writer, globalOptionsTemplate, a.app, nil)
+	}
 }

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+type App struct {
+	app *cli.App
+}
+
+func NewApp(app *cli.App) *App {
+	return &App{app: app}
+}
+
+func (a *App) Run(args []string) error {
+	orderedArgs, err := a.orderArgs(args)
+	if err != nil {
+		return err
+	}
+
+	return a.app.Run(orderedArgs)
+}
+
+func (a *App) orderArgs(args []string) ([]string, error) {
+	flagArgs := []string{args[0]}
+	var valueArgs []string
+
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == "--" {
+			valueArgs = append(valueArgs, args[i:]...)
+			break
+		}
+
+		if isFlag := strings.HasPrefix(arg, "-"); isFlag {
+			flagName := strings.TrimLeft(arg, "-")
+			res, err := a.parseFlagFromArgs(args[i:], flagName)
+			if err != nil {
+				return nil, err
+			}
+			if len(res) > 0 {
+				flagArgs = append(flagArgs, res...)
+				i += len(res) - 1
+			} else {
+				valueArgs = append(valueArgs, arg)
+			}
+		} else {
+			valueArgs = append(valueArgs, arg)
+		}
+	}
+
+	return append(flagArgs, valueArgs...), nil
+}
+
+func (a *App) parseFlagFromArgs(args []string, name string) ([]string, error) {
+	for i := 0; i < len(a.app.Flags); i++ {
+		flag := a.app.Flags[i]
+		for _, flagName := range flag.Names() {
+			if name == flagName {
+				if f, ok := flag.(cli.DocGenerationFlag); ok {
+					if f.TakesValue() {
+						if len(args) == 1 {
+							return nil, fmt.Errorf("%q parameter expects a value", flagName)
+						}
+						return []string{args[0], args[1]}, nil
+					} else {
+						return []string{args[0]}, nil
+					}
+				} else {
+					panic(fmt.Errorf("%T global flag type is not supported yet, please add it to cli.App", flag))
+				}
+			}
+		}
+	}
+	return nil, nil
+}

--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -1,0 +1,247 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/appvia/kore/pkg/cmd"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestAppShouldHandleNoArgs(t *testing.T) {
+	var appArgs []string
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			return nil
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{}, appArgs)
+}
+
+func TestAppShouldHandleMultipleArguments(t *testing.T) {
+	var appArgs []string
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			return nil
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "arg2"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2"}, appArgs)
+}
+
+func TestAppShouldHandleGlobalStringFlagsBeforeArgs(t *testing.T) {
+	var appArgs []string
+	var globalFlag string
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			globalFlag = ctx.String("global-flag")
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "global-flag",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "--global-flag", "foo", "arg1", "arg2"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2"}, appArgs)
+	require.Equal(t, "foo", globalFlag)
+}
+
+func TestAppShouldHandleGlobalStringFlagsAfterArgs(t *testing.T) {
+	var appArgs []string
+	var globalFlag string
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			globalFlag = ctx.String("global-flag")
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "global-flag",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "arg2", "--global-flag", "foo"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2"}, appArgs)
+	require.Equal(t, "foo", globalFlag)
+}
+
+func TestAppShouldReturnErrorIfNoGlobalStringValueIsPresent(t *testing.T) {
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "global-flag",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "--global-flag"})
+	require.EqualError(t, err, "\"global-flag\" parameter expects a value")
+}
+
+func TestAppShouldHandleGlobalStringFlagsBetweenArgs(t *testing.T) {
+	var appArgs []string
+	var globalFlag string
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			globalFlag = ctx.String("global-flag")
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "global-flag",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "--global-flag", "foo", "arg2"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2"}, appArgs)
+	require.Equal(t, "foo", globalFlag)
+}
+
+func TestAppShouldHandleGlobalBoolFlagsBeforeArgs(t *testing.T) {
+	var appArgs []string
+	var debug bool
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			debug = ctx.Bool("debug")
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name: "debug",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "--debug", "arg1", "arg2"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2"}, appArgs)
+	require.True(t, debug)
+}
+
+func TestAppShouldHandleGlobalBoolFlagsBetweenArgs(t *testing.T) {
+	var appArgs []string
+	var debug bool
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			debug = ctx.Bool("debug")
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name: "debug",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "--debug", "arg2"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2"}, appArgs)
+	require.True(t, debug)
+}
+
+func TestAppShouldHandleGlobalBoolFlagsAfterArgs(t *testing.T) {
+	var appArgs []string
+	var debug bool
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			debug = ctx.Bool("debug")
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name: "debug",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "arg2", "--debug"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2"}, appArgs)
+	require.True(t, debug)
+}
+
+func TestAppShouldLeaveNonGlobalFlagsAsIs(t *testing.T) {
+	var appArgs []string
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "global-flag",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "arg2", "--other-flag", "foo"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2", "--other-flag", "foo"}, appArgs)
+}
+
+func TestAppShouldIgnoreFlagsAfterDoubleDash(t *testing.T) {
+	var appArgs []string
+	var globalFlag string
+
+	app := &cli.App{
+		Name: "test",
+		Action: func(ctx *cli.Context) error {
+			appArgs = ctx.Args().Slice()
+			globalFlag = ctx.String("global-flag")
+			return nil
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "global-flag",
+			},
+		},
+	}
+	err := cmd.NewApp(app).Run([]string{"test", "arg1", "arg2", "--", "--global-flag", "foo"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"arg1", "arg2", "--", "--global-flag", "foo"}, appArgs)
+	require.Equal(t, "", globalFlag)
+}

--- a/pkg/cmd/korectl/apply.go
+++ b/pkg/cmd/korectl/apply.go
@@ -37,10 +37,6 @@ func GetApplyCommand(config *Config) *cli.Command {
 				Usage:    "The path to the file containing the resources definitions `PATH`",
 				Required: true,
 			},
-			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "Used to filter the results by team `TEAM`",
-			},
 		},
 		Action: func(ctx *cli.Context) error {
 			for _, file := range ctx.StringSlice("file") {

--- a/pkg/cmd/korectl/audit.go
+++ b/pkg/cmd/korectl/audit.go
@@ -25,12 +25,6 @@ func GetAuditCommand(config *Config) *cli.Command {
 	return &cli.Command{
 		Name:  "audit",
 		Usage: "Used to list and query the audit trail",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "Used to filter the results by team `TEAM`",
-			},
-		},
 		Action: func(ctx *cli.Context) error {
 
 			return nil

--- a/pkg/cmd/korectl/clusters.go
+++ b/pkg/cmd/korectl/clusters.go
@@ -41,10 +41,6 @@ func GetClustersCommand(config *Config) *cli.Command {
 						Name:  "name,n",
 						Usage: "The name of the integration to retrieve `NAME`",
 					},
-					&cli.StringFlag{
-						Name:  "team,t",
-						Usage: "Used to filter the results by team `TEAM`",
-					},
 				},
 				Action: func(ctx *cli.Context) error {
 					clusters := &clustersv1.KubernetesList{}

--- a/pkg/cmd/korectl/create.go
+++ b/pkg/cmd/korectl/create.go
@@ -20,7 +20,7 @@
 package korectl
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/urfave/cli/v2"
 )
@@ -40,12 +40,6 @@ func GetCreateCommand(config *Config) *cli.Command {
 		Usage:       "Creates various objects",
 		Description: formatLongDescription(createLongDescription),
 		ArgsUsage:   "[TYPE] [NAME]",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "Used to select the team context you are operating in",
-			},
-		},
 		Subcommands: []*cli.Command{
 			GetCreateTeamCommand(config),
 			GetCreateTeamMemberCommand(config),
@@ -54,8 +48,8 @@ func GetCreateCommand(config *Config) *cli.Command {
 		},
 		Before: func(ctx *cli.Context) error {
 			if !ctx.Args().Present() {
-				_ = cli.ShowCommandHelp(ctx.Lineage()[1], "create")
-				return errors.New("[TYPE] [NAME] is required")
+				_ = cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("[TYPE] [NAME] is required")
 			}
 			return nil
 		},

--- a/pkg/cmd/korectl/create_cluster.go
+++ b/pkg/cmd/korectl/create_cluster.go
@@ -83,10 +83,6 @@ func GetCreateClusterCommand(config *Config) *cli.Command {
 
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "Used to select the team context you are operating in `NAME`",
-			},
-			&cli.StringFlag{
 				Name:  "plan,p",
 				Usage: "the plan which this cluster will be templated from `NAME`",
 			},

--- a/pkg/cmd/korectl/create_namespace.go
+++ b/pkg/cmd/korectl/create_namespace.go
@@ -58,10 +58,6 @@ func GetCreateNamespaceCommand(config *Config) *cli.Command {
 
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "Used to select the team context you are operating in `NAME`",
-			},
-			&cli.StringFlag{
 				Name:  "cluster,c",
 				Usage: "the name of the cluster you want the namespace to reside `NAME`",
 			},

--- a/pkg/cmd/korectl/delete.go
+++ b/pkg/cmd/korectl/delete.go
@@ -51,17 +51,15 @@ func GetDeleteCommand(config *Config) *cli.Command {
 				Name:  "file,f",
 				Usage: "The path to the file containing the resources definitions `PATH`",
 			},
-			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "Used to filter the results by team `TEAM`",
-			},
 		},
 		Subcommands: []*cli.Command{
 			GetDeleteTeamMemberCommand(config),
 		},
+
 		Before: func(ctx *cli.Context) error {
 			if !ctx.IsSet("file") && !ctx.Args().Present() {
-				return cli.ShowCommandHelp(ctx.Lineage()[1], "delete")
+				_ = cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("-f <file> or [TYPE] [NAME] is required")
 			}
 			return nil
 		},

--- a/pkg/cmd/korectl/edit.go
+++ b/pkg/cmd/korectl/edit.go
@@ -20,7 +20,6 @@
 package korectl
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/urfave/cli/v2"
@@ -43,11 +42,11 @@ func GetEditCommand(config *Config) *cli.Command {
 		Subcommands: []*cli.Command{
 			GetEditTeamCommand(config),
 		},
+
 		Before: func(ctx *cli.Context) error {
 			if !ctx.Args().Present() {
-				_ = cli.ShowCommandHelp(ctx.Lineage()[1], "edit")
-				fmt.Println()
-				return errors.New("[TYPE] [NAME] is required")
+				_ = cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("[TYPE] [NAME] ")
 			}
 			return nil
 		},

--- a/pkg/cmd/korectl/get.go
+++ b/pkg/cmd/korectl/get.go
@@ -20,7 +20,6 @@
 package korectl
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -44,22 +43,13 @@ func GetGetCommand(config *Config) *cli.Command {
 		Usage:       "Retrieves one or more resources from the api",
 		Description: formatLongDescription(getLongDescription),
 		ArgsUsage:   "[TYPE] [NAME]",
-		Flags: append([]cli.Flag{
-			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "Used to filter the results by team",
-			},
-		}, DefaultOptions...),
-
-		Before: func(ctx *cli.Context) error {
-			if !ctx.Args().Present() {
-				return errors.New("you need to specify a resource type")
-			}
-
-			return nil
-		},
+		Flags:       DefaultOptions,
 
 		Action: func(ctx *cli.Context) error {
+			if !ctx.Args().Present() {
+				_ = cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("[TYPE] or [TYPE] [NAME] is required")
+			}
 			req, resourceConfig, err := NewRequestForResource(config, ctx)
 			if err != nil {
 				return err

--- a/pkg/cmd/korectl/teams.go
+++ b/pkg/cmd/korectl/teams.go
@@ -159,10 +159,6 @@ func GetCreateTeamMemberCommand(config *Config) *cli.Command {
 		Usage:   "Creates a new team member",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "The name of the team you wish to add the user to",
-			},
-			&cli.StringFlag{
 				Name:     "user,u",
 				Usage:    "The username of the user you wish to add to the team",
 				Required: true,


### PR DESCRIPTION
## What

### Parsing global flags and reordering os.Args

The urfave/cli library uses the standard flags library which stops parsing flags when it finds the first non-flag argument.

We would like to be able to parse the `--team` argument anywhere, similar to how `kubectl` handles the `--namespace` flag. (But kubectl uses cobra)

This adds a CLI app wrapper which takes the CLI arguments and reorders them:
 - any global flags will be moved to the beginning of the list (so the cli library will parse them as flags and not arguments)

### Printing the global flags

The custom cli app wrapper registers a custom help printer which adds the global flags to all command help texts.

Because the global flags are now printed I removed the `--team` flag from all commands. We have to do this, because if you redefine the team flag on the command level, it breaks the cli lib and you can only define the team value on the command level :(

I also override the subcommand/command templates for consistent command helps and to allow to inject an additional new line if there are no flags for a command.

P.s. I seriously learned to hate this library.