### PR TITLE
Allow team deletion

### DIFF
--- a/pkg/kore/authentication/types.go
+++ b/pkg/kore/authentication/types.go
@@ -23,6 +23,8 @@ type ContextKey struct{}
 type Identity interface {
 	// IsGlobalAdmin checks if the user is a global admin
 	IsGlobalAdmin() bool
+	// IsMember checks if the user is a member of a team
+	IsMember(string) bool
 	// Email returns the user email
 	Email() string
 	// Disabled checks if the user is disabled

--- a/pkg/kore/identity.go
+++ b/pkg/kore/identity.go
@@ -55,6 +55,11 @@ func (i identImpl) IsGlobalAdmin() bool {
 	return utils.Contains(HubAdminTeam, i.teamNames)
 }
 
+// IsMember checks if the user is a member of the team
+func (i identImpl) IsMember(name string) bool {
+	return utils.Contains(name, i.Teams())
+}
+
 // GetUserIdentity queries the user services for the identity
 func (h *hubImpl) GetUserIdentity(ctx context.Context, username string) (authentication.Identity, bool, error) {
 	// @step: retrieve the user from the service

--- a/pkg/kore/teams.go
+++ b/pkg/kore/teams.go
@@ -56,8 +56,13 @@ type teamsImpl struct {
 func (t *teamsImpl) Delete(ctx context.Context, name string) error {
 	// @step: retrieve the user from context
 	user := authentication.MustGetIdentity(ctx)
-	if !user.IsGlobalAdmin() {
-		log.Warn("non admin user attempting to delete a team")
+
+	// @step: one has to be a member of the team to delete it
+	if !user.IsMember(name) && !user.IsGlobalAdmin() {
+		log.WithFields(log.Fields{
+			"team": name,
+			"user": user.Username(),
+		}).Warn("user attempting to delete a delete not a member of")
 
 		return ErrUnauthorized
 	}
@@ -91,7 +96,7 @@ func (t *teamsImpl) Delete(ctx context.Context, name string) error {
 			"team": name,
 		}).Warn("attempting to delete a team whom has cluster")
 
-		return ErrNotAllowed{message: "all team clusters must be deleted before team can be removed"}
+		return ErrNotAllowed{message: "all team resources must be deleted before team can be removed"}
 	}
 
 	// @step: check if the team has any allocations to other teams

--- a/pkg/kore/teams.go
+++ b/pkg/kore/teams.go
@@ -57,12 +57,12 @@ func (t *teamsImpl) Delete(ctx context.Context, name string) error {
 	// @step: retrieve the user from context
 	user := authentication.MustGetIdentity(ctx)
 
-	// @step: one has to be a member of the team to delete it
+	// @step: one has to be a team member or the global admin
 	if !user.IsMember(name) && !user.IsGlobalAdmin() {
 		log.WithFields(log.Fields{
 			"team": name,
 			"user": user.Username(),
-		}).Warn("user attempting to delete a delete not a member of")
+		}).Warn("user attempting to delete a team not a member of")
 
 		return ErrUnauthorized
 	}


### PR DESCRIPTION
fd8d44a4 - adding the IsMember method to the identity
4f6405e5 - changing the logic so only a admin or team member can delete the team
301a4649 - fixing up the comment

fixes #430 