### PR TITLE
Command Line Arguments Reordering

### DIFF
--- a/cmd/korectl/main.go
+++ b/cmd/korectl/main.go
@@ -74,6 +74,10 @@ func main() {
 		Commands: korectl.GetCommands(config),
 
 		Before: func(ctx *cli.Context) error {
+			if ctx.Bool("show-flags") {
+				fmt.Println("flags:", ctx.Args())
+			}
+
 			for _, x := range ctx.Args().Slice() {
 				for x == "--debug" {
 					log.SetLevel(log.DebugLevel)

--- a/cmd/korectl/options/options.go
+++ b/cmd/korectl/options/options.go
@@ -28,5 +28,17 @@ func Options() []cli.Flag {
 			Aliases: []string{"t"},
 			Usage:   "Used to select the team context you are operating in",
 		},
+		&cli.BoolFlag{
+			Name:    "show-flags",
+			Usage:   "Used to debugging the flags on the command line `BOOL`",
+			Hidden:  true,
+			EnvVars: []string{"SHOW_FLAGS"},
+		},
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "The output format of the resource `FORMAT`",
+			Value:   "yaml",
+		},
 	}
 }

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -123,7 +123,7 @@ func (a *App) Reorder(args []string) ([]string, error) {
 			parsed := strings.TrimLeft(arg, "-")
 
 			// @step: we check if the flag is global for related to the command
-			flag, found := a.isGlobalFlag(parsed)
+			flag, found := a.getGlobalFlag(parsed)
 			if found {
 				// we are dealing with a command flag - we need to know if it has args though
 				values, err := a.getFlagValues(parsed, args[i:], flag)
@@ -166,14 +166,14 @@ func (a *App) Reorder(args []string) ([]string, error) {
 		} else {
 			// @step: the argument is not a flag, is it a command?
 			if parent == nil {
-				parent, found = a.isAppCommand(arg)
+				parent, found = a.getAppCommand(arg)
 				if !found {
 					tail = append(tail, arg)
 				} else {
 					head = append(head, arg)
 				}
 			} else {
-				command, found := a.isSubCommand(arg, parent)
+				command, found := a.getSubCommand(arg, parent)
 				if found {
 					parent = command
 					head = append(head, arg)
@@ -195,7 +195,7 @@ func (a *App) Reorder(args []string) ([]string, error) {
 	return append([]string{args[0]}, full...), nil
 }
 
-func (a *App) isAppCommand(name string) (*cli.Command, bool) {
+func (a *App) getAppCommand(name string) (*cli.Command, bool) {
 	for _, x := range a.app.Commands {
 		if utils.Contains(name, x.Names()) {
 			return x, true
@@ -205,7 +205,7 @@ func (a *App) isAppCommand(name string) (*cli.Command, bool) {
 	return nil, false
 }
 
-func (a *App) isSubCommand(name string, parent *cli.Command) (*cli.Command, bool) {
+func (a *App) getSubCommand(name string, parent *cli.Command) (*cli.Command, bool) {
 	for _, x := range parent.Subcommands {
 		if utils.Contains(name, x.Names()) {
 			return x, true
@@ -215,7 +215,7 @@ func (a *App) isSubCommand(name string, parent *cli.Command) (*cli.Command, bool
 	return nil, false
 }
 
-func (a *App) isGlobalFlag(name string) (cli.Flag, bool) {
+func (a *App) getGlobalFlag(name string) (cli.Flag, bool) {
 	for _, flag := range a.app.Flags {
 		if utils.Contains(name, flag.Names()) {
 			return flag, true

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cmd
 
 import (
@@ -174,8 +190,7 @@ func (a *App) Reorder(args []string) ([]string, error) {
 
 	ordered = append(ordered, head...)
 	ordered = append(ordered, tail...)
-	var full []string
-	full = append(global, ordered...)
+	full := append(global, ordered...)
 
 	return append([]string{args[0]}, full...), nil
 }

--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cmd_test
 
 import (

--- a/pkg/cmd/korectl/create_cluster.go
+++ b/pkg/cmd/korectl/create_cluster.go
@@ -42,13 +42,13 @@ import (
 
 var (
 	createClusterLongDescription = `
-Provides the ability to provision a kubernetes cluster in the team. The cluster 
+Provides the ability to provision a kubernetes cluster in the team. The cluster
 itself is provisioned from a predefined plan (a template). You can view the plans
-available to you via $ korectl get plans. Once the cluster has been built the 
-members of your team can gain access via running $ korectl login. 
+available to you via $ korectl get plans. Once the cluster has been built the
+members of your team can gain access via running $ korectl login.
 
 Note: you retrieve a list of all the plans available to you via:
-$ korectl get plans 
+$ korectl get plans
 $ korectl get plans <name> -o yaml
 
 Examples:
@@ -60,7 +60,7 @@ $ korectl -t <myteam> create cluster dev --plan gke-development -a <name> --name
 # Check the status of the cluster
 $ korectl -t <myteam> get cluster dev -o yaml
 
-Once you have created the cluster you can login via 
+Once you have created the cluster you can login via
 $ korectl clusters auth -t <myteam>
 
 This will generate your ${HOME}/.kube/config for you with the clusters from team.
@@ -72,8 +72,8 @@ This will generate your ${HOME}/.kube/config for you with the clusters from team
 // and offload it from the CLI - but needs discussion first.
 func GetCreateClusterCommand(config *Config) *cli.Command {
 	return &cli.Command{
-		Name:        "clusters",
-		Aliases:     []string{"cluster"},
+		Name:        "cluster",
+		Aliases:     []string{"clusters"},
 		Description: createClusterLongDescription,
 		Usage:       "Create a kubernetes cluster within the team",
 		ArgsUsage:   "<name> [options]",

--- a/pkg/cmd/korectl/default.go
+++ b/pkg/cmd/korectl/default.go
@@ -20,12 +20,6 @@ import "github.com/urfave/cli/v2"
 
 // DefaultsOptions are options for all commands
 var DefaultOptions = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "output",
-		Aliases: []string{"o"},
-		Usage:   "The output format of the resource `FORMAT`",
-		Value:   "yaml",
-	},
 	&cli.BoolFlag{
 		Name:    "debug",
 		Aliases: []string{"D"},


### PR DESCRIPTION
Based on the previous work this reorders the argument but takes into account the infomation provided from the commands themselves to order. On a side note, i'm sure will all agree - we need to move to another lib

- this fixes among things the positional arguments ... so commands like `korectl create clusters dev --plan gke-development -a gke -t devs` now work in any order.

Tested against all the commands so far