### PR TITLE
Create & Delete Admin

### DIFF
--- a/pkg/cmd/korectl/create.go
+++ b/pkg/cmd/korectl/create.go
@@ -45,6 +45,7 @@ func GetCreateCommand(config *Config) *cli.Command {
 			GetCreateSecretCommand(config),
 			GetCreateClusterCommand(config),
 			GetCreateNamespaceCommand(config),
+			GetCreateAdminCommand(config),
 		},
 		Before: func(ctx *cli.Context) error {
 			if !ctx.Args().Present() {

--- a/pkg/cmd/korectl/create_admin.go
+++ b/pkg/cmd/korectl/create_admin.go
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package korectl
+
+import (
+	"github.com/appvia/kore/pkg/kore"
+
+	"github.com/urfave/cli/v2"
+)
+
+// GetCreateAdminCommand returns the create member command
+func GetCreateAdminCommand(config *Config) *cli.Command {
+	return &cli.Command{
+		Name:    "admin",
+		Aliases: []string{"admins"},
+		Usage:   "Creates a new administrator in kore",
+
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "user",
+				Aliases:  []string{"u"},
+				Usage:    "The username of the user you wish to add to the team",
+				Required: true,
+			},
+			&cli.BoolFlag{
+				Name:     "invite",
+				Aliases:  []string{"i"},
+				Usage:    "If the user doesn't exist and the invite flag is set, the invite url will be automatically generated.",
+				Required: false,
+			},
+		},
+
+		Action: func(ctx *cli.Context) error {
+			invite := ctx.Bool("invite")
+			username := ctx.String("user")
+
+			return CreateMember(config, kore.HubAdminTeam, username, invite)
+		},
+	}
+}

--- a/pkg/cmd/korectl/delete.go
+++ b/pkg/cmd/korectl/delete.go
@@ -52,6 +52,7 @@ func GetDeleteCommand(config *Config) *cli.Command {
 		},
 		Subcommands: []*cli.Command{
 			GetDeleteTeamMemberCommand(config),
+			GetDeleteAdminCommand(config),
 		},
 
 		Before: func(ctx *cli.Context) error {

--- a/pkg/cmd/korectl/delete_admin.go
+++ b/pkg/cmd/korectl/delete_admin.go
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package korectl
+
+import (
+	"fmt"
+
+	"github.com/appvia/kore/pkg/kore"
+
+	"github.com/urfave/cli/v2"
+)
+
+// GetDeleteAdminCommand returns the create member command
+func GetDeleteAdminCommand(config *Config) *cli.Command {
+	return &cli.Command{
+		Name:    "admin",
+		Aliases: []string{"admins"},
+		Usage:   "Deletes an administrator from kore",
+
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "user",
+				Aliases:  []string{"u"},
+				Usage:    "The username of the user you wish to add to the team",
+				Required: true,
+			},
+		},
+
+		Action: func(ctx *cli.Context) error {
+			username := ctx.String("user")
+
+			err := NewRequest().
+				WithConfig(config).
+				WithEndpoint("/teams/{team}/members/{user}").
+				PathParameter("team", true).
+				PathParameter("user", true).
+				WithInject("team", kore.HubAdminTeam).
+				WithInject("user", username).
+				Delete()
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("User %q has been removed as an administrator from kore\n", username)
+
+			return nil
+		},
+	}
+}

--- a/pkg/cmd/korectl/delete_admin.go
+++ b/pkg/cmd/korectl/delete_admin.go
@@ -35,7 +35,7 @@ func GetDeleteAdminCommand(config *Config) *cli.Command {
 			&cli.StringFlag{
 				Name:     "user",
 				Aliases:  []string{"u"},
-				Usage:    "The username of the user you wish to add to the team",
+				Usage:    "the user you wish to remove from being admin",
 				Required: true,
 			},
 		},

--- a/pkg/kore/members.go
+++ b/pkg/kore/members.go
@@ -147,6 +147,16 @@ func (t tmsImpl) Delete(ctx context.Context, name string) error {
 		return nil
 	}
 
+	// @check: is this the admin team?
+	if t.team == HubAdminTeam {
+		if name == HubAdminUser {
+			return ErrNotAllowed{message: "you cannot remove " + HubAdminUser + " user from this team"}
+		}
+		if len(list) == 1 {
+			return ErrNotAllowed{message: "you cannot remove all administrators from kore"}
+		}
+	}
+
 	// @step: we can delete all the membership
 	if err := t.usermgr.Members().DeleteBy(ctx,
 		users.Filter.WithUser(name),

--- a/test/e2e/integration/users.bats
+++ b/test/e2e/integration/users.bats
@@ -70,3 +70,7 @@ load helper
   [[ "$status" -eq 0 ]]
 }
 
+@test "We should not be allowed to remove the admin user from the kore-admin team" {
+  runit "${KORE} delete member -u admin -t kore-admin"
+  [[ "$status" -eq 1 ]]
+}


### PR DESCRIPTION
- adds the ability to create and delete an administrator in kore (these are effectively shortcuts to -t kore-admin)

The only real change here is pulling the create member code out into a reusable method and adding to additional commands as aliases effective to add and delete from the kore-admin team.

### Testing
```shell
$ korectl create admin -u <username>
$ korectl get member -t kore-admin
$ korectl delete admin -u <username>
$ korectl get member -t kore-admin
```