### PR TITLE
Controller Runtime Client GVK

### DIFF
--- a/pkg/kore/clusters.go
+++ b/pkg/kore/clusters.go
@@ -101,8 +101,6 @@ func (c *clsImpl) Get(ctx context.Context, name string) (*clustersv1.Kubernetes,
 
 		return nil, err
 	}
-	cluster.APIVersion = clustersv1.GroupVersion.String()
-	cluster.Kind = "Kubernetes"
 
 	return cluster, nil
 }

--- a/pkg/store/client.go
+++ b/pkg/store/client.go
@@ -106,12 +106,17 @@ func (r *rclient) Get(ctx context.Context, options ...GetOptionFunc) error {
 		Name:      r.index.query.Name,
 	}
 
+	// @step: retrieve the object the kube-api
 	if err := r.client.Get(ctx, reference, r.value); err != nil {
 		return err
 	}
 
-	// @step: retrieve the object the kube-api
-	return r.client.Get(ctx, reference, r.value)
+	// @step: if possible we try and inject the gvk from the schema
+	if gvk, found, _ := hubschema.GetGroupKindVersion(r.value); found {
+		r.value.GetObjectKind().SetGroupVersionKind(gvk)
+	}
+
+	return nil
 }
 
 // Create is responsible for creating an object in the api - enuring it doesn't exist already


### PR DESCRIPTION
- the controller runtime client appears to strip the gvk on get() but not list(). I recall seeing this as a known issue. Here we are using the registered schema to lookup the gvk again and fill in the detail if found

## Testing

You can build a cluster and then push a namespace claim: `korectl create namespace -t <cluster_name>` .. Then use a curl to grab the resource direct

```shell
bash function
api ()  
{ 
    curl -H "Content-Type: application/json" -H "Authorization: Bearer password" -s http://127.0.0.1:10080/api/v1alpha1${@}
}

api /teams/<name>/namespaceclaims/<ns_name>

- the apiVersion and kind should be missing ... 
- then run again off this branch and it should be part o of the payload
```