### PR TITLE
Rename discovery url to (IDP) server url

### DIFF
--- a/charts/kore/templates/secret.yaml
+++ b/charts/kore/templates/secret.yaml
@@ -29,7 +29,7 @@ stringData:
   KORE_CLIENT_ID: {{ required ".Values.idp.client_id is required!" .Values.idp.client_id }}
   KORE_CLIENT_SCOPES: {{ .Values.idp.client_scopes | join "," }}
   KORE_CLIENT_SECRET: {{ required ".Values.idp.client_secret is required!" .Values.idp.client_secret }}
-  KORE_DISCOVERY_URL: {{ required ".Values.idp.discovery_url is required!" .Values.idp.discovery_url }}
+  KORE_IDP_SERVER_URL: {{ required ".Values.idp.server_url is required!" .Values.idp.server_url }}
   KORE_USER_CLAIMS: {{ .Values.idp.user_claims | join "," }}
 
 ---

--- a/charts/kore/values.yaml
+++ b/charts/kore/values.yaml
@@ -16,7 +16,7 @@ mysql:
 idp:
   client_id: ""
   client_secret: ""
-  discovery_url: ""
+  server_url: ""
   user_claims:
     - preferred_username
     - email

--- a/cmd/auth-proxy/main.go
+++ b/cmd/auth-proxy/main.go
@@ -59,7 +59,7 @@ func main() {
 		Action: func(ctx *cli.Context) error {
 			config := authproxy.Config{
 				ClientID:                   ctx.String("client-id"),
-				DiscoveryURL:               ctx.String("discovery-url"),
+				IDPServerURL:               ctx.String("idp-server-url"),
 				GroupClaims:                ctx.StringSlice("group-claims"),
 				Listen:                     ctx.String("listen"),
 				MetricsListen:              ctx.String("metrics-listen"),

--- a/cmd/auth-proxy/options/options.go
+++ b/cmd/auth-proxy/options/options.go
@@ -38,9 +38,9 @@ func Options() []cli.Flag {
 			EnvVars: []string{"TLS_KEY"},
 		},
 		&cli.StringFlag{
-			Name:    "discovery-url",
-			Usage:   "the openid discovery url used to pull down idp details `URL`",
-			EnvVars: []string{"DISCOVERY_URL"},
+			Name:    "idp-server-url",
+			Usage:   "the openid server url `URL`",
+			EnvVars: []string{"IDP_SERVER_URL"},
 		},
 		&cli.StringFlag{
 			Name:    "client-id",
@@ -49,7 +49,7 @@ func Options() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    "ca-authority",
-			Usage:   "when not using the discovery url we can use this certificate to verity the token `PATH`",
+			Usage:   "when not using the IDP server url we can use this certificate to verity the token `PATH`",
 			EnvVars: []string{"CA_AUTHORITY"},
 		},
 		&cli.StringFlag{

--- a/cmd/kore-apiserver/options/options.go
+++ b/cmd/kore-apiserver/options/options.go
@@ -75,9 +75,9 @@ func Options() []cli.Flag {
 			Value:   cli.NewStringSlice("profile", "email", "offline"),
 		},
 		&cli.StringFlag{
-			Name:    "discovery-url",
-			Usage:   "the openid discovery url to use for the openid authenticator `URL`",
-			EnvVars: []string{"KORE_DISCOVERY_URL"},
+			Name:    "idp-server-url",
+			Usage:   "the openid server url to use for the openid authenticator `URL`",
+			EnvVars: []string{"KORE_IDP_SERVER_URL"},
 		},
 		&cli.StringFlag{
 			Name:    "api-public-url",

--- a/cmd/kore-apiserver/server.go
+++ b/cmd/kore-apiserver/server.go
@@ -69,7 +69,7 @@ func invoke(ctx *cli.Context) error {
 			ClientScopes:               ctx.StringSlice("client-scopes"),
 			ClientSecret:               ctx.String("client-secret"),
 			ClusterAppManImage:         ctx.String("clusterappman-image"),
-			DiscoveryURL:               strings.TrimSuffix(ctx.String("discovery-url"), ".well-known/openid-configuration"),
+			IDPServerURL:               strings.TrimSuffix(ctx.String("idp-server-url"), ".well-known/openid-configuration"),
 			EnableClusterDeletion:      ctx.Bool("enable-cluster-deletion"),
 			EnableClusterDeletionBlock: ctx.Bool("enable-cluster-deletion-block"),
 			EnableClusterProviderCheck: ctx.Bool("enable-cluster-provider-check"),

--- a/cmd/kore-apiserver/server.go
+++ b/cmd/kore-apiserver/server.go
@@ -69,7 +69,7 @@ func invoke(ctx *cli.Context) error {
 			ClientScopes:               ctx.StringSlice("client-scopes"),
 			ClientSecret:               ctx.String("client-secret"),
 			ClusterAppManImage:         ctx.String("clusterappman-image"),
-			IDPServerURL:               strings.TrimSuffix(ctx.String("idp-server-url"), ".well-known/openid-configuration"),
+			IDPServerURL:               ctx.String("idp-server-url"),
 			EnableClusterDeletion:      ctx.Bool("enable-cluster-deletion"),
 			EnableClusterDeletionBlock: ctx.Bool("enable-cluster-deletion-block"),
 			EnableClusterProviderCheck: ctx.Bool("enable-cluster-provider-check"),

--- a/deploy/kube/secrets/openid.example.env
+++ b/deploy/kube/secrets/openid.example.env
@@ -2,8 +2,8 @@
 KORE_CLIENT_ID=CHANGE_ME
 # The authentiation provider secret
 KORE_CLIENT_SECRET=CHANGE_ME
-# The openid discovery url
-KORE_DISCOVERY_URL=CHANGE_ME
+# The openid server url
+KORE_IDP_SERVER_URL=CHANGE_ME
 # This can vary depending on the IDP you are using for the demo as different
 # provider encode the username in different fields
 KORE_USER_CLAIMS=preferred_username,email,name,username

--- a/doc/alpha-local-quick-start.md
+++ b/doc/alpha-local-quick-start.md
@@ -99,13 +99,11 @@ These are the permitted redirects for the applications. Since we are running the
 http://localhost:10080/oauth/callback,http://localhost:3000/auth/callback 
 ```
 
+Please make a note of the [__*Domain, Client ID, and Client Secret*__].
+
 Scroll to the bottom of the settings and click the `Show Advanced Settings`
 
 Choose the `OAuth` tab from the advanced settings and ensure that the `JsonWebToken Signature Algorithm` is set to RS256 and `OIDC Conformant` is toggled on.
-
-Select the `Endpoints` tab and note down the `OpenID Configuration`.
-
-Please make a note of the [__*ClientID, Client Secret and the OpenID endpoint*__].
 
 #### Configuring test users
 
@@ -140,10 +138,12 @@ You'll need access to the following details created earlier:
 
 - Auth0 ClientID.
 - Auth0 Client Secret.
-- Auth0 OpenID endpoint.
+- Auth0 domain.
 - GKE Project ID.
 - GKE Region.
 - Path to the service account key JSON file.
+
+Make sure you fill in the OpenID endpoint as `https://[Auth0 domain]/`, including the trailing `/`.
 
 Once you have everything, run,
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -12,7 +12,7 @@ Configure Auth0 by following the docs [here](auth0.md) and export the obtained v
 ```
 export CLIENT_ID=<your client id>
 export CLIENT_SECRET=<your client secret>
-export DISCOVERY_URL=<your discovery url>
+export IDP_SERVER_URL=<your openid server url>
 ```
 
 ### 3. Create helm configuration values
@@ -23,7 +23,7 @@ cat >> ./charts/my_values.yaml << EOF
 idp:
   client_id: $CLIENT_ID
   client_secret: $CLIENT_SECRET
-  discovery_url: $DISCOVERY_URL
+  server_url: $IDP_SERVER_URL
 api:
   endpoint:
     detect: true

--- a/hack/bin/run-api-with-env.sh
+++ b/hack/bin/run-api-with-env.sh
@@ -13,7 +13,7 @@ source ./demo.env
 export \
     KORE_CLIENT_ID \
     KORE_CLIENT_SECRET \
-    KORE_DISCOVERY_URL \
+    KORE_IDP_SERVER_URL \
     KORE_USER_CLAIMS \
     KORE_CLIENT_SCOPES
 

--- a/hack/compose/demo.env.tmpl
+++ b/hack/compose/demo.env.tmpl
@@ -5,8 +5,8 @@
 KORE_CLIENT_ID=CHANGE_ME
 # The authentiation provider secret
 KORE_CLIENT_SECRET=CHANGE_ME
-# The openid discovery url
-KORE_DISCOVERY_URL=CHANGE_ME
+# The openid server url
+KORE_IDP_SERVER_URL=CHANGE_ME
 # This can vary depending on the IDP you are using for the demo as different
 # provider encode the username in different fields
 KORE_USER_CLAIMS=preferred_username,email,name,username

--- a/hack/compose/local.env.tmpl
+++ b/hack/compose/local.env.tmpl
@@ -5,8 +5,8 @@
 KORE_CLIENT_ID={{.ClientID}}
   # The authentiation provider secret
 KORE_CLIENT_SECRET={{.ClientSecret}}
-  # The openid discovery url
-KORE_DISCOVERY_URL={{.AuthorizeURL}}
+  # The openid server url
+KORE_IDP_SERVER_URL={{.AuthorizeURL}}
   # This can vary depending on the IDP you are using for the demo as different
   # provider encode the username in different fields
 KORE_USER_CLAIMS=preferred_username,email,name,username

--- a/hack/dex.env
+++ b/hack/dex.env
@@ -11,6 +11,6 @@ export KORE_CERTIFICATE_AUTHORITY_KEY=hack/ca/ca-key.pem
 export KORE_CLIENT_ID=broker
 export KORE_CLIENT_SCOPES=email,profile,offline_access
 export KORE_CLIENT_SECRET="f6ae2a9e-443e-11ea-9110-9cb6d0d6cd27"
-export KORE_DISCOVERY_URL="http://localhost:5556/"
+export KORE_IDP_SERVER_URL="http://localhost:5556/"
 export KORE_HMAC="bdT2Qg6DybsLIwc0TbYWrkGC4auovscg"
 export USERS_DB_URL="root:pass@tcp(localhost:3306)/kore?parseTime=true"

--- a/pkg/apis/core/v1/idp_types.go
+++ b/pkg/apis/core/v1/idp_types.go
@@ -104,10 +104,6 @@ type OIDCIDP struct {
 	ClientSecret string `json:"clientSecret"`
 	// Issuer provides the IDP URL
 	Issuer string `json:"issuer"`
-	// DiscoveryURL The OIDC Discovery URL to use
-	// - when using the DEX broker this will differ from the issuer
-	// - when using an IDP directly this will be the same as the Issuer
-	DiscoveryURL string `json:"discoveryUrl"`
 	// ClientScopes provides the OIDC client scopes
 	ClientScopes []string `json:"clientScopes"`
 	// UserClaims to track the identity field to use

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -59,7 +59,7 @@ func New(kore kore.Interface, config Config) (Interface, error) {
 	c.Filter(cors.Filter)
 
 	authFilter := filters.AuthenticationHandler{
-		Realm: kore.Config().DiscoveryURL,
+		Realm: kore.Config().IDPServerURL,
 	}
 
 	// @step: register the resource handlers

--- a/pkg/apiserver/login.go
+++ b/pkg/apiserver/login.go
@@ -67,8 +67,8 @@ func (l *loginHandler) Register(i kore.Interface, builder utils.PathBuilder) (*r
 	ws.Produces(restful.MIME_JSON)
 	ws.Path("oauth")
 
-	if l.Config().DiscoveryURL != "" {
-		provider, err := oidc.NewProvider(context.Background(), l.Config().DiscoveryURL)
+	if l.Config().IDPServerURL != "" {
+		provider, err := oidc.NewProvider(context.Background(), l.Config().IDPServerURL)
 		if err != nil {
 			log.WithError(err).Error("failed to create the openid provider")
 
@@ -229,7 +229,7 @@ func (l *loginHandler) callbackHandler(req *restful.Request, resp *restful.Respo
 		// @step: build an authorization response and hold in the cache
 		res := &AuthorizationResponse{
 			AccessToken:      otoken.AccessToken,
-			AuthorizationURL: l.Config().DiscoveryURL,
+			AuthorizationURL: l.Config().IDPServerURL,
 			ClientID:         l.Config().ClientID,
 			ClientSecret:     l.Config().ClientSecret,
 			IDToken:          rawToken,

--- a/pkg/cmd/auth-proxy/config.go
+++ b/pkg/cmd/auth-proxy/config.go
@@ -25,8 +25,8 @@ func (c Config) IsValid() error {
 	if c.ClientID == "" {
 		return errors.New("no client id")
 	}
-	if c.DiscoveryURL == "" && c.SigningCA == "" {
-		return errors.New("neither disovery-url or signing ca are not defined")
+	if c.IDPServerURL == "" && c.SigningCA == "" {
+		return errors.New("neither IDP server url or signing ca are defined")
 	}
 	if len(c.UserClaims) <= 0 {
 		return errors.New("user claims are empty")

--- a/pkg/cmd/auth-proxy/server.go
+++ b/pkg/cmd/auth-proxy/server.go
@@ -84,12 +84,12 @@ func New(config Config) (Interface, error) {
 
 		verifier = oidc.NewVerifier(config.ClientID, keyset, options)
 	}
-	if config.DiscoveryURL != "" {
+	if config.IDPServerURL != "" {
 		log.WithField(
-			"discovery-url", config.DiscoveryURL,
-		).Info("using the discovery endpoint to verify the requests")
+			"idp-server-url", config.IDPServerURL,
+		).Info("using the IDP server to verify the requests")
 
-		provider, err := oidc.NewProvider(context.Background(), config.DiscoveryURL)
+		provider, err := oidc.NewProvider(context.Background(), config.IDPServerURL)
 		if err != nil {
 			log.WithError(err).Error("trying to retrieve provider details")
 

--- a/pkg/cmd/auth-proxy/types.go
+++ b/pkg/cmd/auth-proxy/types.go
@@ -25,8 +25,8 @@ import (
 type Config struct {
 	// ClientID is the client issuer
 	ClientID string `json:"client_id,omitempty"`
-	// DiscoveryURL is the openid discovery url
-	DiscoveryURL string `json:"discovery_url,omitempty"`
+	// IDPServerURL is the openid server url
+	IDPServerURL string `json:"idp_server_url,omitempty"`
 	// Listen is the interface to listen on
 	Listen string `json:"listen,omitempty"`
 	// TLSCaAuthority is a caroot used when verifying the upstream idp
@@ -35,7 +35,7 @@ type Config struct {
 	TLSCert string `json:"tls_cert,omitempty"`
 	// TLSKey is the private key for the above
 	TLSKey string `json:"tls_key,omitempty"`
-	// SigningCA is used when not using the discovery url
+	// SigningCA is used when not using the IDP server url
 	SigningCA string `json:"signing_ca,omitempty"`
 	// UserClaims is a collection of claims to extract the user idenity
 	UserClaims []string `json:"user_claims,omitempty"`

--- a/pkg/controllers/management/clusterconfig/reconcile.go
+++ b/pkg/controllers/management/clusterconfig/reconcile.go
@@ -139,10 +139,10 @@ func (t ccCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 			Namespace: kore.HubNamespace,
 		},
 		Data: map[string][]byte{
-			"api-url":       []byte(t.Config().PublicAPIURL),
-			"discovery-url": []byte(t.Config().DiscoveryURL),
-			"domain":        []byte(cluster.Spec.Domain),
-			"hub-url":       []byte(t.Config().PublicHubURL),
+			"api-url":        []byte(t.Config().PublicAPIURL),
+			"idp-server-url": []byte(t.Config().IDPServerURL),
+			"domain":         []byte(cluster.Spec.Domain),
+			"hub-url":        []byte(t.Config().PublicHubURL),
 		},
 	}
 	logger.Debug("adding the client configuration to the cluster")

--- a/pkg/controllers/management/kubernetes/proxy.go
+++ b/pkg/controllers/management/kubernetes/proxy.go
@@ -290,7 +290,7 @@ func (a k8sCtrl) EnsureAPIService(ctx context.Context, cc client.Client, cluster
 							},
 							Args: append([]string{
 								"--client-id=" + a.Config().ClientID,
-								"--discovery-url=" + a.Config().DiscoveryURL,
+								"--idp-server-url=" + a.Config().IDPServerURL,
 								"--tls-cert=/tls/tls.crt",
 								"--tls-key=/tls/tls.key",
 							}, claims...),

--- a/pkg/kore/config.go
+++ b/pkg/kore/config.go
@@ -44,7 +44,7 @@ func (c Config) IsValid() error {
 
 // HasOpenID checks if openid is setup
 func (c Config) HasOpenID() bool {
-	return c.DiscoveryURL != ""
+	return c.IDPServerURL != ""
 }
 
 // HasCertificateAuthorityKey check if we have a key

--- a/pkg/kore/idp.go
+++ b/pkg/kore/idp.go
@@ -189,7 +189,6 @@ func (a idpImpl) getDirectIDP() (*corev1.IDP, error) {
 	d := corev1.StaticOIDCIDP{}
 	d.ClientID = a.Config().ClientID
 	d.ClientSecret = a.Config().ClientSecret
-	d.DiscoveryURL = a.Config().IDPServerURL
 	d.Issuer = a.Config().IDPServerURL
 	d.ClientScopes = a.Config().ClientScopes
 	d.UserClaims = a.Config().UserClaims

--- a/pkg/kore/idp.go
+++ b/pkg/kore/idp.go
@@ -189,8 +189,8 @@ func (a idpImpl) getDirectIDP() (*corev1.IDP, error) {
 	d := corev1.StaticOIDCIDP{}
 	d.ClientID = a.Config().ClientID
 	d.ClientSecret = a.Config().ClientSecret
-	d.DiscoveryURL = a.Config().DiscoveryURL
-	d.Issuer = a.Config().DiscoveryURL
+	d.DiscoveryURL = a.Config().IDPServerURL
+	d.Issuer = a.Config().IDPServerURL
 	d.ClientScopes = a.Config().ClientScopes
 	d.UserClaims = a.Config().UserClaims
 

--- a/pkg/kore/types.go
+++ b/pkg/kore/types.go
@@ -112,8 +112,8 @@ type Config struct {
 	ClusterAppManImage string `json:"cluster-app-man-image,omitempty"`
 	// DEX is the config required to configure dex
 	DEX DEX `json:"dex,omitempty"`
-	// DiscoveryURL is the openid discovery url
-	DiscoveryURL string `json:"discovery-url,omitempty"`
+	// IDPServerURL is the openid server url
+	IDPServerURL string `json:"idp-server-url,omitempty"`
 	// EnabledClusterDeletion indicates we should delete cloud providers
 	EnableClusterDeletion bool `json:"enable-cluster-deletion,omitempty"`
 	// EnableClusterDeletionBlock indicates we should only delete the cluster if the cloud

--- a/pkg/plugins/authentication/openid/authenticator.go
+++ b/pkg/plugins/authentication/openid/authenticator.go
@@ -44,14 +44,14 @@ func New(h kore.Interface, config Config) (identity.Plugin, error) {
 		return nil, err
 	}
 	log.WithFields(log.Fields{
-		"discovery-url": config.DiscoveryURL,
-		"user-claim":    config.UserClaims,
+		"server-url": config.ServerURL,
+		"user-claim": config.UserClaims,
 	}).Info("initializing the openid authentication plugin")
 
 	// @step: grab an openid verifier
 	discovery, err := openid.New(openid.Config{
-		ClientID:     config.ClientID,
-		DiscoveryURL: config.DiscoveryURL,
+		ClientID:  config.ClientID,
+		ServerURL: config.ServerURL,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/plugins/authentication/openid/config.go
+++ b/pkg/plugins/authentication/openid/config.go
@@ -24,14 +24,14 @@ import (
 
 // IsValid checks the configuration is valid
 func (c Config) IsValid() error {
-	if c.DiscoveryURL == "" {
-		return errors.New("no discovery url configured")
+	if c.ServerURL == "" {
+		return errors.New("no server url configured")
 	}
 	if c.ClientID == "" {
 		return errors.New("no client id configured")
 	}
-	if _, err := url.Parse(c.DiscoveryURL); err != nil {
-		return fmt.Errorf("invalid discovery url: %s", err)
+	if _, err := url.Parse(c.ServerURL); err != nil {
+		return fmt.Errorf("invalid server url: %s", err)
 	}
 	if len(c.UserClaims) <= 0 {
 		c.UserClaims = append(c.UserClaims, []string{"preferred_username"}...)

--- a/pkg/plugins/authentication/openid/types.go
+++ b/pkg/plugins/authentication/openid/types.go
@@ -20,8 +20,8 @@ package openid
 type Config struct {
 	// ClientID is the openid client id
 	ClientID string
-	// DiscoveryURL is the discovery URL
-	DiscoveryURL string `json:"discovery-url,omitempty"`
+	// ServerURL is the openid server URL
+	ServerURL string `json:"server-url,omitempty"`
 	// SkipTLSVerify skips the TLS for the IDP
 	SkipTLSVerify bool `json:"skip-tls-verify,omitempty"`
 	// UserClaims is the claim fields which specifies the username

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -1,19 +1,3 @@
-/**
- * Copyright 2020 Appvia Ltd <info@appvia.io>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // Code generated for package register by go-bindata DO NOT EDIT. (@generated)
 // sources:
 // deploy/crds/apps.kore.appvia.io_appdeployments.yaml
@@ -3196,11 +3180,6 @@ spec:
                     clientSecret:
                       description: ClientSecret provides the OIDC client secret string
                       type: string
-                    discoveryUrl:
-                      description: DiscoveryURL The OIDC Discovery URL to use - when
-                        using the DEX broker this will differ from the issuer - when
-                        using an IDP directly this will be the same as the Issuer
-                      type: string
                     issuer:
                       description: Issuer provides the IDP URL
                       type: string
@@ -3213,7 +3192,6 @@ spec:
                   - clientID
                   - clientScopes
                   - clientSecret
-                  - discoveryUrl
                   - issuer
                   - userClaims
                   type: object
@@ -3232,11 +3210,6 @@ spec:
                     clientSecret:
                       description: ClientSecret provides the OIDC client secret string
                       type: string
-                    discoveryUrl:
-                      description: DiscoveryURL The OIDC Discovery URL to use - when
-                        using the DEX broker this will differ from the issuer - when
-                        using an IDP directly this will be the same as the Issuer
-                      type: string
                     issuer:
                       description: Issuer provides the IDP URL
                       type: string
@@ -3249,7 +3222,6 @@ spec:
                   - clientID
                   - clientScopes
                   - clientSecret
-                  - discoveryUrl
                   - issuer
                   - userClaims
                   type: object

--- a/pkg/server/authenticators.go
+++ b/pkg/server/authenticators.go
@@ -58,9 +58,9 @@ func makeAuthenticators(hubcc kore.Interface, config Config) error {
 				return headers.New(hubcc)
 			case "openid":
 				return openid.New(hubcc, openid.Config{
-					ClientID:     config.Kore.ClientID,
-					DiscoveryURL: config.Kore.DiscoveryURL,
-					UserClaims:   config.Kore.UserClaims,
+					ClientID:   config.Kore.ClientID,
+					ServerURL:  config.Kore.IDPServerURL,
+					UserClaims: config.Kore.UserClaims,
 				})
 			default:
 				return nil, errors.New("unknown plugin")

--- a/pkg/utils/openid/config.go
+++ b/pkg/utils/openid/config.go
@@ -22,8 +22,8 @@ func (c Config) IsValid() error {
 	if c.ClientID == "" {
 		return errors.New("no client id")
 	}
-	if c.DiscoveryURL == "" {
-		return errors.New("no discovery url")
+	if c.ServerURL == "" {
+		return errors.New("no server url")
 	}
 
 	return nil

--- a/pkg/utils/openid/discovery.go
+++ b/pkg/utils/openid/discovery.go
@@ -93,11 +93,11 @@ func (a *authImpl) Run(ctx context.Context) error {
 		for {
 			err := func() error {
 				log.WithFields(log.Fields{
-					"discovery-url": a.DiscoveryURL,
+					"server-url": a.ServerURL,
 				}).Info("attempting to retrieve provider details via discovery url")
 
 				// @step: attempt to retrieve the details for the discovery url
-				provider, err := oidc.NewProvider(ctx, a.DiscoveryURL)
+				provider, err := oidc.NewProvider(ctx, a.ServerURL)
 				if err != nil {
 					return err
 				}

--- a/pkg/utils/openid/types.go
+++ b/pkg/utils/openid/types.go
@@ -38,8 +38,8 @@ type Authenticator interface {
 type Config struct {
 	// ClientID is the client id
 	ClientID string
-	// DiscoveryURL is the openid discovery url
-	DiscoveryURL string
+	// ServerURL is the openid server url
+	ServerURL string
 	// SkipIDCheck indicates we skip checking the issuer
 	SkipClientIDCheck bool
 }


### PR DESCRIPTION
## What

I've renamed the "idp discovery url" parameters to "idp server url" as in reality we expect the server (issuer) url for this parameters or env vars.

You have to make sure you use exactly the same issuer URL as present on the discovery url endpoint. See https://github.com/appvia/kore/issues/318.

Relevant kore-ui PR: https://github.com/appvia/kore-ui/pull/82

### Additional changes

* I've also removed the unused OIDCIDP.DiscoveryURL field.
* I removed the stripping of `.well-known/openid-configuration` in the api-server as it can lead to confusing idp auth errors

### Local changes

If you have dev.env/demo.env locally, you have to replace KORE_DISCOVERY_URL with:

```
KORE_IDP_SERVER_URL=https://[YOUR AUTH0 DOMAIN]/
```

Also you should edit your `~/.korectl/config` and set the same value for `authorize-url`