### PR TITLE
GKE Bootstrap Fix

### DIFF
--- a/pkg/controllers/cloud/gcp/gke/bootstrap.go
+++ b/pkg/controllers/cloud/gcp/gke/bootstrap.go
@@ -94,6 +94,7 @@ func (p *bootImpl) Run(ctx context.Context, client client.Client) error {
 
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/controllers/cloud/gcp/gke/reconcile.go
+++ b/pkg/controllers/cloud/gcp/gke/reconcile.go
@@ -25,6 +25,7 @@ import (
 	core "github.com/appvia/kore/pkg/apis/core/v1"
 	gcp "github.com/appvia/kore/pkg/apis/gcp/v1alpha1"
 	gke "github.com/appvia/kore/pkg/apis/gke/v1alpha1"
+	"github.com/appvia/kore/pkg/controllers"
 	gcpcc "github.com/appvia/kore/pkg/controllers/cloud/gcp/projectclaim"
 	"github.com/appvia/kore/pkg/utils/kubernetes"
 
@@ -203,13 +204,14 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 
 		logger.Info("attempting to bootstrap the gke cluster")
 
-		boot, err := newBootstrapClient(resource, creds)
+		bc, err := newBootstrapClient(resource, creds)
 		if err != nil {
 			logger.WithError(err).Error("trying to create bootstrap client")
 
 			return false, err
 		}
-		if err := boot.Run(ctx, t.mgr.GetClient()); err != nil {
+
+		if err := controllers.NewBootstrap(bc).Run(ctx, t.mgr.GetClient()); err != nil {
 			logger.WithError(err).Error("trying to bootstrap gke cluster")
 
 			return false, err

--- a/pkg/controllers/management/kubernetes/reconcile.go
+++ b/pkg/controllers/management/kubernetes/reconcile.go
@@ -537,6 +537,8 @@ func (a k8sCtrl) CheckProviderStatus(ctx context.Context, resource *clustersv1.K
 		}
 
 		switch status.Status {
+		case corev1.SuccessStatus:
+			return nil
 		case corev1.FailureStatus:
 			message := status.Message
 			if message == "" {

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -17,7 +17,6 @@
 package controllers
 
 import (
-	"log"
 	"sync"
 )
 
@@ -33,7 +32,6 @@ func Register(handler RegisterInterface) error {
 	controllerLock.Lock()
 	defer controllerLock.Unlock()
 
-	log.Printf("adding controller %s", handler.Name())
 	controllerList = append(controllerList, handler)
 
 	return nil


### PR DESCRIPTION
7bfbbedc - fixing the gke bootstrap code as eks merge had removed the part where we create the credentials
8359aebd - removing the extra debug line
572d23a2 - ensuring a clean return

The merge of EKS has removed the section of code where GKE created it's k8s service token.