### PR TITLE
Fix deepcopy-gen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -10,7 +10,7 @@ if [[ -z "${HUB_APIS}" ]]; then
   exit 1
 fi
 
-/usr/bin/env bash vendor/k8s.io/code-generator/generate-groups.sh -- deepcopy  \
+/usr/bin/env bash vendor/k8s.io/code-generator/generate-groups.sh deepcopy  \
   github.com/appvia/kore/pkg/client \
   github.com/appvia/kore/pkg/apis \
   "${HUB_APIS}" \

--- a/pkg/apis/clusters/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusters/v1/zz_generated.deepcopy.go
@@ -130,6 +130,11 @@ func (in *KubernetesSpec) DeepCopyInto(out *KubernetesSpec) {
 		**out = **in
 	}
 	out.Provider = in.Provider
+	if in.ProxyAllowedIPs != nil {
+		in, out := &in.ProxyAllowedIPs, &out.ProxyAllowedIPs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/org/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/org/v1/zz_generated.deepcopy.go
@@ -89,6 +89,8 @@ func (in *AuditEventList) DeepCopyObject() runtime.Object {
 func (in *AuditEventSpec) DeepCopyInto(out *AuditEventSpec) {
 	*out = *in
 	in.CreatedAt.DeepCopyInto(&out.CreatedAt)
+	in.StartedAt.DeepCopyInto(&out.StartedAt)
+	in.CompletedAt.DeepCopyInto(&out.CompletedAt)
 	return
 }
 


### PR DESCRIPTION
# What

During the vendoring changes I broke `make deepcopy-gen` and it simply exits without errors.

I introduced the `--` parameter erroneously.

I've also included a couple of out-of-date generated files. ﻿
