### PR TITLE
WhoAmI Command Rendering Fix

### DIFF
--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -292,6 +292,15 @@ func (c *Requestor) makeValues(in io.Reader, paths []string) ([]string, error) {
 			v = []byte("Unknown")
 		}
 
+		// @step: if this is an array, lets try and decode it
+		if strings.HasPrefix(string(v), "[") && strings.HasSuffix(string(v), "]") {
+			var values []string
+			if err := yaml.Unmarshal(v, &values); err == nil {
+				v = []byte(strings.Join(values, ","))
+			}
+		}
+
+		// @step: we need to remove the double quotes
 		list = append(list, strings.ReplaceAll(string(v), "\"", ""))
 	}
 

--- a/pkg/cmd/korectl/whoami.go
+++ b/pkg/cmd/korectl/whoami.go
@@ -16,8 +16,13 @@
 
 package korectl
 
-import "github.com/urfave/cli/v2"
+import (
+	"fmt"
 
+	"github.com/urfave/cli/v2"
+)
+
+// GetWhoamiCommand returns the whoami command
 func GetWhoamiCommand(config *Config) *cli.Command {
 	return &cli.Command{
 		Name:    "whoami",
@@ -25,7 +30,7 @@ func GetWhoamiCommand(config *Config) *cli.Command {
 		Usage:   "Used to retrieve details on your identity within the kore",
 
 		Action: func(ctx *cli.Context) error {
-			return NewRequest().
+			err := NewRequest().
 				WithConfig(config).
 				WithContext(ctx).
 				WithEndpoint("/whoami").
@@ -35,6 +40,12 @@ func GetWhoamiCommand(config *Config) *cli.Command {
 					Column("Teams", ".teams"),
 				).
 				Get()
+			if err != nil {
+				return err
+			}
+			fmt.Println("")
+
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
- fixing the rendering of the whoami command

The current implementation does not render the whoami command correctly. This is a bit of a hack as the jsonpath lib we using should probably hand us back the type rather than convert to a []byte{}.

```shell
Before:
[jest@starfury kore]$ korectl whoami
SLVE
Username                        Email                           Teams
rohith.jayawardene@appvia.io    rohith.jayawardene@appvia.io    [
  kore-admin,
  devs

After:
[jest@starfury kore]$ korectl whoami
Username                        Email                           Teams
rohith.jayawardene@appvia.io    rohith.jayawardene@appvia.io    kore-admin,devs
```