### PR TITLE
Team Name Regex

### DIFF
--- a/pkg/kore/helpers.go
+++ b/pkg/kore/helpers.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/appvia/kore/pkg/kore/validation"
+
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
@@ -40,14 +42,20 @@ import (
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 func IsValidResourceName(name string) error {
 	if !ResourceNameFilter.MatchString(name) {
-		return fmt.Errorf("name must comply with %s", ResourceNameFilter.String())
-	}
-	if name == "" {
-		return errors.New("name cannot be empty")
+		return validation.NewErrValidation().WithFieldErrorf(
+			"name",
+			validation.Pattern,
+			"must comply with %s",
+			ResourceNameFilter.String(),
+		)
 	}
 
 	if len(name) > 63 {
-		return errors.New("name length must be less than 64 characters")
+		return validation.NewErrValidation().WithFieldError(
+			"name",
+			validation.MaxLength,
+			"length must be less than 64 characters",
+		)
 	}
 
 	return nil

--- a/pkg/kore/helpers.go
+++ b/pkg/kore/helpers.go
@@ -26,7 +26,6 @@ import (
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
 	"github.com/appvia/kore/pkg/kore/authentication"
 	"github.com/appvia/kore/pkg/utils"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +33,25 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// IsValidResourceName checks the resource name is valid
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+func IsValidResourceName(name string) error {
+	if !ResourceNameFilter.MatchString(name) {
+		return fmt.Errorf("name must comply with %s", ResourceNameFilter.String())
+	}
+	if name == "" {
+		return errors.New("name cannot be empty")
+	}
+
+	if len(name) > 63 {
+		return errors.New("name length must be less than 64 characters")
+	}
+
+	return nil
+}
 
 // TeamsToList returns an array of teams
 func TeamsToList(list *orgv1.TeamList) []string {

--- a/pkg/kore/helpers_test.go
+++ b/pkg/kore/helpers_test.go
@@ -17,12 +17,47 @@
 package kore
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/appvia/kore/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestIsValidResourceName(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Expect bool
+	}{
+		{Name: "", Expect: false},
+		{Name: "kore", Expect: true},
+		{Name: "kore-admin", Expect: true},
+		{Name: "1kore", Expect: false},
+		{Name: "kore1", Expect: true},
+		{Name: "kore_admin", Expect: false},
+		{Name: "-kore", Expect: false},
+		{Name: "kore-", Expect: false},
+		{Name: ".kore", Expect: false},
+		{Name: ".kore.", Expect: false},
+		{Name: "kore--admin", Expect: false},
+		{Name: "kore-admin-ok", Expect: true},
+		{Name: "kore-admin-ok1", Expect: true},
+		{Name: "1kore-admin-ok1", Expect: false},
+		{Name: "kore-admin-ok1111", Expect: true},
+		{Name: strings.ToLower(utils.Random(63)), Expect: true},
+		{Name: strings.ToLower(utils.Random(64)), Expect: false},
+	}
+	for i, c := range cases {
+		switch c.Expect {
+		case true:
+			assert.NoError(t, IsValidResourceName(c.Name), "case %d, value: %s should have passed", i, c.Name)
+		default:
+			assert.Error(t, IsValidResourceName(c.Name), "case %d, value: %s should have failed", i, c.Name)
+		}
+	}
+}
 
 func TestEmptyUser(t *testing.T) {
 	u := EmptyUser("test")

--- a/pkg/kore/teams.go
+++ b/pkg/kore/teams.go
@@ -149,7 +149,7 @@ func (t *teamsImpl) Update(ctx context.Context, team *orgv1.Team) (*orgv1.Team, 
 	// @step: teams are slightly different as they are being placed in both a database
 	// and a kubernetes. In order to ensure both instances comply with the naming conver
 	if err := IsValidResourceName(team.Name); err != nil {
-		return nil, fmt.Errorf("invalid team name, %s", err)
+		return nil, err
 	}
 
 	team.Namespace = HubNamespace

--- a/pkg/kore/teams.go
+++ b/pkg/kore/teams.go
@@ -18,7 +18,6 @@ package kore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -147,19 +146,20 @@ func (t *teamsImpl) Exists(ctx context.Context, name string) (bool, error) {
 
 // Update is responsible for updating the team
 func (t *teamsImpl) Update(ctx context.Context, team *orgv1.Team) (*orgv1.Team, error) {
-	// @step: check the team is ok
-	if team.Name == "" {
-		return nil, errors.New("no name for team defined")
+	// @step: teams are slightly different as they are being placed in both a database
+	// and a kubernetes. In order to ensure both instances comply with the naming conver
+	if err := IsValidResourceName(team.Name); err != nil {
+		return nil, fmt.Errorf("invalid team name, %s", err)
 	}
+
 	team.Namespace = HubNamespace
 
 	// @step: retrieve the user from context
 	user := authentication.MustGetIdentity(ctx)
 
 	logger := log.WithFields(log.Fields{
-		"team":  team.Name,
-		"teams": strings.Join(user.Teams(), ","),
-		"user":  user.Username(),
+		"team": team.Name,
+		"user": user.Username(),
 	})
 	logger.Info("attempting to update or create team in kore")
 

--- a/pkg/kore/types.go
+++ b/pkg/kore/types.go
@@ -18,6 +18,7 @@ package kore
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"github.com/appvia/kore/pkg/kore/authentication"
@@ -40,6 +41,9 @@ const (
 var (
 	// Client is the default client for the kore
 	Client Interface
+	// ResourceNameFilter is a filter that all team names MUST comply with
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	ResourceNameFilter = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
 )
 
 // Interface is the contrat between the api and store

--- a/pkg/kore/validation/err_validation.go
+++ b/pkg/kore/validation/err_validation.go
@@ -55,6 +55,16 @@ func (e *ErrValidation) WithFieldError(field string, errCode ErrorCode, message 
 	return e
 }
 
+// WithFieldErrorf adds an error for a specific field to a validation error.
+func (e *ErrValidation) WithFieldErrorf(field string, errCode ErrorCode, format string, args ...interface{}) *ErrValidation {
+	e.FieldErrors = append(e.FieldErrors, FieldError{
+		Field:   field,
+		ErrCode: errCode,
+		Message: fmt.Sprintf(format, args...),
+	})
+	return e
+}
+
 // FieldError provides information about a validation error on a specific field.
 type FieldError struct {
 	// Field causing the error, in format x.y.z
@@ -68,7 +78,12 @@ type FieldError struct {
 // ErrorCode is the type of validation error detected.
 type ErrorCode string
 
+// The error codes should match the validator names from JSON Schema
 const (
+	// MinLength error indicates the supplied value is shorted than the allowed minimum.
+	MinLength ErrorCode = "minLength"
 	// MaxLength error indicates the supplied value is longer than the allowed maximum.
 	MaxLength ErrorCode = "maxLength"
+	// Pattern error indicates the input doesn't match the required regex pattern
+	Pattern ErrorCode = "pattern"
 )


### PR DESCRIPTION
Teams are a little different in kore as they exist in both the database and k8s (for triggers). At the moment this leaves us open to the name being find in mysql but failing in k8s. This PR fixes the issue by ensuring the name complies with the k8s requirement (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names). At the moment we only need to apply it here and k8s will handle the other resources for us.