### PR TITLE
Fix cluster controller non-nil errors

### DIFF
--- a/pkg/controllers/controllerstest/test.go
+++ b/pkg/controllers/controllerstest/test.go
@@ -154,7 +154,10 @@ func (t *Test) checkCallCount(i, callCount int, method string) {
 }
 
 func (t *Test) ExpectRequeue(res reconcile.Result, err error) {
-	Expect(err).ToNot(HaveOccurred())
+	// We shouldn't use the HaveOccurred() matcher because it returns true if the value is a nil concrete value as an interface
+	if err != nil {
+		Fail(fmt.Sprintf("reconcile error is not nil: (%T) %v", err, err))
+	}
 	if !res.Requeue && res.RequeueAfter == 0 {
 		Fail("was expecting Requeue = true or RequeueAfter > 0")
 	}

--- a/pkg/controllers/error.go
+++ b/pkg/controllers/error.go
@@ -16,36 +16,23 @@
 
 package controllers
 
-import (
-	"fmt"
-)
-
-type ReconcileError struct {
-	Err      error
-	Critical bool
+type criticalError struct {
+	err error
 }
 
-func NewReconcileError(err error, critical bool) *ReconcileError {
-	return &ReconcileError{
-		Err:      err,
-		Critical: critical,
+func NewCriticalError(err error) error {
+	return criticalError{
+		err: err,
 	}
 }
 
-func (r *ReconcileError) Error() string {
-	return r.Err.Error()
+func (r criticalError) Error() string {
+	return r.err.Error()
 }
 
-func (r *ReconcileError) Wrap(message string) *ReconcileError {
-	if r != nil && r.Err != nil {
-		r.Err = fmt.Errorf("%s: %w", message, r.Err)
+func IsCriticalError(err error) bool {
+	if _, ok := err.(criticalError); ok {
+		return true
 	}
-	return r
-}
-
-func (r *ReconcileError) Wrapf(format string, args ...interface{}) *ReconcileError {
-	if r != nil && r.Err != nil {
-		r.Err = fmt.Errorf(format, append(args, r.Err)...)
-	}
-	return r
+	return false
 }

--- a/pkg/controllers/management/cluster/controller_test.go
+++ b/pkg/controllers/management/cluster/controller_test.go
@@ -197,6 +197,10 @@ var _ = Describe("Cluster Controller", func() {
 					Expect(kubernetes.Spec.Cluster).To(Equal(cluster.Ownership()))
 				})
 
+				It("should requeue and not error", func() {
+					test.ExpectRequeue(reconcileResult, reconcileErr)
+				})
+
 				When("the components can not be created", func() {
 					BeforeEach(func() {
 						cluster.Spec.Configuration = v1beta1.JSON{}
@@ -426,6 +430,10 @@ var _ = Describe("Cluster Controller", func() {
 					Expect(test.Client.DeleteCallCount()).To(Equal(1))
 					deletedObj := &clustersv1.Kubernetes{}
 					test.ExpectDelete(0, deletedObj)
+				})
+
+				It("should requeue and not error", func() {
+					test.ExpectRequeue(reconcileResult, reconcileErr)
 				})
 
 				When("deleting the Kubernetes component fails", func() {


### PR DESCRIPTION
## What

I've returned a nil concrete value (*ReconcileError <nil>) in the reconciliation loop, which becomes a non-nil value when wrapped with the `error` interface.

From the Go docs: "an interface value that holds a nil concrete value is itself non-nil."

I've replaced the ReconcileError type with a simple CriticalError type and we only create it with a non-nil error.