### PR TITLE
Return unauthorised when getting a team you are not a member of

### DIFF
--- a/pkg/kore/teams.go
+++ b/pkg/kore/teams.go
@@ -130,6 +130,11 @@ func (t *teamsImpl) Get(ctx context.Context, name string) (*orgv1.Team, error) {
 		return nil, err
 	}
 
+	user := authentication.MustGetIdentity(ctx)
+	if !user.IsMember(name) && !user.IsGlobalAdmin() {
+		return nil, ErrUnauthorized
+	}
+
 	return DefaultConvertor.FromTeamModel(model), err
 }
 


### PR DESCRIPTION
## What

As a user I shouldn't be able to query a team object, which I'm not a member of.

This also fixes a bug on the UI, where we don't expect getting the members fail if we can get the team object.

Fixes https://github.com/appvia/kore/issues/485