### PR TITLE
Add kubernetes resource config, clean up custom path override logic

### DIFF
--- a/pkg/cmd/korectl/helper.go
+++ b/pkg/cmd/korectl/helper.go
@@ -268,17 +268,7 @@ func ParseDocument(src io.Reader, namespace string) ([]*Document, error) {
 			return nil, errors.New("resource requires an api group")
 		}
 
-		kind := u.GetKind()
-		remapping := map[string]string{
-			"kubernetes": "clusters",
-		}
-		for k, v := range remapping {
-			if k == kind {
-				kind = v
-			}
-		}
-
-		resourceConfig := getResourceConfig(kind)
+		resourceConfig := getResourceConfig(u.GetKind())
 
 		team := u.GetNamespace()
 		if !resourceConfig.IsGlobal {

--- a/pkg/cmd/korectl/resource.go
+++ b/pkg/cmd/korectl/resource.go
@@ -45,6 +45,17 @@ func getResourceConfig(name string) resourceConfig {
 	}
 }
 
+var clusterResourceConfig = resourceConfig{
+	Name:   "clusters",
+	IsTeam: true,
+	Columns: []string{
+		Column("Name", "metadata.name"),
+		Column("Provider", "spec.provider.group"),
+		Column("Endpoint", "status.endpoint"),
+		Column("Status", "status.status"),
+	},
+}
+
 var resourceConfigs = map[string]resourceConfig{
 	"allocation": {
 		Name:   "allocations",
@@ -65,16 +76,8 @@ var resourceConfigs = map[string]resourceConfig{
 			Column("Name", "metadata.name"),
 		},
 	},
-	"cluster": {
-		Name:   "clusters",
-		IsTeam: true,
-		Columns: []string{
-			Column("Name", "metadata.name"),
-			Column("Provider", "spec.provider.group"),
-			Column("Endpoint", "status.endpoint"),
-			Column("Status", "status.status"),
-		},
-	},
+	"cluster":    clusterResourceConfig,
+	"kubernetes": clusterResourceConfig,
 	"gke": {
 		Name:   "gkes",
 		IsTeam: true,
@@ -163,12 +166,6 @@ var resourceConfigs = map[string]resourceConfig{
 			Column("Username", "metadata.name"),
 			Column("Email", "spec.email"),
 			Column("Disabled", "spec.disabled"),
-		},
-	},
-	"kubernetes": {
-		Name: "kubernetes",
-		Columns: []string{
-			Column("Name", "metadata.name"),
 		},
 	},
 }

--- a/pkg/cmd/korectl/resource.go
+++ b/pkg/cmd/korectl/resource.go
@@ -19,7 +19,7 @@ package korectl
 import (
 	"strings"
 
-	"github.com/go-openapi/inflect"
+	"github.com/appvia/kore/pkg/utils"
 )
 
 type resourceConfig struct {
@@ -30,14 +30,21 @@ type resourceConfig struct {
 }
 
 func getResourceConfig(name string) resourceConfig {
-	name = inflect.Singularize(strings.ToLower(name))
+	name = strings.ToLower(name)
+	switch name {
+	case "eks", "ekss":
+		name = "eks"
+	default:
+		name = utils.Singularize(name)
+	}
+
 	if config, ok := resourceConfigs[name]; ok {
 		return config
 	}
 
 	// TODO: we don't have a way to validate whether a resource exists yet, so we generate a team resource configuration dynamically
 	return resourceConfig{
-		Name:   inflect.Pluralize(name),
+		Name:   utils.Pluralize(name),
 		IsTeam: true,
 		Columns: []string{
 			Column("Name", "metadata.name"),

--- a/pkg/cmd/korectl/resource.go
+++ b/pkg/cmd/korectl/resource.go
@@ -165,4 +165,10 @@ var resourceConfigs = map[string]resourceConfig{
 			Column("Disabled", "spec.disabled"),
 		},
 	},
+	"kubernetes": {
+		Name: "kubernetes",
+		Columns: []string{
+			Column("Name", "metadata.name"),
+		},
+	},
 }

--- a/pkg/utils/inflect.go
+++ b/pkg/utils/inflect.go
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"github.com/go-openapi/inflect"
+)
+
+func init() {
+	inflect.AddUncountable("kubernetes")
+}
+
+func Singularize(word string) string {
+	return inflect.Singularize(word)
+}
+
+func Pluralize(word string) string {
+	return inflect.Pluralize(word)
+}


### PR DESCRIPTION
## What

This handles exceptions like "kubernetes" and "eks/ekss" when loading the resource config.

I moved the inflect function to util, so we hide the library used and we can add any exception to one place.