### PR TITLE
CLI v2 upgrade fixes

### DIFF
--- a/cmd/korectl/options/options.go
+++ b/cmd/korectl/options/options.go
@@ -24,8 +24,9 @@ import (
 func Options() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:  "team,t",
-			Usage: "Used to select the team context you are operating in",
+			Name:    "team",
+			Aliases: []string{"t"},
+			Usage:   "Used to select the team context you are operating in",
 		},
 	}
 }

--- a/pkg/cmd/korectl/apply.go
+++ b/pkg/cmd/korectl/apply.go
@@ -30,7 +30,8 @@ func GetApplyCommand(config *Config) *cli.Command {
 		Usage: "Used to apply one of more resources to the API",
 		Flags: []cli.Flag{
 			&cli.StringSliceFlag{
-				Name:     "file,f",
+				Name:     "file",
+				Aliases:  []string{"f"},
 				Usage:    "The path to the file containing the resources definitions `PATH`",
 				Required: true,
 			},

--- a/pkg/cmd/korectl/clusters.go
+++ b/pkg/cmd/korectl/clusters.go
@@ -74,10 +74,6 @@ func GetClustersCommand(config *Config) *cli.Command {
 						Name:  "name,n",
 						Usage: "The name of the integration to retrieve `NAME`",
 					},
-					&cli.StringFlag{
-						Name:  "team,t",
-						Usage: "Used to filter the results by team `TEAM`",
-					},
 				}, DefaultOptions...),
 				Action: func(ctx *cli.Context) error {
 					team := ctx.String("team")

--- a/pkg/cmd/korectl/clusters.go
+++ b/pkg/cmd/korectl/clusters.go
@@ -35,8 +35,9 @@ func GetClustersCommand(config *Config) *cli.Command {
 				Usage: "Used to retrieve the API endpoints of the clusters and provision your kubeconfig",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "name,n",
-						Usage: "The name of the integration to retrieve `NAME`",
+						Name:    "name",
+						Aliases: []string{"n"},
+						Usage:   "The name of the integration to retrieve `NAME`",
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -71,8 +72,9 @@ func GetClustersCommand(config *Config) *cli.Command {
 				Usage: "Used to retrieve one or all clusters from the kore",
 				Flags: append([]cli.Flag{
 					&cli.StringFlag{
-						Name:  "name,n",
-						Usage: "The name of the integration to retrieve `NAME`",
+						Name:    "name",
+						Aliases: []string{"n"},
+						Usage:   "The name of the integration to retrieve `NAME`",
 					},
 				}, DefaultOptions...),
 				Action: func(ctx *cli.Context) error {

--- a/pkg/cmd/korectl/create_cluster.go
+++ b/pkg/cmd/korectl/create_cluster.go
@@ -80,8 +80,9 @@ func GetCreateClusterCommand(config *Config) *cli.Command {
 
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "plan,p",
-				Usage: "the plan which this cluster will be templated from `NAME`",
+				Name:    "plan",
+				Aliases: []string{"p"},
+				Usage:   "the plan which this cluster will be templated from `NAME`",
 			},
 			&cli.StringFlag{
 				Name:  "description",
@@ -97,8 +98,9 @@ func GetCreateClusterCommand(config *Config) *cli.Command {
 				Usage: "you can preprovision a collection namespaces on this cluster as well `NAMES`",
 			},
 			&cli.StringFlag{
-				Name:  "allocation,a",
-				Usage: "the name of the allocated credentials to use for this cluster `NAME`",
+				Name:    "allocation",
+				Aliases: []string{"a"},
+				Usage:   "the name of the allocated credentials to use for this cluster `NAME`",
 			},
 			&cli.BoolFlag{
 				Name:  "show-time",

--- a/pkg/cmd/korectl/create_namespace.go
+++ b/pkg/cmd/korectl/create_namespace.go
@@ -55,8 +55,9 @@ func GetCreateNamespaceCommand(config *Config) *cli.Command {
 
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "cluster,c",
-				Usage: "the name of the cluster you want the namespace to reside `NAME`",
+				Name:    "cluster",
+				Aliases: []string{"c"},
+				Usage:   "the name of the cluster you want the namespace to reside `NAME`",
 			},
 			&cli.BoolFlag{
 				Name:  "dry-run",

--- a/pkg/cmd/korectl/default.go
+++ b/pkg/cmd/korectl/default.go
@@ -21,12 +21,14 @@ import "github.com/urfave/cli/v2"
 // DefaultsOptions are options for all commands
 var DefaultOptions = []cli.Flag{
 	&cli.StringFlag{
-		Name:  "output,o",
-		Usage: "The output format of the resource `FORMAT`",
-		Value: "yaml",
+		Name:    "output",
+		Aliases: []string{"o"},
+		Usage:   "The output format of the resource `FORMAT`",
+		Value:   "yaml",
 	},
 	&cli.BoolFlag{
-		Name:  "debug,D",
-		Usage: "Indicates for verbose logging `BOOL`",
+		Name:    "debug",
+		Aliases: []string{"D"},
+		Usage:   "Indicates for verbose logging `BOOL`",
 	},
 }

--- a/pkg/cmd/korectl/delete.go
+++ b/pkg/cmd/korectl/delete.go
@@ -45,8 +45,9 @@ func GetDeleteCommand(config *Config) *cli.Command {
 		ArgsUsage:   "-f <file> | [TYPE] [NAME]",
 		Flags: []cli.Flag{
 			&cli.StringSliceFlag{
-				Name:  "file,f",
-				Usage: "The path to the file containing the resources definitions `PATH`",
+				Name:    "file",
+				Aliases: []string{"f"},
+				Usage:   "The path to the file containing the resources definitions `PATH`",
 			},
 		},
 		Subcommands: []*cli.Command{

--- a/pkg/cmd/korectl/locallogs.go
+++ b/pkg/cmd/korectl/locallogs.go
@@ -39,7 +39,8 @@ func GetLocalLogsSubCommand(_ *Config) *cli.Command {
 		Usage: "View logs from local Kore.",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:     "follow, f",
+				Name:     "follow",
+				Aliases:  []string{"f"},
 				Usage:    "Follow log output.",
 				Required: false,
 			},

--- a/pkg/cmd/korectl/login.go
+++ b/pkg/cmd/korectl/login.go
@@ -53,17 +53,20 @@ func GetLoginCommand(config *Config) *cli.Command {
 
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "api-server,a",
-				Usage: "allows you to specify the kore api server to login as `URL`",
+				Name:    "api-server",
+				Aliases: []string{"a"},
+				Usage:   "allows you to specify the kore api server to login as `URL`",
 			},
 			&cli.BoolFlag{
-				Name:  "force,f",
-				Usage: "must be set when you want to override the api-server on an existing profile `BOOL`",
+				Name:    "force",
+				Aliases: []string{"f"},
+				Usage:   "must be set when you want to override the api-server on an existing profile `BOOL`",
 			},
 			&cli.IntFlag{
-				Name:  "port,p",
-				Usage: "sets the local port used for redirection when authenticating",
-				Value: 3001,
+				Name:    "port",
+				Aliases: []string{"p"},
+				Usage:   "sets the local port used for redirection when authenticating",
+				Value:   3001,
 			},
 		},
 

--- a/pkg/cmd/korectl/teams.go
+++ b/pkg/cmd/korectl/teams.go
@@ -156,12 +156,14 @@ func GetCreateTeamMemberCommand(config *Config) *cli.Command {
 		Usage:   "Creates a new team member",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "user,u",
+				Name:     "user",
+				Aliases:  []string{"u"},
 				Usage:    "The username of the user you wish to add to the team",
 				Required: true,
 			},
 			&cli.BoolFlag{
-				Name:     "invite,i",
+				Name:     "invite",
+				Aliases:  []string{"i"},
 				Usage:    "If the user doesn't exist and the invite flag is set, the invite url will be automatically generated.",
 				Required: false,
 			},
@@ -240,7 +242,8 @@ func GetDeleteTeamMemberCommand(config *Config) *cli.Command {
 		Usage:   "Removes a member from the given team",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "user,u",
+				Name:     "user",
+				Aliases:  []string{"u"},
 				Usage:    "The username of the user you wish to remove from the team",
 				Required: true,
 			},

--- a/pkg/cmd/korectl/teams.go
+++ b/pkg/cmd/korectl/teams.go
@@ -240,10 +240,6 @@ func GetDeleteTeamMemberCommand(config *Config) *cli.Command {
 		Usage:   "Removes a member from the given team",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "team,t",
-				Usage: "The name of the team you wish to remove the user from",
-			},
-			&cli.StringFlag{
 				Name:     "user,u",
 				Usage:    "The username of the user you wish to remove from the team",
 				Required: true,


### PR DESCRIPTION
* Flag aliases are not supported in v2 anymore in the Name field (e.g. "user,u"), we have to use the Aliases field
* Removing some remaining command level team parameters