### PR TITLE
GCP Organization Credentials Verification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jinzhu/gorm v1.9.12
 	github.com/jmhodges/levigo v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/manifoldco/promptui v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,8 @@ github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52Cu
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=

--- a/pkg/apis/config/v1/codec.go
+++ b/pkg/apis/config/v1/codec.go
@@ -35,7 +35,7 @@ func (s *Secret) Decode() error {
 	for k, v := range s.Spec.Data {
 		decoded, err := base64.RawStdEncoding.DecodeString(v)
 		if err != nil {
-			return fmt.Errorf("key: %s, value: %s is not base64 encoded", k, v)
+			return fmt.Errorf("key: %q is not base64 encoded", k)
 		}
 		s.Spec.Data[k] = string(decoded)
 	}

--- a/pkg/cmd/korectl/create_secret.go
+++ b/pkg/cmd/korectl/create_secret.go
@@ -161,7 +161,7 @@ func createSecretFromLiterals(keypairs []string) (*configv1.Secret, error) {
 			return nil, fmt.Errorf("invalid value: %s must conform to: %s", kv, filter)
 		}
 		items := strings.Split(kv, "=")
-		secret.Spec.Data[items[0]] = base64.StdEncoding.EncodeToString([]byte(items[1]))
+		secret.Spec.Data[items[0]] = base64.RawStdEncoding.EncodeToString([]byte(items[1]))
 	}
 
 	return secret, nil
@@ -188,7 +188,7 @@ func createSecretFromFile(keypair string) (*configv1.Secret, error) {
 	return &configv1.Secret{
 		Spec: configv1.SecretSpec{
 			Data: map[string]string{
-				key: base64.StdEncoding.EncodeToString(content),
+				key: base64.RawStdEncoding.EncodeToString(content),
 			},
 		},
 	}, nil
@@ -223,7 +223,7 @@ func createSecretFromEnvironmentFile(path string) (*configv1.Secret, error) {
 
 		e := strings.Split(scanner.Text(), "=")
 
-		secret.Spec.Data[e[0]] = base64.StdEncoding.EncodeToString([]byte(e[1]))
+		secret.Spec.Data[e[0]] = base64.RawStdEncoding.EncodeToString([]byte(e[1]))
 	}
 
 	return secret, nil

--- a/pkg/controllers/register/register.go
+++ b/pkg/controllers/register/register.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/appvia/kore/pkg/controllers/management/podpolicy"
 
 	// import secret controllers
+	_ "github.com/appvia/kore/pkg/controllers/secrets/gcp"
 	_ "github.com/appvia/kore/pkg/controllers/secrets/generic"
 
 	// importing the user controllers

--- a/pkg/controllers/secrets/gcp/controller.go
+++ b/pkg/controllers/secrets/gcp/controller.go
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gcp
+
+import (
+	"context"
+	"time"
+
+	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
+	"github.com/appvia/kore/pkg/controllers"
+	"github.com/appvia/kore/pkg/kore"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type ctrl struct {
+	kore.Interface
+	// mgr is the manager
+	mgr manager.Manager
+	// stopCh is the stop channel
+	stopCh chan struct{}
+}
+
+func init() {
+	if err := controllers.Register(&ctrl{}); err != nil {
+		log.WithError(err).Fatal("failed to register controller")
+	}
+}
+
+// Name returns the name of the controller
+func (a ctrl) Name() string {
+	return "secret-gcp"
+}
+
+// Run is called when the controller is started
+func (a *ctrl) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
+	a.Interface = hi
+
+	// @step: create the manager for the controller
+	mgr, err := manager.New(cfg, controllers.DefaultManagerOptions(a))
+	if err != nil {
+		log.WithError(err).Error("failed to create the manager")
+
+		return err
+	}
+	a.mgr = mgr
+	a.Interface = hi
+
+	// @step: create the controller
+	ctrl, err := controller.New(a.Name(), mgr, controllers.DefaultControllerOptions(a))
+	if err != nil {
+		log.WithError(err).Error("trying to create the controller")
+
+		return err
+	}
+
+	// @step: setup watches for the resources
+	if err := ctrl.Watch(&source.Kind{Type: &configv1.Secret{}},
+		&handler.EnqueueRequestForObject{},
+		&predicate.GenerationChangedPredicate{},
+	); err != nil {
+
+		log.WithError(err).Error("failed to create watcher on resource")
+
+		return err
+	}
+
+	go func() {
+		log.Info("starting the controller loop")
+
+		for {
+			a.stopCh = make(chan struct{})
+
+			if err := mgr.Start(a.stopCh); err != nil {
+				log.WithError(err).Error("failed to start the controller")
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	// @step: use a routine to catch the stop channel
+	go func() {
+		<-ctx.Done()
+		log.WithFields(log.Fields{
+			"controller": a.Name(),
+		}).Info("stopping the controller")
+
+		close(a.stopCh)
+	}()
+
+	return nil
+}
+
+// Stop is responsible for calling a halt on the controller
+func (a *ctrl) Stop(context.Context) error {
+	log.WithFields(log.Fields{
+		"controller": a.Name(),
+	}).Info("attempting to stop the controller")
+
+	return nil
+}

--- a/pkg/controllers/secrets/gcp/doc.go
+++ b/pkg/controllers/secrets/gcp/doc.go
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package gcp provides a controller used to reconcile gcp organization secrets
+package gcp

--- a/pkg/controllers/secrets/gcp/reconcile.go
+++ b/pkg/controllers/secrets/gcp/reconcile.go
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
+	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
+	"github.com/appvia/kore/pkg/kore/assets"
+	"github.com/appvia/kore/pkg/utils"
+	gcputils "github.com/appvia/kore/pkg/utils/cloud/gcp"
+
+	log "github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	// ErrMissingClientEmail indicates the client email was missing from the service account
+	ErrMissingClientEmail = errors.New("client email is missing from service account key")
+	// ErrMissingOrganization indicates we were unable to find the organization associated to the account
+	ErrMissingOrganization = errors.New("no gcp organization found associated to service account")
+	// ErrMultipleOrganizations indicates the service account as multiple orgs associated
+	ErrMultipleOrganizations = errors.New("multiple gcp organizations associated to service account")
+	// ErrMissingServiceAccountKey indicates the service account is missing
+	ErrMissingServiceAccountKey = errors.New("secret does not have a 'key' field holding the service account")
+)
+
+// Reconcile ensures the clusters roles across all the managed clusters
+func (a ctrl) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx := context.Background()
+	logger := log.WithFields(log.Fields{
+		"name":      request.NamespacedName.Name,
+		"namespace": request.NamespacedName.Namespace,
+	})
+	logger.Debug("attempting to reconcile generic secret roles")
+
+	// @step: retrieve the resource from the api
+	secret := &configv1.Secret{}
+	if err := a.mgr.GetClient().Get(ctx, request.NamespacedName, secret); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+	original := secret.DeepCopy()
+
+	// @step: we only care about gcp organizational secrets
+	if secret.Spec.Type != assets.GCPOrganizationalSecret.Name {
+		return reconcile.Result{}, nil
+	}
+
+	// @step: we need to get if the roles exists in the service account
+	result, err := func() (reconcile.Result, error) {
+		// @step: set the resource to pending
+		if secret.Status.Status != corev1.PendingStatus {
+			secret.Status.Status = corev1.PendingStatus
+			secret.Status.Conditions = []corev1.Condition{}
+
+			return reconcile.Result{Requeue: true}, nil
+		}
+
+		// @step: decode the secret
+		copied := secret.DeepCopy()
+		if err := copied.Decode(); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// @step: set the default and false
+		secret.Status.Verified = utils.BoolPtr(false)
+
+		// @step: check the key is set
+		sa, found := copied.Spec.Data["key"]
+		if !found {
+			return reconcile.Result{}, ErrMissingServiceAccountKey
+		}
+
+		// @step: retrieve the client email from the service account
+		account, found, err := gcputils.GetServiceAccountFromKeyFile(sa)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if !found {
+			return reconcile.Result{}, ErrMissingClientEmail
+		}
+
+		// @step: create a resource manager client
+		client, err := gcputils.CreateResourceManagerClientFromServiceAccount(sa)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// a list of missing roles
+		var missing []string
+
+		err = utils.Retry(ctx, 3, true, 5*time.Second, func() (bool, error) {
+			list, err := gcputils.GetServiceAccountOrganizationsIDs(ctx, sa)
+			if err != nil {
+				logger.WithError(err).Error("trying to retrieve service account organization")
+
+				return false, nil
+			}
+			if len(list) <= 0 {
+				return false, ErrMissingOrganization
+			}
+			if len(list) > 1 {
+				return false, ErrMultipleOrganizations
+			}
+			id := list[0]
+
+			roles, err := gcputils.CheckOrganizationRoles(ctx, id, account, client)
+			if err != nil {
+				logger.WithError(err).Error("trying to check service account roles for gcp credentials")
+
+				return false, nil
+			}
+
+			// @step: check which if any roles are missing
+			for _, x := range a.RequiredRoles() {
+				if !utils.Contains(x, roles) {
+					missing = append(missing, x)
+				}
+			}
+
+			if len(missing) > 0 {
+				return false, fmt.Errorf("missing the follings: %s", strings.Join(missing, ","))
+			}
+
+			return true, nil
+		})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		secret.Status.Status = corev1.SuccessStatus
+		secret.Status.Verified = utils.BoolPtr(true)
+		secret.Status.Conditions = []corev1.Condition{}
+
+		return reconcile.Result{}, nil
+	}()
+	if err != nil {
+		logger.WithError(err).Error("trying to check the gcp organization credentials")
+
+		secret.Status.Status = corev1.FailureStatus
+		secret.Status.Conditions = []corev1.Condition{{
+			Detail:  err.Error(),
+			Message: "Failed trying to validate the GCP Organization secret",
+		}}
+	}
+
+	if err := a.mgr.GetClient().Status().Patch(ctx, secret, client.MergeFrom(original)); err != nil {
+		logger.WithError(err).Error("trying to update generic secret resource status")
+
+		return reconcile.Result{}, err
+	}
+
+	return result, nil
+}
+
+// RequiredRoles returns the roles required to provision
+func (a ctrl) RequiredRoles() []string {
+	return []string{
+		"roles/billing.user",
+		"roles/browser",
+		"roles/iam.securityReviewer",
+		"roles/orgpolicy.policyViewer",
+		"roles/resourcemanager.projectCreator",
+		"roles/resourcemanager.projectDeleter",
+		"roles/viewer",
+	}
+}

--- a/pkg/kore/assets/secret_types.go
+++ b/pkg/kore/assets/secret_types.go
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package assets
+
+// SecretTypes is a secret type
+type SecretTypes struct {
+	// Name is the name of the secret
+	Name string
+	// Fields is required list of fields for this secret
+	Fields []string
+}
+
+// @TODO potentially move this to JSONSchema?
+var (
+	// AWSCredentialsSecret holds kubernetes endpoints
+	AWSCredentialsSecret = SecretTypes{
+		Name:   "aws-credential",
+		Fields: []string{"access_id", "access_secret"},
+	}
+
+	// GenericSecret is used to generic secrets
+	GenericSecret = SecretTypes{
+		Name:   "generic",
+		Fields: []string{},
+	}
+
+	// GKECredentialsSecret holds the gke credentials
+	GKECredentialsSecret = SecretTypes{
+		Name:   "gke-credentials",
+		Fields: []string{"key"},
+	}
+
+	// GCPProjectSecret holds the details related to a gcp project credential
+	GCPProjectSecret = SecretTypes{
+		Name:   "gcp-project",
+		Fields: []string{"expires", "project_id", "project", "key", "key_id"},
+	}
+
+	// GCPOrganizationalSecret holds the SA for gcp organization
+	GCPOrganizationalSecret = SecretTypes{
+		Name:   "gcp-org",
+		Fields: []string{"key", "org-id"},
+	}
+
+	// KubernetesSecret holds kubernetes endpoints
+	KubernetesSecret = SecretTypes{
+		Name:   "kubernetes",
+		Fields: []string{"ca.crt", "endpoint", "token"},
+	}
+)
+
+// GetSecretTypeOrGeneric returns the secret type
+func GetSecretTypeOrGeneric(name string) SecretTypes {
+	for _, x := range SupportedSecretTypes() {
+		if x.Name == name {
+			return x
+		}
+	}
+
+	return GenericSecret
+}
+
+// SupportedSecretTypes returns a list of secret types
+func SupportedSecretTypes() []SecretTypes {
+	return []SecretTypes{
+		AWSCredentialsSecret,
+		GCPOrganizationalSecret,
+		GCPProjectSecret,
+		GenericSecret,
+		GKECredentialsSecret,
+		KubernetesSecret,
+	}
+}
+
+// SupportedSecretTypesNames returns a list of secret type names
+func SupportedSecretTypesNames() []string {
+	list := make([]string, len(SupportedSecretTypes()))
+	types := SupportedSecretTypes()
+
+	for i := 0; i < len(list); i++ {
+		list[i] = types[i].Name
+	}
+
+	return list
+}

--- a/pkg/kore/secrets.go
+++ b/pkg/kore/secrets.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
+	"github.com/appvia/kore/pkg/kore/assets"
 	"github.com/appvia/kore/pkg/kore/authentication"
 	"github.com/appvia/kore/pkg/services/users"
 	"github.com/appvia/kore/pkg/store"
@@ -52,7 +53,7 @@ type secretImpl struct {
 
 // SupportedSecretTypes returns a list of supported types
 func (h *secretImpl) SupportedSecretTypes() []string {
-	return []string{"generic", "credentials"}
+	return assets.SupportedSecretTypesNames()
 }
 
 // Update is responsible for updating the resource

--- a/pkg/utils/cloud/gcp/iam.go
+++ b/pkg/utils/cloud/gcp/iam.go
@@ -18,6 +18,9 @@ package gcp
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"strings"
 
 	"github.com/appvia/kore/pkg/utils"
 
@@ -25,8 +28,90 @@ import (
 	"google.golang.org/api/option"
 )
 
+var (
+	// ErrClientEmailMissing indicates the client email is missing in service account
+	ErrClientEmailMissing = errors.New("client email missing in service account json")
+)
+
 // MaxChunkSize is the largest number of permissions that can be checked in one request
 const MaxChunkSize = 100
+
+// CreateResourceManagerClientFromServiceAccount creates a resource manager client
+func CreateResourceManagerClientFromServiceAccount(sa string) (*resourcemanager.Service, error) {
+	options := option.WithCredentialsJSON([]byte(sa))
+
+	return resourcemanager.NewService(context.Background(), options)
+}
+
+// GetServiceAccountFromKeyFile extract the service account name from the service account key
+func GetServiceAccountFromKeyFile(sa string) (string, bool, error) {
+	value, err := GetServiceAccountKeyAttribute(sa, "client_email")
+
+	return value, len(value) > 0, err
+}
+
+// GetServiceAccountKeyAttribute decodes the service account key and extract a value
+func GetServiceAccountKeyAttribute(sa, attribute string) (string, error) {
+	values := make(map[string]interface{})
+
+	if err := json.NewDecoder(strings.NewReader(sa)).Decode(&values); err != nil {
+		return "", err
+	}
+
+	value, ok := values[attribute].(string)
+	if !ok {
+		return "", nil
+	}
+
+	return value, nil
+}
+
+// GetServiceAccountOrganizationsIDs retrieve the organizations for a service account
+func GetServiceAccountOrganizationsIDs(ctx context.Context, sa string) ([]string, error) {
+	client, err := CreateResourceManagerClientFromServiceAccount(sa)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Organizations.List().Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	var list []string
+
+	for _, x := range resp.Organizations {
+		list = append(list, x.OrganizationId)
+	}
+
+	return list, nil
+}
+
+// CheckOrganizationRoles checks the role the service account has
+func CheckOrganizationRoles(ctx context.Context, id, email string, client *resourcemanager.Service) ([]string, error) {
+	resp, err := client.
+		Organizations.
+		GetIamPolicy("organizations/"+id, &resourcemanager.GetIamPolicyRequest{}).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, err
+	}
+
+	member := email
+	if strings.Contains(email, "gserviceaccount.com") {
+		member = "serviceAccount:" + email
+	}
+
+	var list []string
+	for _, x := range resp.Bindings {
+		if utils.Contains(member, x.Members) {
+			list = append(list, x.Role)
+		}
+	}
+
+	return list, nil
+}
 
 // CheckServiceAccountPermissions is responsible for checking the service account the permissions
 func CheckServiceAccountPermissions(
@@ -35,10 +120,9 @@ func CheckServiceAccountPermissions(
 	serviceAccountKey string,
 	list []string,
 ) (bool, []string, error) {
-	options := option.WithCredentialsJSON([]byte(serviceAccountKey))
 
 	// @step: we create a client from the service account first
-	client, err := resourcemanager.NewService(context.Background(), options)
+	client, err := CreateResourceManagerClientFromServiceAccount(serviceAccountKey)
 	if err != nil {
 		return false, nil, err
 	}

--- a/pkg/utils/cloud/gcp/iam.go
+++ b/pkg/utils/cloud/gcp/iam.go
@@ -37,7 +37,7 @@ var (
 const MaxChunkSize = 100
 
 // CreateResourceManagerClientFromServiceAccount creates a resource manager client
-func CreateResourceManagerClientFromServiceAccount(sa string) (*resourcemanager.Service, error) {
+func CreateResourceManagerClientFromServiceAccount(ctx context.Context, sa string) (*resourcemanager.Service, error) {
 	options := option.WithCredentialsJSON([]byte(sa))
 
 	return resourcemanager.NewService(context.Background(), options)
@@ -68,7 +68,7 @@ func GetServiceAccountKeyAttribute(sa, attribute string) (string, error) {
 
 // GetServiceAccountOrganizationsIDs retrieve the organizations for a service account
 func GetServiceAccountOrganizationsIDs(ctx context.Context, sa string) ([]string, error) {
-	client, err := CreateResourceManagerClientFromServiceAccount(sa)
+	client, err := CreateResourceManagerClientFromServiceAccount(ctx, sa)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func CheckServiceAccountPermissions(
 ) (bool, []string, error) {
 
 	// @step: we create a client from the service account first
-	client, err := CreateResourceManagerClientFromServiceAccount(serviceAccountKey)
+	client, err := CreateResourceManagerClientFromServiceAccount(ctx, serviceAccountKey)
 	if err != nil {
 		return false, nil, err
 	}

--- a/pkg/utils/pointers.go
+++ b/pkg/utils/pointers.go
@@ -34,3 +34,8 @@ func TruePtr() *bool {
 
 	return &yes
 }
+
+// BoolPtr returns the a pointer to the boolean
+func BoolPtr(v bool) *bool {
+	return &v
+}

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -55,7 +55,7 @@ func Retry(ctx context.Context, attempts int, jitter bool, minInterval time.Dura
 	backoff := &backoff.Backoff{
 		Min:    minInterval,
 		Max:    minInterval * 2,
-		Factor: 1,
+		Factor: 1.5,
 		Jitter: jitter,
 	}
 

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jpillora/backoff"
+)
+
+var (
+	// ErrReachMaxAttempts indicates we hit the limit
+	ErrReachMaxAttempts = errors.New("reached max attempts")
+)
+
+const (
+	// MaxAttempts is the max attempts
+	MaxAttempts = 99999999
+)
+
+// RetryFunc performs the operation
+type RetryFunc func() (bool, error)
+
+// RetryWithTimeout creates a retry with a specific timeout
+func RetryWithTimeout(ctx context.Context, timeout, interval time.Duration, retryFn RetryFunc) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return Retry(ctx, 0, true, interval, retryFn)
+}
+
+// Retry is used to retry an operation multiple times under a context
+func Retry(ctx context.Context, attempts int, jitter bool, minInterval time.Duration, retryFn RetryFunc) error {
+	// @hack: quick way to do this for now
+	if attempts == 0 {
+		attempts = MaxAttempts
+	}
+
+	backoff := &backoff.Backoff{
+		Min:    minInterval,
+		Max:    minInterval * 2,
+		Factor: 1,
+		Jitter: jitter,
+	}
+
+	for i := 0; i < attempts; i++ {
+		select {
+		case <-ctx.Done():
+			return ErrCancelled
+		default:
+		}
+
+		finished, err := retryFn()
+		if err != nil {
+			return err
+		}
+		if finished {
+			return nil
+		}
+
+		Sleep(ctx, backoff.Duration())
+	}
+
+	return ErrReachMaxAttempts
+}

--- a/pkg/utils/retry_test.go
+++ b/pkg/utils/retry_test.go
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	err := Retry(ctx, 0, true, 1000*time.Millisecond, func() (bool, error) {
+		return false, nil
+	})
+	assert.Equal(t, ErrCancelled, err)
+}
+
+func TestRetryWithSuccess(t *testing.T) {
+	err := Retry(context.Background(), 0, true, 10*time.Millisecond, func() (bool, error) {
+		return true, nil
+	})
+	assert.NoError(t, err)
+}
+
+func TestRetryMaxAttempts(t *testing.T) {
+	var list []string
+
+	err := Retry(context.Background(), 3, true, 10*time.Millisecond, func() (bool, error) {
+		list = append(list, "done")
+
+		return false, nil
+	})
+	require.Error(t, err)
+	assert.Equal(t, ErrReachMaxAttempts, err)
+}
+
+func TestRetryWithError(t *testing.T) {
+	err := Retry(context.Background(), 3, true, 10*time.Millisecond, func() (bool, error) {
+		return false, errors.New("bad")
+	})
+	require.Error(t, err)
+	assert.Equal(t, "bad", err.Error())
+}
+
+func TestRetryWithTimeout(t *testing.T) {
+	err := RetryWithTimeout(context.Background(), 50*time.Millisecond, 30*time.Millisecond, func() (bool, error) {
+		return false, nil
+	})
+	require.Error(t, err)
+	assert.Equal(t, ErrCancelled, err)
+}

--- a/vendor/github.com/jpillora/backoff/LICENSE
+++ b/vendor/github.com/jpillora/backoff/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jaime Pillora
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jpillora/backoff/README.md
+++ b/vendor/github.com/jpillora/backoff/README.md
@@ -1,0 +1,119 @@
+# Backoff
+
+A simple exponential backoff counter in Go (Golang)
+
+[![GoDoc](https://godoc.org/github.com/jpillora/backoff?status.svg)](https://godoc.org/github.com/jpillora/backoff) [![Circle CI](https://circleci.com/gh/jpillora/backoff.svg?style=shield)](https://circleci.com/gh/jpillora/backoff)
+
+### Install
+
+```
+$ go get -v github.com/jpillora/backoff
+```
+
+### Usage
+
+Backoff is a `time.Duration` counter. It starts at `Min`. After every call to `Duration()` it is  multiplied by `Factor`. It is capped at `Max`. It returns to `Min` on every call to `Reset()`. `Jitter` adds randomness ([see below](#example-using-jitter)). Used in conjunction with the `time` package.
+
+---
+
+#### Simple example
+
+``` go
+
+b := &backoff.Backoff{
+	//These are the defaults
+	Min:    100 * time.Millisecond,
+	Max:    10 * time.Second,
+	Factor: 2,
+	Jitter: false,
+}
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+200ms
+400ms
+Reset!
+100ms
+```
+
+---
+
+#### Example using `net` package
+
+``` go
+b := &backoff.Backoff{
+    Max:    5 * time.Minute,
+}
+
+for {
+	conn, err := net.Dial("tcp", "example.com:5309")
+	if err != nil {
+		d := b.Duration()
+		fmt.Printf("%s, reconnecting in %s", err, d)
+		time.Sleep(d)
+		continue
+	}
+	//connected
+	b.Reset()
+	conn.Write([]byte("hello world!"))
+	// ... Read ... Write ... etc
+	conn.Close()
+	//disconnected
+}
+
+```
+
+---
+
+#### Example using `Jitter`
+
+Enabling `Jitter` adds some randomization to the backoff durations. [See Amazon's writeup of performance gains using jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html). Seeding is not necessary but doing so gives repeatable results.
+
+```go
+import "math/rand"
+
+b := &backoff.Backoff{
+	Jitter: true,
+}
+
+rand.Seed(42)
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+106.600049ms
+281.228155ms
+Reset!
+100ms
+104.381845ms
+214.957989ms
+```
+
+#### Documentation
+
+https://godoc.org/github.com/jpillora/backoff
+
+#### Credits
+
+Forked from [some JavaScript](https://github.com/segmentio/backo) written by [@tj](https://github.com/tj)

--- a/vendor/github.com/jpillora/backoff/backoff.go
+++ b/vendor/github.com/jpillora/backoff/backoff.go
@@ -1,0 +1,100 @@
+// Package backoff provides an exponential-backoff implementation.
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+// Backoff is a time.Duration counter, starting at Min. After every call to
+// the Duration method the current timing is multiplied by Factor, but it
+// never exceeds Max.
+//
+// Backoff is not generally concurrent-safe, but the ForAttempt method can
+// be used concurrently.
+type Backoff struct {
+	attempt uint64
+	// Factor is the multiplying factor for each increment step
+	Factor float64
+	// Jitter eases contention by randomizing backoff steps
+	Jitter bool
+	// Min and Max are the minimum and maximum values of the counter
+	Min, Max time.Duration
+}
+
+// Duration returns the duration for the current attempt before incrementing
+// the attempt counter. See ForAttempt.
+func (b *Backoff) Duration() time.Duration {
+	d := b.ForAttempt(float64(atomic.AddUint64(&b.attempt, 1) - 1))
+	return d
+}
+
+const maxInt64 = float64(math.MaxInt64 - 512)
+
+// ForAttempt returns the duration for a specific attempt. This is useful if
+// you have a large number of independent Backoffs, but don't want use
+// unnecessary memory storing the Backoff parameters per Backoff. The first
+// attempt should be 0.
+//
+// ForAttempt is concurrent-safe.
+func (b *Backoff) ForAttempt(attempt float64) time.Duration {
+	// Zero-values are nonsensical, so we use
+	// them to apply defaults
+	min := b.Min
+	if min <= 0 {
+		min = 100 * time.Millisecond
+	}
+	max := b.Max
+	if max <= 0 {
+		max = 10 * time.Second
+	}
+	if min >= max {
+		// short-circuit
+		return max
+	}
+	factor := b.Factor
+	if factor <= 0 {
+		factor = 2
+	}
+	//calculate this duration
+	minf := float64(min)
+	durf := minf * math.Pow(factor, attempt)
+	if b.Jitter {
+		durf = rand.Float64()*(durf-minf) + minf
+	}
+	//ensure float64 wont overflow int64
+	if durf > maxInt64 {
+		return max
+	}
+	dur := time.Duration(durf)
+	//keep within bounds
+	if dur < min {
+		return min
+	}
+	if dur > max {
+		return max
+	}
+	return dur
+}
+
+// Reset restarts the current attempt counter at zero.
+func (b *Backoff) Reset() {
+	atomic.StoreUint64(&b.attempt, 0)
+}
+
+// Attempt returns the current attempt counter value.
+func (b *Backoff) Attempt() float64 {
+	return float64(atomic.LoadUint64(&b.attempt))
+}
+
+// Copy returns a backoff with equals constraints as the original
+func (b *Backoff) Copy() *Backoff {
+	return &Backoff{
+		Factor: b.Factor,
+		Jitter: b.Jitter,
+		Min:    b.Min,
+		Max:    b.Max,
+	}
+}

--- a/vendor/github.com/jpillora/backoff/go.mod
+++ b/vendor/github.com/jpillora/backoff/go.mod
@@ -1,0 +1,3 @@
+module github.com/jpillora/backoff
+
+go 1.13

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -376,6 +376,8 @@ github.com/jirfag/go-printf-func-name/pkg/analyzer
 github.com/jmespath/go-jmespath
 # github.com/jonboulle/clockwork v0.1.0
 github.com/jonboulle/clockwork
+# github.com/jpillora/backoff v1.0.0
+github.com/jpillora/backoff
 # github.com/json-iterator/go v1.1.8
 github.com/json-iterator/go
 # github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a


### PR DESCRIPTION
ac080a58 - adding the vendors code
770c0021 - adding the retry logic and pointer utils
1664d44c - fixing up the base64 encoding of the secrets
c36cab12 - removing teh value from the error message
e046854e - adding the secret types to the kore assets (perhaps switch these to jsonschema at some point?)
bb6822c9 - adding the various cloud utils for gcp permissions
1491fa2d - adding the controller to verify the credentials for the gcp organization type
