### PR TITLE
Allow CLI to create kube config file if non-existant. Addresses #306.

### DIFF
--- a/doc/alpha-local-quick-start.md
+++ b/doc/alpha-local-quick-start.md
@@ -252,7 +252,7 @@ You now have a sandbox environment locally provisioned for your team. 🎉
 
 We'll be using `kubectl`, the Kubernetes CLI, to make the deployment. If you don't have it already, [please install and setup kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-macos).
 
-Once `kubectl` is installed, `korectl` should be used to configure it with details of your new cluster, including short-lived credentials to access it:
+Now we have to configure our `kubectl` kubeconfig in ~/.kube/config with our new GKE cluster.
 
 ```shell script
 bin/korectl clusters auth -t team-appvia

--- a/doc/alpha-local-quick-start.md
+++ b/doc/alpha-local-quick-start.md
@@ -252,14 +252,7 @@ You now have a sandbox environment locally provisioned for your team. 🎉
 
 We'll be using `kubectl`, the Kubernetes CLI, to make the deployment. If you don't have it already, [please install and setup kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-macos).
 
-Ensure kubeconfig is available.
-
-```shell script
-ls -alh ~/.kube/config
-# ...
-```
-
-Then set up our kubeconfig in `~/.kube/config` with our newly minted sandbox environment.
+Once `kubectl` is installed, `korectl` should be used to configure it with details of your new cluster, including short-lived credentials to access it:
 
 ```shell script
 bin/korectl clusters auth -t team-appvia

--- a/pkg/cmd/korectl/clusters.go
+++ b/pkg/cmd/korectl/clusters.go
@@ -54,7 +54,7 @@ func GetClustersCommand(config *Config) *cli.Command {
 						return nil
 					}
 
-					kubeconfig, err := GetKubeConfig()
+					kubeconfig, err := GetOrCreateKubeConfig()
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/korectl/helper.go
+++ b/pkg/cmd/korectl/helper.go
@@ -287,7 +287,7 @@ func GetCaches(config *Config) error {
 }
 
 //
-func GetKubeConfig() (string, error) {
+func GetOrCreateKubeConfig() (string, error) {
 	path := func() string {
 		p := os.ExpandEnv(os.Getenv("$KUBECONFIG"))
 		if p != "" {
@@ -297,12 +297,9 @@ func GetKubeConfig() (string, error) {
 		return os.ExpandEnv("${HOME}/.kube/config")
 	}()
 
-	found, err := utils.FileExists(path)
+	_, err := utils.EnsureFileExists(path)
 	if err != nil {
 		return "", err
-	}
-	if !found {
-		return "", errors.New("no kubeconfig found")
 	}
 
 	return path, nil

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -16,7 +16,10 @@
 
 package utils
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // FileExists checks if a file exists
 func FileExists(filename string) (bool, error) {
@@ -30,4 +33,24 @@ func FileExists(filename string) (bool, error) {
 	}
 
 	return !info.IsDir(), nil
+}
+
+// Creates an (empty) file if filename does not exist (returning true) or does
+// nothing if it already exists (returning false). Will create missing directories.
+func EnsureFileExists(filename string) (bool, error) {
+	exists, err := FileExists(filename)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return false, nil
+	}
+	// Create directory (will no-op if it already exists)
+	if err := os.MkdirAll(filepath.Dir(filename), os.ModePerm); err != nil {
+		return false, err
+	}
+	if _, err := os.Create(filename); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -35,8 +35,8 @@ func FileExists(filename string) (bool, error) {
 	return !info.IsDir(), nil
 }
 
-// Creates an (empty) file if filename does not exist (returning true) or does
-// nothing if it already exists (returning false). Will create missing directories.
+// EnsureFileExists creates an (empty) file if filename does not exist (returning true)
+// or does nothing if it already exists (returning false). Will create missing directories.
 func EnsureFileExists(filename string) (bool, error) {
 	exists, err := FileExists(filename)
 	if err != nil {
@@ -45,7 +45,6 @@ func EnsureFileExists(filename string) (bool, error) {
 	if exists {
 		return false, nil
 	}
-	// Create directory (will no-op if it already exists)
 	if err := os.MkdirAll(filepath.Dir(filename), os.ModePerm); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Pretty simple one - when running on a machine where kubectl is installed but you've not yet used it, allows kubectl auth to work correctly. Tested and working locally.