### PR TITLE
View plans

### DIFF
--- a/pkg/apiclient/operations/operations_client.go
+++ b/pkg/apiclient/operations/operations_client.go
@@ -208,7 +208,7 @@ func (a *Client) AddTeamMember(params *AddTeamMemberParams, authInfo runtime.Cli
 		Method:             "PUT",
 		PathPattern:        "/api/v1alpha1/teams/{team}/members/{user}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"*/*", "application/json"},
 		Schemes:            []string{"http"},
 		Params:             params,
 		Reader:             &AddTeamMemberReader{formats: a.formats},

--- a/pkg/apiserver/apiserver_integration_test.go
+++ b/pkg/apiserver/apiserver_integration_test.go
@@ -83,6 +83,7 @@ func getApi() *apiclient.AppviaKore {
 		uri = "localhost"
 	}
 	transport := httptransport.New(uri+":10080", "", nil)
+	transport.Producers["*/*"] = runtime.JSONProducer()
 	return apiclient.New(transport, strfmt.Default)
 }
 

--- a/pkg/apiserver/teams.go
+++ b/pkg/apiserver/teams.go
@@ -138,6 +138,8 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Operation("AddTeamMember").
 			Param(ws.PathParameter("team", "Is the name of the team you are acting within")).
 			Param(ws.PathParameter("user", "Is the user you are adding to the team")).
+			// As there's no body, need to explicitly say we consume any MIME type. Arguably a go-restful bug:
+			Consumes(restful.MIME_JSON, "*/*").
 			Returns(http.StatusOK, "The user has been successfully added to the team", orgv1.TeamMember{}).
 			Returns(http.StatusNotFound, "Team does not exist", nil),
 	)

--- a/ui/lib/components/cluster-build/ClusterOptionsForm.js
+++ b/ui/lib/components/cluster-build/ClusterOptionsForm.js
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 
-import { Typography, Form, Select, Card, Radio, Table, Modal, Input } from 'antd'
+import { Typography, Form, Select, Card, Radio, Modal, Input } from 'antd'
 const { Text, Title } = Typography
 const { Option } = Select
+
+import Plan from '../configure/Plan'
 
 class ClusterOptionsForm extends React.Component {
   static propTypes = {
@@ -32,39 +34,9 @@ class ClusterOptionsForm extends React.Component {
   showPlanDetails = planName => {
     return () => {
       const selectedPlan = this.props.plans.find(p => p.metadata.name === planName)
-      const planColumns = [{
-        title: 'Property',
-        dataIndex: 'property',
-        key: 'property',
-      }, {
-        title: 'Value',
-        dataIndex: 'value',
-        key: 'value',
-      }]
-      const planValues = selectedPlan ?
-        Object.keys(selectedPlan.spec.values).map(key => {
-          let value = selectedPlan.spec.values[key]
-          if (key === 'authorizedMasterNetworks') {
-            const complexValue = selectedPlan.spec.values[key]
-            value = `${complexValue[0].name}: ${complexValue[0].cidr}`
-          }
-          return {
-            key,
-            property: key,
-            value: `${value}`
-          }
-        }) :
-        null
       Modal.info({
-        title: (<div><Title level={4}>{selectedPlan.spec.description}</Title><Text>{selectedPlan.spec.summary}</Text></div>),
-        content: (
-          <Table
-            size="small"
-            pagination={false}
-            columns={planColumns}
-            dataSource={planValues}
-          />
-        ),
+        title: (<><Title level={4}>{selectedPlan.spec.description}</Title><Text>{selectedPlan.spec.summary}</Text></>),
+        content: <Plan plan={selectedPlan} />,
         width: 700,
         onOk() {}
       })

--- a/ui/lib/components/configure/GCPOrganizationsList.js
+++ b/ui/lib/components/configure/GCPOrganizationsList.js
@@ -35,11 +35,7 @@ class GCPOrganizationsList extends ResourceList {
     const { resources, allTeams, edit, add } = this.state
 
     return (
-      <Card
-        title="Organizations"
-        extra={<Button type="primary" onClick={this.add(true)}>+ New</Button>}
-        style={this.props.style}
-      >
+      <>
         <Alert
           message="Give Kore access to your Google Cloud Platform organization"
           description="This will allow Kore to manage the organization for you. This includes managing the creation of projects and Service Accounts giving Kore teams the ability to create clusters with ease."
@@ -47,6 +43,7 @@ class GCPOrganizationsList extends ResourceList {
           showIcon
           style={{ marginBottom: '20px' }}
         />
+        <Button type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
         {!resources ? <Icon type="loading" /> : (
           <>
             <List
@@ -95,7 +92,7 @@ class GCPOrganizationsList extends ResourceList {
             ) : null}
           </>
         )}
-      </Card>
+      </>
     )
   }
 }

--- a/ui/lib/components/configure/GCPOrganizationsList.js
+++ b/ui/lib/components/configure/GCPOrganizationsList.js
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types'
-import { Typography, Card, List, Button, Drawer, Icon, Alert } from 'antd'
+import { Typography, List, Button, Drawer, Icon, Alert } from 'antd'
 const { Title } = Typography
 
 import { kore } from '../../../config'
 import GCPOrganization from '../team/GCPOrganization'
 import ResourceList from '../configure/ResourceList'
 import GCPOrganizationForm from '../forms/GCPOrganizationForm'
-import apiRequest from '../../utils/api-request'
-import apiPaths from '../../utils/api-paths'
+import KoreApi from '../../utils/kore-api'
 
 class GCPOrganizationsList extends ResourceList {
 
@@ -19,10 +18,11 @@ class GCPOrganizationsList extends ResourceList {
   updatedMessage = 'GCP organization updated successfully'
 
   async fetchComponentData() {
+    const api = await KoreApi.client()
     const [ allTeams, gcpOrganizations, allAllocations ] = await Promise.all([
-      apiRequest(null, 'get', apiPaths.teams),
-      apiRequest(null, 'get', apiPaths.team(kore.koreAdminTeamName).gcpOrganizations),
-      apiRequest(null, 'get', apiPaths.team(kore.koreAdminTeamName).allocations)
+      api.ListTeams(),
+      api.ListGCPOrganizations(kore.koreAdminTeamName),
+      api.ListAllocations(kore.koreAdminTeamName)
     ])
     allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
     gcpOrganizations.items.forEach(org => {

--- a/ui/lib/components/configure/GKECredentialsList.js
+++ b/ui/lib/components/configure/GKECredentialsList.js
@@ -35,11 +35,7 @@ class GKECredentialsList extends ResourceList {
     const { resources, allTeams, edit, add } = this.state
 
     return (
-      <Card
-        title="Projects"
-        extra={<Button type="primary" onClick={this.add(true)}>+ New</Button>}
-        style={this.props.style}
-      >
+      <>
         <Alert
           message="Give Kore access to your existing Google Cloud Platform projects"
           description="This will enable Kore to build clusters inside a GCP project that you already manage outside of Kore. You must create a Service Account inside your project and add the key in JSON format here."
@@ -47,6 +43,7 @@ class GKECredentialsList extends ResourceList {
           showIcon
           style={{ marginBottom: '20px' }}
         />
+        <Button type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
         {!resources ? <Icon type="loading" /> : (
           <>
             <List
@@ -95,7 +92,7 @@ class GKECredentialsList extends ResourceList {
             ) : null}
           </>
         )}
-      </Card>
+      </>
     )
   }
 }

--- a/ui/lib/components/configure/GKECredentialsList.js
+++ b/ui/lib/components/configure/GKECredentialsList.js
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types'
-import { Typography, Card, List, Button, Drawer, Alert, Icon } from 'antd'
+import { Typography, List, Button, Drawer, Alert, Icon } from 'antd'
 const { Title } = Typography
 
 import { kore } from '../../../config'
 import Credentials from '../team/Credentials'
 import ResourceList from '../configure/ResourceList'
 import GKECredentialsForm from '../forms/GKECredentialsForm'
-import apiRequest from '../../utils/api-request'
-import apiPaths from '../../utils/api-paths'
+import KoreApi from '../../utils/kore-api'
 
 class GKECredentialsList extends ResourceList {
 
@@ -19,10 +18,11 @@ class GKECredentialsList extends ResourceList {
   updatedMessage = 'GCP project updated successfully'
 
   async fetchComponentData() {
+    const api = await KoreApi.client()
     const [ allTeams, gkeCredentials, allAllocations ] = await Promise.all([
-      apiRequest(null, 'get', apiPaths.teams),
-      apiRequest(null, 'get', apiPaths.team(kore.koreAdminTeamName).gkeCredentials),
-      apiRequest(null, 'get', apiPaths.team(kore.koreAdminTeamName).allocations)
+      api.ListTeams(),
+      api.ListGKECredentials(kore.koreAdminTeamName),
+      api.ListAllocations(kore.koreAdminTeamName)
     ])
     allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
     gkeCredentials.items.forEach(gke => {

--- a/ui/lib/components/configure/Plan.js
+++ b/ui/lib/components/configure/Plan.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types'
+import { Table } from 'antd'
+
+const Plan = ({ plan }) => {
+  const planColumns = [{
+    title: 'Property',
+    dataIndex: 'property',
+    key: 'property',
+  }, {
+    title: 'Value',
+    dataIndex: 'value',
+    key: 'value',
+  }]
+
+  const planValues = plan ?
+    Object.keys(plan.spec.values).map(key => {
+      let value = plan.spec.values[key]
+      if (key === 'authorizedMasterNetworks') {
+        const complexValue = plan.spec.values[key]
+        value = `${complexValue[0].name}: ${complexValue[0].cidr}`
+      }
+      return {
+        key,
+        property: key,
+        value: `${value}`
+      }
+    }) :
+    null
+
+  return (
+    <Table
+      size="small"
+      pagination={false}
+      columns={planColumns}
+      dataSource={planValues}
+    />
+  )
+}
+
+Plan.propTypes = {
+  plan: PropTypes.object.isRequired
+}
+
+export default Plan

--- a/ui/lib/components/configure/PlanList.js
+++ b/ui/lib/components/configure/PlanList.js
@@ -1,0 +1,61 @@
+import PropTypes from 'prop-types'
+import { List, Alert, Icon, Drawer, Typography } from 'antd'
+
+const { Title, Text } = Typography
+
+import PlanItem from '../team/PlanItem'
+import ResourceList from '../configure/ResourceList'
+import Plan from '../configure/Plan'
+import KoreApi from '../../utils/kore-api'
+
+class PlanList extends ResourceList {
+
+  static propTypes = {
+    kind: PropTypes.string,
+    style: PropTypes.object
+  }
+
+  async fetchComponentData() {
+    const api = await KoreApi.client()
+    const planList = await api.ListPlans(this.props.kind)
+    return { resources: planList }
+  }
+
+  render() {
+    const { resources, view } = this.state
+
+    return (
+      <>
+        <Alert
+          message="Manage the cluster plans"
+          description="These plans define the specification of the clusters that can be created using the Google Kubernetes Engine on GCP. These help to give teams an easy way to provision clusters which match the requirements of the organization."
+          type="info"
+          showIcon
+          style={{ marginBottom: '20px' }}
+        />
+        {!resources ? <Icon type="loading" /> : (
+          <>
+            <List
+              dataSource={resources.items}
+              renderItem={plan => <PlanItem plan={plan} viewPlan={this.view} /> }
+            >
+            </List>
+
+            {view ? (
+              <Drawer
+                title={<><Title level={4}>{view.spec.description}</Title><Text>{view.spec.summary}</Text></>}
+                visible={Boolean(view)}
+                onClose={this.view(false)}
+                width={700}
+              >
+                <Plan plan={view} />
+              </Drawer>
+            ) : null}
+          </>
+        )}
+      </>
+    )
+  }
+}
+
+export default PlanList

--- a/ui/lib/components/configure/ResourceList.js
+++ b/ui/lib/components/configure/ResourceList.js
@@ -15,7 +15,8 @@ class ResourceList extends React.Component {
     this.state = {
       dataLoading: true,
       edit: false,
-      add: false
+      add: false,
+      view: false
     }
   }
 
@@ -40,6 +41,14 @@ class ResourceList extends React.Component {
     return async () => {
       const state = copy(this.state)
       state.edit = resource ? resource : false
+      this.setState(state)
+    }
+  }
+
+  view = resource => {
+    return async () => {
+      const state = copy(this.state)
+      state.view = resource ? resource : false
       this.setState(state)
     }
   }

--- a/ui/lib/components/configure/ResourceList.js
+++ b/ui/lib/components/configure/ResourceList.js
@@ -23,10 +23,11 @@ class ResourceList extends React.Component {
   componentDidMount() {
     return this.fetchComponentData()
       .then(data => {
-        let state = copy(this.state)
-        state = { ...state, ...data }
-        state.dataLoading = false
-        this.setState(state)
+        this.setState({
+          ...this.state,
+          ...data,
+          dataLoading: false
+        })
       })
   }
 
@@ -37,48 +38,48 @@ class ResourceList extends React.Component {
     this.setState(state, done)
   }
 
-  edit = resource => {
-    return async () => {
-      const state = copy(this.state)
-      state.edit = resource ? resource : false
-      this.setState(state)
-    }
+  _setStateKey = (key, data) => {
+    const state = copy(this.state)
+    state[key] = data ? data : false
+    this.setState(state)
   }
 
-  view = resource => {
-    return async () => {
-      const state = copy(this.state)
-      state.view = resource ? resource : false
-      this.setState(state)
-    }
-  }
+  view = resource => async () => this._setStateKey('view', resource)
+  edit = resource => async () => this._setStateKey('edit', resource)
+  add = enabled => async () => this._setStateKey('add', enabled)
 
   handleEditSave = updated => {
-    const state = copy(this.state)
-
-    const edited = state.resources.items.find(c => c.metadata.name === state.edit.metadata.name)
-    edited.spec = updated.spec
-    edited.allocation = updated.allocation
-    edited.status.status = 'Pending'
-
-    state.edit = false
-    this.setState(state)
+    const editedName = this.state.edit.metadata.name
+    this.setState({
+      ...this.state,
+      edit: false,
+      resources: {
+        items: this.state.resources.items.map(resource => {
+          if (resource.metadata.name === editedName) {
+            return {
+              ...resource,
+              spec: updated.spec,
+              allocation: updated.allocation,
+              status: {
+                ...resource.status, status: 'Pending'
+              }
+            }
+          }
+          return resource
+        })
+      }
+    })
     message.success(this.updatedMessage)
   }
 
-  add = enabled => {
-    return () => {
-      const state = copy(this.state)
-      state.add = enabled
-      this.setState(state)
-    }
-  }
-
   handleAddSave = async created => {
-    const state = copy(this.state)
-    state.resources.items.push(created)
-    state.add = false
-    this.setState(state)
+    this.setState({
+      ...this.state,
+      add: false,
+      resources: {
+        items: this.state.resources.items.concat([ created ])
+      }
+    })
     message.success(this.createdMessage)
   }
 }

--- a/ui/lib/components/team/Credentials.js
+++ b/ui/lib/components/team/Credentials.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import { List, Avatar, Icon, Typography, message, Tooltip } from 'antd'
-const { Text, Title } = Typography
+const { Text } = Typography
 
 import ResourceVerificationStatus from '../ResourceVerificationStatus'
 import AutoRefreshComponent from './AutoRefreshComponent'
@@ -53,7 +53,7 @@ class Credentials extends AutoRefreshComponent {
           avatar={<Avatar icon="project" />}
           title={
             <>
-              <Title level={4} style={{ display: 'inline', marginRight: '15px' }}>{gke.spec.project}</Title>
+              <Text style={{ display: 'inline', marginRight: '15px', fontSize: '20px', fontWeight: '600' }}>{gke.spec.project}</Text>
               <Text style={{ marginRight: '5px' }}>{gke.allocation.spec.name}</Text>
               <Tooltip title={gke.allocation.spec.summary}>
                 <Icon type="info-circle" theme="twoTone" />

--- a/ui/lib/components/team/GCPOrganization.js
+++ b/ui/lib/components/team/GCPOrganization.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import { List, Avatar, Icon, Typography, message, Tooltip } from 'antd'
-const { Text, Title } = Typography
+const { Text } = Typography
 
 import ResourceStatusTag from '../ResourceStatusTag'
 import AutoRefreshComponent from './AutoRefreshComponent'
@@ -53,7 +53,7 @@ class GCPOrganization extends AutoRefreshComponent {
           avatar={<Avatar icon="cloud" />}
           title={
             <>
-              <Title level={4} style={{ display: 'inline', marginRight: '15px' }}>{organization.spec.parentID}</Title>
+              <Text style={{ display: 'inline', marginRight: '15px', fontSize: '20px', fontWeight: '600' }}>{organization.spec.parentID}</Text>
               <Text style={{ marginRight: '5px' }}>{organization.allocation.spec.name}</Text>
               <Tooltip title={organization.allocation.spec.summary}>
                 <Icon type="info-circle" theme="twoTone" />

--- a/ui/lib/components/team/PlanItem.js
+++ b/ui/lib/components/team/PlanItem.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+import { List, Avatar, Icon, Typography } from 'antd'
+const { Text } = Typography
+
+class PlanItem extends React.Component {
+  static propTypes = {
+    plan: PropTypes.object.isRequired,
+    viewPlan: PropTypes.func.isRequired
+  }
+
+  render() {
+    const { plan, viewPlan } = this.props
+    const created = moment(plan.metadata.creationTimestamp).fromNow()
+
+    return (
+      <List.Item key={plan.metadata.name} actions={[
+        <Text key="view_plan"><a onClick={viewPlan(plan)}><Icon type="eye" theme="filled"/> View</a></Text>
+      ]}>
+        <List.Item.Meta
+          avatar={<Avatar icon="build" />}
+          title={plan.spec.description}
+          description={plan.spec.summary}
+        />
+        <Text type='secondary'>Created {created}</Text>
+      </List.Item>
+    )
+  }
+
+}
+
+export default PlanItem

--- a/ui/lib/utils/kore-api-client.js
+++ b/ui/lib/utils/kore-api-client.js
@@ -48,7 +48,7 @@ class KoreApiClient {
   ListGCPOrganizations = (team) => this.apis.default.findOrganizations({team})
   ListAllocations = (team) => this.apis.default.ListAllocations({team})
   UpdateTeam = (team, teamSpec) => this.apis.default.UpdateTeam({team, body: teamSpec})
-  AddTeamMember = (team, user) => this.apis.default.AddTeamMember({team, user, body: {}})
+  AddTeamMember = (team, user) => this.apis.default.AddTeamMember({team, user})
   RemoveTeamMember = (team, user) => this.apis.default.RemoveTeamMember({team, user})
 }
 

--- a/ui/lib/utils/kore-api-client.js
+++ b/ui/lib/utils/kore-api-client.js
@@ -46,6 +46,7 @@ class KoreApiClient {
   ListTeamMembers = (team) => this.apis.default.ListTeamMembers({team})
   ListGKECredentials = (team) => this.apis.default.ListGKECredentials({team})
   ListGCPOrganizations = (team) => this.apis.default.findOrganizations({team})
+  ListAllocations = (team) => this.apis.default.ListAllocations({team})
   UpdateTeam = (team, teamSpec) => this.apis.default.UpdateTeam({team, body: teamSpec})
   AddTeamMember = (team, user) => this.apis.default.AddTeamMember({team, user, body: {}})
   RemoveTeamMember = (team, user) => this.apis.default.RemoveTeamMember({team, user})

--- a/ui/lib/utils/kore-api-client.js
+++ b/ui/lib/utils/kore-api-client.js
@@ -37,7 +37,7 @@ class KoreApiClient {
 
   // @TODO: Auto-generate these?
   ListAllocations = (team, assigned = undefined) => this.apis.default.ListAllocations({team, assigned: assigned})
-  ListPlans = () => this.apis.default.ListPlans()
+  ListPlans = (kind) => this.apis.default.ListPlans({ kind })
   ListUsers = () => this.apis.default.ListUsers()
   ListUserTeams = (user) => this.apis.default.ListUserTeams({user})
   UpdateUser = (user, userSpec) => this.apis.default.UpdateUser({user, body: userSpec})

--- a/ui/pages/configure/cloud.js
+++ b/ui/pages/configure/cloud.js
@@ -5,6 +5,7 @@ import { Alert, Tabs } from 'antd'
 import Breadcrumb from '../../lib/components/Breadcrumb'
 import GKECredentialsList from '../../lib/components/configure/GKECredentialsList'
 import GCPOrganizationsList from '../../lib/components/configure/GCPOrganizationsList'
+import PlanList from '../../lib/components/configure/PlanList'
 import CloudTabs from '../../lib/components/configure/CloudTabs'
 import copy from '../../lib/utils/object-copy'
 
@@ -35,12 +36,15 @@ class ConfigureCloudPage extends React.Component {
         />
         <CloudTabs defaultSelectedKey={selectedCloud} handleSelectCloud={this.handleSelectCloud}/>
         {selectedCloud === 'GCP' ? (
-          <Tabs defaultActiveKey={'teams'} tabPosition="left" style={{ marginTop: '20px' }}>
+          <Tabs defaultActiveKey={'orgs'} tabPosition="left" style={{ marginTop: '20px' }}>
             <Tabs.TabPane tab="Organizations" key="orgs">
               <GCPOrganizationsList />
             </Tabs.TabPane>
             <Tabs.TabPane tab="Projects" key="projects">
               <GKECredentialsList />
+            </Tabs.TabPane>
+            <Tabs.TabPane tab="Plans" key="plans">
+              <PlanList kind="GKE" />
             </Tabs.TabPane>
           </Tabs>
         ) : null}

--- a/ui/pages/configure/cloud.js
+++ b/ui/pages/configure/cloud.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Alert } from 'antd'
+import { Alert, Tabs } from 'antd'
 
 import Breadcrumb from '../../lib/components/Breadcrumb'
 import GKECredentialsList from '../../lib/components/configure/GKECredentialsList'
@@ -35,10 +35,14 @@ class ConfigureCloudPage extends React.Component {
         />
         <CloudTabs defaultSelectedKey={selectedCloud} handleSelectCloud={this.handleSelectCloud}/>
         {selectedCloud === 'GCP' ? (
-          <>
-            <GCPOrganizationsList style={{ marginBottom: '20px' }} />
-            <GKECredentialsList />
-          </>
+          <Tabs defaultActiveKey={'teams'} tabPosition="left" style={{ marginTop: '20px' }}>
+            <Tabs.TabPane tab="Organizations" key="orgs">
+              <GCPOrganizationsList />
+            </Tabs.TabPane>
+            <Tabs.TabPane tab="Projects" key="projects">
+              <GKECredentialsList />
+            </Tabs.TabPane>
+          </Tabs>
         ) : null}
       </>
     )


### PR DESCRIPTION
Exposing the plans we have to the admins under the GCP tab in Configure Cloud settings.
At this stage, it's only exposing what we currently have and not covering adding/editing.

Changing the look of the Configure Cloud page to have "vertical tabs" to separate sections.

<img width="1385" alt="Screen Shot 2020-04-06 at 16 05 23" src="https://user-images.githubusercontent.com/1334068/78574015-4ed42000-7821-11ea-89fa-8f0b5b7935fa.png">

<img width="1380" alt="Screen Shot 2020-04-06 at 16 05 33" src="https://user-images.githubusercontent.com/1334068/78574036-5693c480-7821-11ea-816d-982abe4f714f.png">
