### PR TITLE
Fix namespace claim wait

### DIFF
--- a/pkg/cmd/korectl/create_namespace.go
+++ b/pkg/cmd/korectl/create_namespace.go
@@ -105,11 +105,12 @@ func GetCreateNamespaceCommand(config *Config) *cli.Command {
 				Name:      cluster,
 			}
 
-			if err := CreateClusterNamespace(config, owner, team, name, dry); err != nil {
+			claim, err := CreateClusterNamespace(config, owner, team, name, dry)
+			if err != nil {
 				return fmt.Errorf("trying to provision namespace on cluster: %s", err)
 			}
 
-			return WaitForResourceCheck(context.Background(), config, team, kind, name, nowait)
+			return WaitForResourceCheck(context.Background(), config, team, kind, claim.Name, nowait)
 		},
 	}
 }

--- a/pkg/cmd/korectl/helper.go
+++ b/pkg/cmd/korectl/helper.go
@@ -230,7 +230,11 @@ func WaitForResource(ctx context.Context, config *Config, team, kind, name strin
 		request.WithRuntimeObject(u)
 
 		if err := request.Get(); err != nil {
-			return false, nil
+			// @note: this has been added because the runtime.Client doesn't always return
+			// the api type
+			if !utils.IsMissingKind(err) {
+				return false, nil
+			}
 		}
 
 		// @step: check the status of the resource

--- a/pkg/controllers/management/namespaceclaims/reconcile.go
+++ b/pkg/controllers/management/namespaceclaims/reconcile.go
@@ -18,7 +18,6 @@ package namespaceclaims
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
@@ -27,7 +26,6 @@ import (
 	ctrl "github.com/appvia/kore/pkg/controllers/management/kubernetes"
 	"github.com/appvia/kore/pkg/kore"
 	"github.com/appvia/kore/pkg/utils/kubernetes"
-	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
@@ -227,7 +225,6 @@ func (a *nsCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error) 
 				Name:     x.Spec.Username,
 			})
 		}
-		fmt.Printf("USER: %s", spew.Sdump(binding))
 
 		// @step: ensuring the binding exists
 		if _, err := kubernetes.CreateOrUpdate(ctx, client, binding); err != nil {

--- a/pkg/utils/unstructured.go
+++ b/pkg/utils/unstructured.go
@@ -17,10 +17,21 @@
 package utils
 
 import (
+	"strings"
+
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// IsMissingKind checks if a runtime kind error
+func IsMissingKind(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "Object 'Kind' is missing in")
+}
 
 // GetOwnership returns an ownership from a object
 func GetOwnership(object *unstructured.Unstructured, name string) corev1.Ownership {


### PR DESCRIPTION
The wait on namespace claim was not working
a) the namespace claims are prefixed with the cluster so it needed to reflect
b) the unstructured type was not decoding due to missing Kind (this is an issue with the controller-runtime)

```
### Testing (first build a cluster) 
$ korectl create namespace -c dev -t devs <name>
```

It *should* return when complete and not pend until timeout

28b6adf8 - fixing up the resource name as namespaceclaims have the cluster prefix
ebe311ba - bypassing the missing kind on unstructured decoding
85ff39cb - removing the debug statement

