### PR TITLE
Default Option Value

### DIFF
--- a/cmd/korectl/options/options.go
+++ b/cmd/korectl/options/options.go
@@ -42,7 +42,7 @@ func Options() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  "no-wait",
-			Usage: "if we should wait for the resource to provision (default: false) `BOOL`",
+			Usage: "if we should wait for the resource to provision `BOOL`",
 			Value: false,
 		},
 	}


### PR DESCRIPTION
- removing the unrequired (default: false), as v2 prints these now so was getting (default: false) BOOL (default: false)