### PR TITLE
Check whether `make apis` was run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,10 @@ jobs:
             KORE_UI_PUBLIC_URL: "http://localhost:3000"
             USERS_DB_URL: "root:pass@tcp(database:3306)/kore?parseTime=true"
       - run:
+          name: Checking generated API resources
+          command: |
+            make check-apis
+      - run:
           name: Checking swagger
           command: |
             make swagger-json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,43 @@ jobs:
 
     docker:
       - image: circleci/golang:1.13
+
+      - name: database
+        image: mariadb:bionic
+        environment:
+          MYSQL_ROOT_PASSWORD: pass
+        command:
+          sh -c "
+            echo 'CREATE DATABASE IF NOT EXISTS kore;' > /docker-entrypoint-initdb.d/init.sql;
+            /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
+
+    steps:
+      - checkout
+      - run:
+          name: Test
+          environment:
+            TEST_USERS_DATABASE_URL: "root:pass@tcp(database:3306)/kore?parseTime=true"
+          command: |
+            make test
+      - run:
+          name: Build
+          command: |
+            make build
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - auth-proxy
+            - kore-apiserver
+            - kore-clusterappman
+
+  check-apis:
+    environment:
+      USE_GIT_VERSION: "true"
+      GOFLAGS: "-mod=vendor"
+
+    docker:
+      - image: circleci/golang:1.13
+
       - name: etcd
         image: bitnami/etcd:latest
         environment:
@@ -53,14 +90,12 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Test & Build
-          environment:
-            TEST_USERS_DATABASE_URL: "root:pass@tcp(database:3306)/kore?parseTime=true"
+          name: Checking generated API resources
           command: |
-            make test
-            make build
+            make check-apis
       - run:
           command: |
+            make kore-apiserver
             bin/kore-apiserver --verbose
           background: true
           environment:
@@ -73,20 +108,10 @@ jobs:
             KORE_UI_PUBLIC_URL: "http://localhost:3000"
             USERS_DB_URL: "root:pass@tcp(database:3306)/kore?parseTime=true"
       - run:
-          name: Checking generated API resources
-          command: |
-            make check-apis
-      - run:
           name: Checking swagger
           command: |
             make swagger-json
             make swagger-validate
-      - persist_to_workspace:
-          root: bin
-          paths:
-            - auth-proxy
-            - kore-apiserver
-            - kore-clusterappman
 
   release:
     environment:
@@ -119,9 +144,14 @@ workflows:
           filters:
             tags:
               only: /^v.*$/
+      - check-apis:
+          filters:
+            tags:
+              only: /^v.*$/
       - release:
           requires:
             - build
+            - check-apis
           filters:
             branches:
               only: master

--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,13 @@ apis: golang
 	@${MAKE} crd-gen
 	@${MAKE} schema-gen
 
+check-apis: apis
+	@if [ $$(git status --porcelain | wc -l) -gt 0 ]; then \
+		echo "There are local changes after running 'make apis'. Did you forget to run it?"; \
+		git status --porcelain; \
+		exit 1; \
+	fi
+
 deepcopy-gen:
 	@echo "--> Generating the deepcopies"
 	@hack/update-codegen.sh

--- a/pkg/apis/config/v1/zz_generated_openapi.go
+++ b/pkg/apis/config/v1/zz_generated_openapi.go
@@ -417,6 +417,13 @@ func schema_pkg_apis_config_v1_SecretStatus(ref common.ReferenceCallback) common
 				Description: "SecretStatus defines the observed state of Plan",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"systemManaged": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SystemManaged indicates the secret is managed by kore and cannot be changed",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/pkg/kore/helpers_test.go
+++ b/pkg/kore/helpers_test.go
@@ -46,8 +46,8 @@ func TestIsValidResourceName(t *testing.T) {
 		{Name: "kore-admin-ok1", Expect: true},
 		{Name: "1kore-admin-ok1", Expect: false},
 		{Name: "kore-admin-ok1111", Expect: true},
-		{Name: strings.ToLower(utils.Random(63)), Expect: true},
-		{Name: strings.ToLower(utils.Random(64)), Expect: false},
+		{Name: "a" + strings.ToLower(utils.Random(62)), Expect: true},  // 63 characters
+		{Name: "a" + strings.ToLower(utils.Random(63)), Expect: false}, // 64 characters
 	}
 	for i, c := range cases {
 		switch c.Expect {

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -3090,6 +3090,10 @@ spec:
             status:
               description: Status is overall status of the workspace
               type: string
+            systemManaged:
+              description: SystemManaged indicates the secret is managed by kore and
+                cannot be changed
+              type: boolean
             verified:
               description: Verified indicates if the secret has been verified as working
               type: boolean


### PR DESCRIPTION
# What

We easily forget to run `make apis`, so I've added a check to CircleCI which runs it and checks whether there are any changed files.

I've added a separate job for running the check-apis test and the swagger validation, so we can run this in parallel with the tests.

Additional changes:
 * Updating outdated API resources
 * Fix an unstable test