### PR TITLE
Auto Generated Resources 

### DIFF
--- a/cmd/korectl/options/options.go
+++ b/cmd/korectl/options/options.go
@@ -41,9 +41,9 @@ func Options() []cli.Flag {
 			Value:   "yaml",
 		},
 		&cli.BoolFlag{
-			Name:  "wait",
-			Usage: "if we should wait for the resource to provision (defaults: true) `BOOL`",
-			Value: true,
+			Name:  "no-wait",
+			Usage: "if we should wait for the resource to provision (default: false) `BOOL`",
+			Value: false,
 		},
 	}
 }

--- a/cmd/korectl/options/options.go
+++ b/cmd/korectl/options/options.go
@@ -40,5 +40,10 @@ func Options() []cli.Flag {
 			Usage:   "The output format of the resource `FORMAT`",
 			Value:   "yaml",
 		},
+		&cli.BoolFlag{
+			Name:  "wait",
+			Usage: "if we should wait for the resource to provision (defaults: true) `BOOL`",
+			Value: true,
+		},
 	}
 }

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -217,6 +217,8 @@ func (a *App) getSubCommand(name string, parent *cli.Command) (*cli.Command, boo
 }
 
 func (a *App) getGlobalFlag(name string) (cli.Flag, bool) {
+	name = strings.Split(name, "=")[0]
+
 	for _, flag := range a.app.Flags {
 		if utils.Contains(name, flag.Names()) {
 			return flag, true

--- a/pkg/cmd/korectl/create_allocation.go
+++ b/pkg/cmd/korectl/create_allocation.go
@@ -17,6 +17,7 @@
 package korectl
 
 import (
+	"context"
 	"fmt"
 
 	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
@@ -107,6 +108,7 @@ func GetCreateAllocation(config *Config) *cli.Command {
 			resource := ctx.String("resource")
 			teams := ctx.StringSlice("to")
 			version := ctx.String("version")
+			wait := ctx.Bool("wait")
 
 			found, err := TeamResourceExists(config, team, "allocation", name)
 			if err != nil {
@@ -138,9 +140,8 @@ func GetCreateAllocation(config *Config) *cli.Command {
 			if err := CreateTeamResource(config, team, "allocation", name, o); err != nil {
 				return err
 			}
-			fmt.Printf("%q has been successfully created\n", name)
 
-			return nil
+			return WaitForResourceCheck(context.Background(), config, team, kind, name, wait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/create_allocation.go
+++ b/pkg/cmd/korectl/create_allocation.go
@@ -108,7 +108,7 @@ func GetCreateAllocation(config *Config) *cli.Command {
 			resource := ctx.String("resource")
 			teams := ctx.StringSlice("to")
 			version := ctx.String("version")
-			wait := ctx.Bool("wait")
+			nowait := ctx.Bool("no-wait")
 
 			found, err := TeamResourceExists(config, team, "allocation", name)
 			if err != nil {
@@ -141,7 +141,7 @@ func GetCreateAllocation(config *Config) *cli.Command {
 				return err
 			}
 
-			return WaitForResourceCheck(context.Background(), config, team, kind, name, wait)
+			return WaitForResourceCheck(context.Background(), config, team, kind, name, nowait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/create_cluster.go
+++ b/pkg/cmd/korectl/create_cluster.go
@@ -135,7 +135,7 @@ func GetCreateClusterCommand(config *Config) *cli.Command {
 			plan := ctx.String("plan")
 			role := ctx.String("team-role")
 			team := ctx.String("team")
-			wait := ctx.Bool("wait")
+			wait := ctx.Bool("no-wait")
 
 			if team == "" {
 				return errTeamParameterMissing

--- a/pkg/cmd/korectl/create_gcp_organization.go
+++ b/pkg/cmd/korectl/create_gcp_organization.go
@@ -17,6 +17,7 @@
 package korectl
 
 import (
+	"context"
 	"fmt"
 
 	gcp "github.com/appvia/kore/pkg/apis/gcp/v1alpha1"
@@ -124,6 +125,7 @@ func GetCreateGCPOrganization(config *Config) *cli.Command {
 			kind := "organization"
 			cname := ctx.String("credentials")
 			cnamespace := ctx.String("credentials-team")
+			wait := ctx.Bool("wait")
 
 			found, err := TeamResourceExists(config, team, kind, name)
 			if err != nil {
@@ -139,9 +141,9 @@ func GetCreateGCPOrganization(config *Config) *cli.Command {
 					Namespace: team,
 				},
 				Spec: gcp.OrganizationSpec{
-					ParentType:     ctx.String("parent-type"),
-					ParentID:       ctx.String("parent-id"),
 					BillingAccount: ctx.String("billing-account-id"),
+					ParentID:       ctx.String("parent-id"),
+					ParentType:     ctx.String("parent-type"),
 					ServiceAccount: ctx.String("service-account-name"),
 					CredentialsRef: &v1.SecretReference{
 						Name:      cname,
@@ -153,9 +155,8 @@ func GetCreateGCPOrganization(config *Config) *cli.Command {
 			if err := CreateTeamResource(config, team, kind, name, o); err != nil {
 				return err
 			}
-			fmt.Printf("%q has been successfully created\n", name)
 
-			return nil
+			return WaitForResourceCheck(context.Background(), config, team, kind, name, wait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/create_gcp_organization.go
+++ b/pkg/cmd/korectl/create_gcp_organization.go
@@ -125,7 +125,7 @@ func GetCreateGCPOrganization(config *Config) *cli.Command {
 			kind := "organization"
 			cname := ctx.String("credentials")
 			cnamespace := ctx.String("credentials-team")
-			wait := ctx.Bool("wait")
+			nowait := ctx.Bool("no-wait")
 
 			found, err := TeamResourceExists(config, team, kind, name)
 			if err != nil {
@@ -156,7 +156,7 @@ func GetCreateGCPOrganization(config *Config) *cli.Command {
 				return err
 			}
 
-			return WaitForResourceCheck(context.Background(), config, team, kind, name, wait)
+			return WaitForResourceCheck(context.Background(), config, team, kind, name, nowait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/create_gcp_projectclaim.go
+++ b/pkg/cmd/korectl/create_gcp_projectclaim.go
@@ -78,7 +78,7 @@ func GetCreateGCPProject(config *Config) *cli.Command {
 			name := ctx.Args().First()
 			kind := "projectclaim"
 			org := ctx.String("organization")
-			wait := ctx.Bool("wait")
+			wait := ctx.Bool("no-wait")
 
 			found, err := TeamResourceExists(config, team, kind, name)
 			if err != nil {

--- a/pkg/cmd/korectl/create_member.go
+++ b/pkg/cmd/korectl/create_member.go
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package korectl
+
+import (
+	"fmt"
+
+	"github.com/manifoldco/promptui"
+	"github.com/urfave/cli/v2"
+)
+
+// GetCreateTeamMemberCommand returns the create member command
+func GetCreateTeamMemberCommand(config *Config) *cli.Command {
+	return &cli.Command{
+		Name:    "member",
+		Aliases: []string{"members"},
+		Usage:   "Creates a new team member",
+
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "user",
+				Aliases:  []string{"u"},
+				Usage:    "The username of the user you wish to add to the team",
+				Required: true,
+			},
+			&cli.BoolFlag{
+				Name:     "invite",
+				Aliases:  []string{"i"},
+				Usage:    "If the user doesn't exist and the invite flag is set, the invite url will be automatically generated.",
+				Required: false,
+			},
+		},
+
+		Action: func(ctx *cli.Context) error {
+			invite := ctx.Bool("invite")
+			team := ctx.String("team")
+			username := ctx.String("user")
+
+			if team == "" {
+				return errTeamParameterMissing
+			}
+
+			// @step: check the team exist
+			found, err := ResourceExists(config, "team", team)
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("team %q does not exist", team)
+			}
+
+			// @step: check the user exist
+			found, err = ResourceExists(config, "user", username)
+			if err != nil {
+				return err
+			}
+			if !found {
+				if !invite {
+					prompt := promptui.Prompt{
+						Label:     "The user does not exist. Do you want to create an invite link",
+						IsConfirm: true,
+						Default:   "Y",
+					}
+
+					// Prompt will return an error if the input is not y/Y
+					if _, err := prompt.Run(); err != nil {
+						return nil
+					}
+				}
+
+				var inviteURL string
+				err := NewRequest().
+					WithConfig(config).
+					WithContext(ctx).
+					WithEndpoint("/teams/{team}/invites/generate/{user}").
+					PathParameter("team", true).
+					WithInject("team", team).
+					PathParameter("user", true).
+					WithRuntimeObject(&inviteURL).
+					Get()
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Invite URL: %s\n", inviteURL)
+				return nil
+			}
+
+			err = NewRequest().
+				WithConfig(config).
+				WithContext(ctx).
+				WithEndpoint("/teams/{team}/members/{user}").
+				PathParameter("team", true).
+				PathParameter("user", true).
+				Update()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%q has been successfully added to team %q\n", ctx.String("user"), ctx.String("team"))
+
+			return nil
+		},
+	}
+}

--- a/pkg/cmd/korectl/create_namespace.go
+++ b/pkg/cmd/korectl/create_namespace.go
@@ -17,6 +17,7 @@
 package korectl
 
 import (
+	"context"
 	"fmt"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
@@ -76,8 +77,10 @@ func GetCreateNamespaceCommand(config *Config) *cli.Command {
 		Action: func(ctx *cli.Context) error {
 			name := ctx.Args().First()
 			cluster := ctx.String("cluster")
-			team := ctx.String("team")
 			dry := ctx.Bool("dry-run")
+			kind := "namespaceclaim"
+			team := ctx.String("team")
+			wait := ctx.Bool("wait")
 
 			// @step: evaluate the options
 			if team == "" {
@@ -105,9 +108,8 @@ func GetCreateNamespaceCommand(config *Config) *cli.Command {
 			if err := CreateClusterNamespace(config, owner, team, name, dry); err != nil {
 				return fmt.Errorf("trying to provision namespace on cluster: %s", err)
 			}
-			fmt.Println("Namespace provisioning on the cluster, you can check via: $ korectl get namespaceclaims -t", team)
 
-			return nil
+			return WaitForResourceCheck(context.Background(), config, team, kind, name, wait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/create_namespace.go
+++ b/pkg/cmd/korectl/create_namespace.go
@@ -80,7 +80,7 @@ func GetCreateNamespaceCommand(config *Config) *cli.Command {
 			dry := ctx.Bool("dry-run")
 			kind := "namespaceclaim"
 			team := ctx.String("team")
-			wait := ctx.Bool("wait")
+			nowait := ctx.Bool("no-wait")
 
 			// @step: evaluate the options
 			if team == "" {
@@ -109,7 +109,7 @@ func GetCreateNamespaceCommand(config *Config) *cli.Command {
 				return fmt.Errorf("trying to provision namespace on cluster: %s", err)
 			}
 
-			return WaitForResourceCheck(context.Background(), config, team, kind, name, wait)
+			return WaitForResourceCheck(context.Background(), config, team, kind, name, nowait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/create_team.go
+++ b/pkg/cmd/korectl/create_team.go
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package korectl
+
+import (
+	"fmt"
+
+	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
+
+	"github.com/urfave/cli/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetCreateTeamCommand returns the create team command
+func GetCreateTeamCommand(config *Config) *cli.Command {
+	return &cli.Command{
+		Name:      "team",
+		Aliases:   []string{"teams"},
+		Usage:     "Creates a team",
+		ArgsUsage: "TEAM",
+
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "description",
+				Usage:    "The description of the team",
+				Required: false,
+			},
+		},
+
+		Before: func(ctx *cli.Context) error {
+			if !ctx.Args().Present() {
+				return fmt.Errorf("the team should have a name")
+			}
+
+			return nil
+		},
+
+		Action: func(ctx *cli.Context) error {
+			name := ctx.Args().First()
+			description := ctx.String("description")
+			kind := "team"
+			wait := ctx.Bool("wait")
+
+			// @step: check if the resource exist already
+			if found, err := ResourceExists(config, kind, name); err != nil {
+				return err
+			} else if found {
+				return fmt.Errorf("%q already exists, please edit instead", name)
+			}
+
+			// @step: create the resource from options
+			team := &orgv1.Team{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Team",
+					APIVersion: orgv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: orgv1.TeamSpec{
+					Summary:     name,
+					Description: description,
+				},
+			}
+
+			if err := CreateResource(config, kind, name, team); err != nil {
+				return err
+			}
+
+			return WaitForResourceCheck(ctx.Context, config, "", kind, name, wait)
+		},
+	}
+}

--- a/pkg/cmd/korectl/create_team.go
+++ b/pkg/cmd/korectl/create_team.go
@@ -77,7 +77,13 @@ func GetCreateTeamCommand(config *Config) *cli.Command {
 				},
 			}
 
-			if err := CreateResource(config, kind, name, team); err != nil {
+			req, _, err := NewRequestForResource(config, "", kind, name)
+			if err != nil {
+				return err
+			}
+			req.WithRuntimeObject(team)
+
+			if err := req.Update(); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/korectl/create_team.go
+++ b/pkg/cmd/korectl/create_team.go
@@ -53,7 +53,7 @@ func GetCreateTeamCommand(config *Config) *cli.Command {
 			name := ctx.Args().First()
 			description := ctx.String("description")
 			kind := "team"
-			wait := ctx.Bool("wait")
+			nowait := ctx.Bool("no-wait")
 
 			// @step: check if the resource exist already
 			if found, err := ResourceExists(config, kind, name); err != nil {
@@ -87,7 +87,7 @@ func GetCreateTeamCommand(config *Config) *cli.Command {
 				return err
 			}
 
-			return WaitForResourceCheck(ctx.Context, config, "", kind, name, wait)
+			return WaitForResourceCheck(ctx.Context, config, "", kind, name, nowait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/get.go
+++ b/pkg/cmd/korectl/get.go
@@ -44,7 +44,7 @@ func GetGetCommand(config *Config) *cli.Command {
 	var commands []*cli.Command
 
 	for k, v := range resourceConfigs {
-		usage := "retrieve the " + k + "resource from kore"
+		usage := "retrieve the " + k + " resource from kore"
 		if v.IsGlobal {
 			usage = "retrieve the global resource " + k + " from kore"
 		}

--- a/pkg/cmd/korectl/get.go
+++ b/pkg/cmd/korectl/get.go
@@ -27,11 +27,11 @@ var getLongDescription = `
 The object type accepts both singular and plural nouns (e.g. "user" and "users").
 
 Examples:
-  List users:
-  $ korectl get users
+List users:
+$ korectl get users
 
-  Get information about a specific user:
-  $ korectl get user admin -o yaml
+Get information about a specific user:
+$ korectl get user admin -o yaml
 `
 
 // GetGetCommand returns the auto-generated resources
@@ -44,9 +44,9 @@ func GetGetCommand(config *Config) *cli.Command {
 	var commands []*cli.Command
 
 	for k, v := range resourceConfigs {
-		usage := "retrieve the " + k + " resource from kore"
+		usage := "retrieve the " + k + " resource"
 		if v.IsGlobal {
-			usage = "retrieve the global resource " + k + " from kore"
+			usage = "retrieve the global resource " + k
 		}
 
 		command := &cli.Command{
@@ -60,12 +60,9 @@ func GetGetCommand(config *Config) *cli.Command {
 				resource := getResourceConfig(ctx.Command.Name)
 
 				// @step: determine the resource request type
-				var request *Requestor
-
-				if resource.IsGlobal {
-					request = NewGlobalRequest(config, resource.Name, name)
-				} else {
-					request = NewTeamRequest(config, team, resource.Name, name)
+				request, _, err := NewRequestForResource(config, team, resource.Name, name)
+				if err != nil {
+					return err
 				}
 				request = request.Render(resource.Columns...).WithContext(ctx)
 

--- a/pkg/cmd/korectl/get.go
+++ b/pkg/cmd/korectl/get.go
@@ -34,41 +34,69 @@ Examples:
   $ korectl get user admin -o yaml
 `
 
+// GetGetCommand returns the auto-generated resources
 func GetGetCommand(config *Config) *cli.Command {
+	// @note: the moment the user need to 'know' the name of all resource
+	// types for them to retrieve from the API. Ideally this would be retrieved
+	// from the API (later to come) but for now to complete the story we need
+	// a means to these to autocomplete on the CLI to make it apparent.
+
+	var commands []*cli.Command
+
+	for k, v := range resourceConfigs {
+		usage := "retrieve the " + k + "resource from kore"
+		if v.IsGlobal {
+			usage = "retrieve the global resource " + k + " from kore"
+		}
+
+		command := &cli.Command{
+			Name:    k,
+			Aliases: []string{v.Name},
+			Usage:   usage,
+
+			Action: func(ctx *cli.Context) error {
+				team := ctx.String("team")
+				name := ctx.Args().First()
+				resource := getResourceConfig(ctx.Command.Name)
+
+				// @step: determine the resource request type
+				var request *Requestor
+
+				if resource.IsGlobal {
+					request = NewGlobalRequest(config, resource.Name, name)
+				} else {
+					request = NewTeamRequest(config, team, resource.Name, name)
+				}
+				request = request.Render(resource.Columns...).WithContext(ctx)
+
+				// @step: make the request to the api
+				if err := request.Get(); err != nil {
+					if reqErr, ok := err.(*RequestError); ok {
+						if reqErr.statusCode == http.StatusNotFound {
+							if ctx.NArg() == 1 {
+								return fmt.Errorf("%q is not a valid resource type", ctx.Args().Get(0))
+							}
+
+							return fmt.Errorf("%q does not exist", ctx.Args().Get(1))
+						}
+					}
+
+					return err
+				}
+				fmt.Println("")
+
+				return nil
+			},
+		}
+
+		commands = append(commands, command)
+	}
+
 	return &cli.Command{
 		Name:        "get",
 		Usage:       "Retrieves one or more resources from the api",
 		Description: formatLongDescription(getLongDescription),
 		ArgsUsage:   "[TYPE] [NAME]",
-		Flags:       DefaultOptions,
-
-		Action: func(ctx *cli.Context) error {
-			if !ctx.Args().Present() {
-				_ = cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("[TYPE] or [TYPE] [NAME] is required")
-			}
-			req, resourceConfig, err := NewCLIRequestForResource(config, ctx)
-			if err != nil {
-				return err
-			}
-
-			req.Render(resourceConfig.Columns...)
-
-			if err := req.Get(); err != nil {
-				if reqErr, ok := err.(*RequestError); ok {
-					if reqErr.statusCode == http.StatusNotFound {
-						if ctx.NArg() == 1 {
-							return fmt.Errorf("%q is not a valid resource type", ctx.Args().Get(0))
-						} else {
-							return fmt.Errorf("%q does not exist", ctx.Args().Get(1))
-						}
-					}
-				}
-				return err
-			}
-			fmt.Println("")
-
-			return nil
-		},
+		Subcommands: commands,
 	}
 }

--- a/pkg/cmd/korectl/helper.go
+++ b/pkg/cmd/korectl/helper.go
@@ -178,9 +178,11 @@ func GetResourceList(config *Config, team, kind, name string, object runtime.Obj
 }
 
 // WaitForResourceCheck is just a wrap to check if we are waiting
-func WaitForResourceCheck(ctx context.Context, config *Config, team, kind, name string, wait bool) error {
-	if !wait {
+func WaitForResourceCheck(ctx context.Context, config *Config, team, kind, name string, nowait bool) error {
+	if nowait {
 		fmt.Printf("Resource %q has been successfully requested\n", name)
+
+		return nil
 	}
 
 	return WaitForResource(ctx, config, team, kind, name)

--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -384,7 +384,6 @@ func (c *Requestor) doRequest(method, url string, handler func(*http.Response) e
 	var err error
 
 	if c.runtimeObj != nil {
-		fmt.Println("DECODING")
 		encoded, err := json.Marshal(c.runtimeObj)
 		if err != nil {
 			return err

--- a/pkg/cmd/korectl/requestor.go
+++ b/pkg/cmd/korectl/requestor.go
@@ -216,10 +216,7 @@ func (c *Requestor) Delete() error {
 }
 
 func (c *Requestor) parseObjectResponse(resp *http.Response) error {
-	if err := json.NewDecoder(resp.Body).Decode(c.runtimeObj); err != nil {
-		return err
-	}
-	return nil
+	return json.NewDecoder(resp.Body).Decode(c.runtimeObj)
 }
 
 func (c *Requestor) parseResponse(resp *http.Response) error {
@@ -387,6 +384,7 @@ func (c *Requestor) doRequest(method, url string, handler func(*http.Response) e
 	var err error
 
 	if c.runtimeObj != nil {
+		fmt.Println("DECODING")
 		encoded, err := json.Marshal(c.runtimeObj)
 		if err != nil {
 			return err
@@ -474,8 +472,6 @@ func (c *Requestor) makeURI() (string, error) {
 		list = append(list, fmt.Sprintf("%s=%v", k, v))
 	}
 	url := fmt.Sprintf("%s/%s?%s", c.config.GetAPI(), uri, strings.Join(list, "&"))
-
-	log.WithField("url", url).Debug("making request to kore apiserver")
 
 	return url, nil
 }

--- a/pkg/cmd/korectl/resource.go
+++ b/pkg/cmd/korectl/resource.go
@@ -146,6 +146,7 @@ var resourceConfigs = map[string]resourceConfig{
 			Column("Type", "spec.type"),
 			Column("Description", "spec.description"),
 			Column("Verified", "status.verified"),
+			Column("Status", "status.status"),
 		},
 	},
 	"team": {
@@ -154,6 +155,7 @@ var resourceConfigs = map[string]resourceConfig{
 		Columns: []string{
 			Column("Name", "metadata.name"),
 			Column("Description", "spec.description"),
+			Column("Status", "status.status"),
 		},
 	},
 	"user": {

--- a/pkg/cmd/korectl/resource.go
+++ b/pkg/cmd/korectl/resource.go
@@ -85,6 +85,16 @@ var resourceConfigs = map[string]resourceConfig{
 			Column("Status", "status.status"),
 		},
 	},
+	"gkecredential": {
+		Name:   "gkecredentials",
+		IsTeam: true,
+		Columns: []string{
+			Column("Name", "metadata.name"),
+			Column("Project", "spec.project"),
+			Column("Status", "status.status"),
+			Column("Verified", "status.verified"),
+		},
+	},
 	"member": {
 		Name:   "members",
 		IsTeam: true,


### PR DESCRIPTION
At the moment the user (admin or developer) needs to know the name of the resource to retrieve it, which isn't the best user experience. Long term this needs to be in the API but for now we can auto generate them from the resourceConfigs. This is related to https://github.com/appvia/kore/issues/221 and the documentation for the CLI

Note PR https://github.com/appvia/kore/pull/386 should be merged first. The two extra commits on top of this are;

98392a8a Auto Generating the Resources
ebf425a2 - fixing the title for the resource

```shell
[jest@starfury kore]$ korectl get 
NAME:
   korectl get - Retrieves one or more resources from the api

USAGE:
   korectl get [command options] [TYPE] [NAME]

DESCRIPTION:
   The object type accepts both singular and plural nouns (e.g. "user" and "users").
   
   Examples:
     List users:
     $ korectl get users
   
     Get information about a specific user:
     $ korectl get user admin -o yaml

COMMANDS:
   member, members                  retrieve the member resource from kore
   namespaceclaim, namespaceclaims  retrieve the namespaceclaim resource from kore
   secret, secrets                  retrieve the secret resource from kore
   allocation, allocations          retrieve the allocation resource from kore
   cluster, clusters                retrieve the cluster resource from kore
   gkecredential, gkecredentials    retrieve the gkecredential resource from kore
   organization, organizations      retrieve the organization resource from kore
   projectclaim, projectclaims      retrieve the projectclaim resource from kore
   team, teams                      retrieve the global resource team from kore
   user, users                      retrieve the global resource user from kore
   audit-event, audit               retrieve the global resource audit-event from kore
   gke, gkes                        retrieve the gke resource from kore
   plan, plans                      retrieve the global resource plan from kore
   help, h                          Shows a list of commands or help for one command
```

Could probably add a description to the resource to make the usage a little easier to read