### PR TITLE
Deleting GKE before Cluster Fix

### DIFF
--- a/pkg/kore/helpers.go
+++ b/pkg/kore/helpers.go
@@ -107,7 +107,7 @@ func IsOwn(a, b corev1.Ownership) bool {
 	return true
 }
 
-// IsResourceOwner checks if the resource is pointed to
+// IsResourceOwner checks if the object is pointed to by the ownership reference
 func IsResourceOwner(o runtime.Object, ownership corev1.Ownership) (bool, error) {
 	if o == nil {
 		return false, errors.New("no object defined")

--- a/pkg/kore/helpers.go
+++ b/pkg/kore/helpers.go
@@ -27,6 +27,7 @@ import (
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
 	"github.com/appvia/kore/pkg/kore/authentication"
+	koreschema "github.com/appvia/kore/pkg/schema"
 	"github.com/appvia/kore/pkg/utils"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -104,6 +105,40 @@ func IsOwn(a, b corev1.Ownership) bool {
 	}
 
 	return true
+}
+
+// IsResourceOwner checks if the resource is pointed to
+func IsResourceOwner(o runtime.Object, ownership corev1.Ownership) (bool, error) {
+	if o == nil {
+		return false, errors.New("no object defined")
+	}
+	mo, ok := o.(metav1.Object)
+	if !ok {
+		return false, errors.New("object does not implement metav1.Object")
+	}
+
+	gvk, found, err := koreschema.GetGroupKindVersion(o)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, errors.New("resource not found in registered schema")
+	}
+
+	switch {
+	case mo.GetName() != ownership.Name:
+		return false, nil
+	case mo.GetNamespace() != ownership.Namespace:
+		return false, nil
+	case gvk.Group != ownership.Group:
+		return false, nil
+	case gvk.Version != ownership.Version:
+		return false, nil
+	case gvk.Kind != ownership.Kind:
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // ResourceExists checks if some resource exists


### PR DESCRIPTION
At present the use via the CLI or API can delete the cloud provider before the cluster itself, which can lead to wierd outcomes. This PR ensures when the cloud resource is requested deletion we first check if it referenced anywhere and if so denies the deletion

### Testing

- Create a cluster
- Try and delete the GKE resource `korectl delete gkes <name> -t <team>`. The deletion should be denied
