### PR TITLE
Replace `korectl cli auth`

### DIFF
--- a/doc/alpha-local-quick-start.md
+++ b/doc/alpha-local-quick-start.md
@@ -246,7 +246,8 @@ bin/korectl create cluster appvia-trial -t team-appvia --plan gke-development -a
 # Cluster appvia-sdbox has been successfully provisioned
 # --> Attempting to create namespace: sandbox
 
-# You can retrieve your kubeconfig via: $ korectl clusters auth -t team-appvia
+# You can update your kubeconfig via: $ korectl kubeconfig -t team-appvia 
+# Then use 'kubectl' to interact with your team's cluster
 ```
 
 There's a lot to unpack here. So, lets walk through it,
@@ -272,8 +273,10 @@ We'll be using `kubectl`, the Kubernetes CLI, to make the deployment. If you don
 Now we have to configure our `kubectl` kubeconfig in ~/.kube/config with our new GKE cluster.
 
 ```shell script
-bin/korectl clusters auth -t team-appvia
-# Successfully updated your kubeconfig with credentials
+bin/korectl kubeconfig -t team-appvia
+# Successfully added team [team-appvia] provisioned clusters to your kubeconfig
+# Context        Cluster              
+# appvia-trial   appvia-trial
 ```
 
 Switch the current `kubectl` context to `appvia-trial`,

--- a/pkg/cmd/korectl/clusters.go
+++ b/pkg/cmd/korectl/clusters.go
@@ -17,10 +17,6 @@
 package korectl
 
 import (
-	"fmt"
-
-	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -30,43 +26,6 @@ func GetClustersCommand(config *Config) *cli.Command {
 		Aliases: []string{"cls"},
 		Usage:   "Used to manage and interact with clusters provisioned by the kore",
 		Subcommands: []*cli.Command{
-			{
-				Name:  "auth",
-				Usage: "Used to retrieve the API endpoints of the clusters and provision your kubeconfig",
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:    "name",
-						Aliases: []string{"n"},
-						Usage:   "The name of the integration to retrieve `NAME`",
-					},
-				},
-				Action: func(ctx *cli.Context) error {
-					clusters := &clustersv1.KubernetesList{}
-					team := ctx.String("team")
-
-					if err := GetTeamResourceList(config, team, "clusters", clusters); err != nil {
-						return err
-					}
-
-					if len(clusters.Items) <= 0 {
-						fmt.Println("no clusters found in this team's namespace")
-
-						return nil
-					}
-
-					kubeconfig, err := GetOrCreateKubeConfig()
-					if err != nil {
-						return err
-					}
-
-					if err := PopulateKubeconfig(clusters, kubeconfig, config); err != nil {
-						return err
-					}
-					fmt.Println("Successfully updated your kubeconfig with credentials")
-
-					return nil
-				},
-			},
 			{
 				Name:  "get",
 				Usage: "Used to retrieve one or all clusters from the kore",

--- a/pkg/cmd/korectl/commands.go
+++ b/pkg/cmd/korectl/commands.go
@@ -35,5 +35,6 @@ func GetCommands(config *Config) []*cli.Command {
 		GetClustersCommand(config),
 		GetGetCommand(config),
 		GetWhoamiCommand(config),
+		GetKubeconfigCommand(config),
 	}
 }

--- a/pkg/cmd/korectl/create_cluster.go
+++ b/pkg/cmd/korectl/create_cluster.go
@@ -62,10 +62,10 @@ $ korectl -t <myteam> create cluster dev --plan gke-development -a <name> --name
 # Check the status of the cluster
 $ korectl -t <myteam> get cluster dev -o yaml
 
-Once you have created the cluster you can login via
-$ korectl clusters auth -t <myteam>
+	Now update your kubeconfig to use your team's provisioned cluster.
+	$ korectl kubeconfig -t <myteam>
 
-This will generate your ${HOME}/.kube/config for you with the clusters from team.
+This will modify your ${HOME}/.kube/config. Now you can use 'kubectl' to interact with your team's cluster.
 `
 )
 
@@ -251,7 +251,7 @@ func GetCreateClusterCommand(config *Config) *cli.Command {
 			}
 
 			// @step: print a the message
-			fmt.Printf("\nYou can retrieve your kubeconfig via: $ korectl clusters auth -t %s\n", team)
+			fmt.Printf("\nYou can retrieve your kubeconfig via: $ korectl kubeconfig -t %s\n", team)
 
 			return nil
 		},

--- a/pkg/cmd/korectl/kubeconfig.go
+++ b/pkg/cmd/korectl/kubeconfig.go
@@ -19,6 +19,7 @@ package korectl
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 
@@ -27,6 +28,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 )
+
+var kubeconfigUser = "kore"
 
 func GetKubeconfigCommand(config *Config) *cli.Command {
 	return &cli.Command{
@@ -54,7 +57,7 @@ func DoKubeconfig(config *Config, team string) error {
 	}
 
 	if len(clusters.Items) <= 0 {
-		fmt.Println("no clusters found in this team's namespace")
+		fmt.Println("No clusters found in this team's namespace")
 		return nil
 	}
 
@@ -63,17 +66,15 @@ func DoKubeconfig(config *Config, team string) error {
 		return err
 	}
 
-	if err := PopulateKubeconfig(clusters, kubeconfig, config); err != nil {
+	if err := WriteKubeconfig(clusters, kubeconfig, config); err != nil {
 		return err
 	}
 
-	fmt.Println("Successfully updated your kubeconfig with credentials")
-
-	return nil
+	return newKubeconfigResultPrinter(team, clusters).Print(os.Stdout)
 }
 
-// Populate kubeconfig is used to populate the users kubeconfig
-func PopulateKubeconfig(clusters *clustersv1.KubernetesList, kubeconfig string, config *Config) error {
+// WriteKubeconfig writes kubeconfig to the user's kubeconfig
+func WriteKubeconfig(clusters *clustersv1.KubernetesList, kubeconfig string, config *Config) error {
 	cfg, err := clientcmd.LoadFromFile(kubeconfig)
 	if err != nil {
 		return err
@@ -83,7 +84,7 @@ func PopulateKubeconfig(clusters *clustersv1.KubernetesList, kubeconfig string, 
 		return errors.New("you must be using a context backed by an idp")
 	}
 
-	cfg.AuthInfos["kore"] = &api.AuthInfo{
+	cfg.AuthInfos[kubeconfigUser] = &api.AuthInfo{
 		AuthProvider: &api.AuthProviderConfig{
 			Name: "oidc",
 			Config: map[string]string{
@@ -99,7 +100,8 @@ func PopulateKubeconfig(clusters *clustersv1.KubernetesList, kubeconfig string, 
 
 	for _, x := range clusters.Items {
 		if x.Status.Endpoint == "" {
-			fmt.Printf("skipping cluster: %s as it does not have an endpoint yet\n", x.Name)
+			fmt.Printf("SKIPPING CLUSTER: %s as it does not have an endpoint yet\n", x.Name)
+			continue
 		}
 		// @step: add the endpoint
 		cfg.Clusters[x.Name] = &api.Cluster{
@@ -110,11 +112,38 @@ func PopulateKubeconfig(clusters *clustersv1.KubernetesList, kubeconfig string, 
 		// @step: add the context
 		if _, found := cfg.Contexts[x.Name]; !found {
 			cfg.Contexts[x.Name] = &api.Context{
-				AuthInfo: "kore",
+				AuthInfo: kubeconfigUser,
 				Cluster:  x.Name,
 			}
 		}
 	}
 
 	return clientcmd.WriteToFile(*cfg, kubeconfig)
+}
+
+func newKubeconfigResultPrinter(team string, clusters *clustersv1.KubernetesList) printer {
+	var (
+		header  string
+		columns = []string{"Context", "Cluster"}
+		lines   [][]string
+	)
+
+	for _, item := range clusters.Items {
+		if len(item.Status.Endpoint) < 1 {
+			continue
+		}
+		lines = append(lines, []string{item.Name, item.Name})
+	}
+
+	if len(lines) < 1 {
+		header = fmt.Sprintf("Successfully added the [%s] user to your kubeconfig", kubeconfigUser)
+	} else {
+		header = fmt.Sprintf("Successfully added team [%s] provisioned clusters to your kubeconfig", team)
+	}
+
+	return table{
+		header,
+		columns,
+		lines,
+	}
 }

--- a/pkg/cmd/korectl/print.go
+++ b/pkg/cmd/korectl/print.go
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2020 Appvia Ltd <info@appvia.io>
+ *
+ * This file is part of kore.
+ *
+ * kore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * kore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with kore.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package korectl
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/juju/ansiterm/tabwriter"
+)
+
+type printer interface {
+	Print(output io.Writer) error
+}
+
+type table struct {
+	header  string
+	columns []string
+	lines   [][]string
+}
+
+func (t table) Print(output io.Writer) error {
+	if _, err := fmt.Printf("%s\n", t.header); err != nil {
+		return err
+	}
+
+	w := new(tabwriter.Writer)
+	w.Init(output, 0, 10, 4, ' ', 0)
+
+	if _, err := fmt.Fprintf(w, "%s\n", strings.Join(t.columns, "\t")); err != nil {
+		return err
+	}
+
+	for _, line := range t.lines {
+		if _, err := fmt.Fprintf(w, "%s\n", strings.Join(line, "\t")); err != nil {
+			return err
+		}
+	}
+
+	return w.Flush()
+}

--- a/pkg/cmd/korectl/print.go
+++ b/pkg/cmd/korectl/print.go
@@ -1,20 +1,17 @@
 /**
- * Copyright (C) 2020 Appvia Ltd <info@appvia.io>
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
  *
- * This file is part of kore.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * kore is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * kore is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with kore.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package korectl


### PR DESCRIPTION
This resolves https://github.com/appvia/kore/issues/296.

We replace `korectl cli auth -t <a-team>` with `korectl kubeconfig -t <a-team>`.

The highlights,
- **Bug fix**: ensures only clusters with an Endpoint are added kubeconfig.
- Highlights `kubeconfig` modification results.
- Updates inline CLI documentation to include new `korectl kubeconfig...` command.
- Updates quick start to use new `korectl kubeconfig...` command.
- Decouples CLI code from actual action to aid any future CLI migration.

In action,

**Cluster, with endpoint available**

```shell script
bin/korectl kubeconfig -t team-appvia
# Successfully added team [team-appvia] provisioned clusters to your kubeconfig
# Context        Cluster              
# appvia-trial   appvia-trial
```

**Cluster, with NO endpoint available**

```shell script
bin/korectl kubeconfig -t team-appvia
# SKIPPING CLUSTER: appvia-trial as it does not have an endpoint yet
# Successfully added the [kore] user to your kubeconfig
# Context        Cluster              
```