### PR TITLE
Kore Helm Chart - HMAC

### DIFF
--- a/charts/kore/templates/secret.yaml
+++ b/charts/kore/templates/secret.yaml
@@ -61,3 +61,8 @@ type: Opaque
 stringData:
   KORE_ADMIN_TOKEN: {{randAlphaNum 32 }}
   KORE_ADMIN_PASS: {{randAlphaNum 32 }}
+  {{- if .Values.api.hmac }}
+  KORE_HMAC: {{ .Values.api.hmac }}
+  {{- else }}
+  KORE_HMAC: {{ randAlphaNum 32 }}
+  {{- end }}


### PR DESCRIPTION
- the chart was not generating a know hmac, the kore-apiserver will gen a epherimal one which will effects the team invite urls