### PR TITLE
GKE Reconciliation Loop

### DIFF
--- a/pkg/controllers/cloud/gcp/gke/delete.go
+++ b/pkg/controllers/cloud/gcp/gke/delete.go
@@ -106,6 +106,13 @@ func (t *gkeCtrl) Delete(request reconcile.Request) (reconcile.Result, error) {
 			}
 		}
 
+		// @step: we can now delete the sysadmin token
+		if err := controllers.DeleteClusterCredentialsSecret(ctx,
+			t.mgr.GetClient(), resource.Namespace, resource.Name); err != nil {
+
+			return reconcile.Result{}, err
+		}
+
 		return reconcile.Result{}, nil
 	}()
 	if err != nil {

--- a/pkg/controllers/cloud/gcp/gke/delete.go
+++ b/pkg/controllers/cloud/gcp/gke/delete.go
@@ -18,7 +18,7 @@ package gke
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 	gke "github.com/appvia/kore/pkg/apis/gke/v1alpha1"
@@ -55,57 +55,73 @@ func (t *gkeCtrl) Delete(request reconcile.Request) (reconcile.Result, error) {
 
 	finalizer := kubernetes.NewFinalizer(t.mgr.GetClient(), finalizerName)
 
-	requeue, err := func() (bool, error) {
+	result, err := func() (reconcile.Result, error) {
+		// @step: lets update the status of the resource to deleting
+		if resource.Status.Status != corev1.DeletingStatus {
+			resource.Status.Status = corev1.DeletingStatus
+
+			return reconcile.Result{Requeue: true}, nil
+		}
+
 		creds, err := t.GetCredentials(ctx, resource, request.Namespace)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		// @step: create a cloud client for us
 		client, err := NewClient(creds, resource)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
-		// @step: check if the cluster exists and if so we wait or the operation or the exit
-		found, err := client.Exists()
+		// @step: we need to retrieve the current state
+		cluster, found, err := client.GetCluster(ctx)
 		if err != nil {
-			return false, fmt.Errorf("checking if cluster exists: %s", err)
-		}
+			logger.WithError(err).Error("trying to retrieve the state of the cluster")
 
-		// @step: lets update the status of the resource to deleting
-		if resource.Status.Status != corev1.DeletingStatus {
-			resource.Status.Status = corev1.DeletingStatus
-
-			return true, nil
+			return reconcile.Result{}, err
 		}
 
 		if found {
-			return false, client.Delete(ctx)
+			switch cluster.Status {
+			case "PROVISIONING", "RECONCILING":
+				return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+			case "ERROR", "RUNNING":
+				if err := client.Delete(ctx); err != nil {
+					logger.WithError(err).Error("trying to delete the cluster")
+					resource.Status.Status = core.FailureStatus
+
+					return reconcile.Result{}, err
+				}
+
+				return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+			case "STOPPING":
+				resource.Status.Status = core.DeletingStatus
+
+				return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+			default:
+				logger.Warn("cluster is in an unknown state, choosing to requeue instead")
+
+				return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+			}
 		}
 
-		// @step: we can now delete the sysadmin token
-		if err := controllers.DeleteClusterCredentialsSecret(ctx,
-			t.mgr.GetClient(), resource.Namespace, resource.Name); err != nil {
-
-			return false, err
-		}
-
-		return false, nil
+		return reconcile.Result{}, nil
 	}()
 	if err != nil {
 		logger.WithError(err).Error("attempting to delete the cluster")
 
 		return reconcile.Result{}, err
 	}
-	if requeue {
-		if err := t.mgr.GetClient().Status().Patch(ctx, resource, client.MergeFrom(original)); err != nil {
-			logger.WithError(err).Error("trying to update the resource status")
 
-			return reconcile.Result{}, err
-		}
+	if err := t.mgr.GetClient().Status().Patch(ctx, resource, client.MergeFrom(original)); err != nil {
+		logger.WithError(err).Error("trying to update the resource status")
 
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{}, err
+	}
+
+	if result.Requeue || result.RequeueAfter > 0 {
+		return result, nil
 	}
 
 	if err := finalizer.Remove(resource); err != nil {

--- a/pkg/controllers/cloud/gcp/gke/gke_client.go
+++ b/pkg/controllers/cloud/gcp/gke/gke_client.go
@@ -690,8 +690,6 @@ func (g *gkeClient) FindOperation(ctx context.Context, operationType, resource, 
 	})
 	logger.Debug("searching for any running operations")
 
-	g.ce.Projects.Locations.Clusters.Get("me").Do()
-
 	resp, err := g.ce.Projects.Locations.Operations.List(fmt.Sprintf("projects/%s/locations/%s",
 		g.credentials.project, g.region)).Do()
 	if err != nil {

--- a/pkg/controllers/cloud/gcp/gke/reconcile.go
+++ b/pkg/controllers/cloud/gcp/gke/reconcile.go
@@ -199,7 +199,7 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 			}
 		}
 
-		// @step: we check the current state against the desired and see if we need to ammend
+		// @step: we check the current state against the desired and see if we need to amend
 		updating, err := client.Update(ctx)
 		if err != nil {
 			logger.WithError(err).Error("attempting to update cluster")

--- a/pkg/controllers/cloud/gcp/gke/reconcile.go
+++ b/pkg/controllers/cloud/gcp/gke/reconcile.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	config "github.com/appvia/kore/pkg/apis/config/v1"
 	core "github.com/appvia/kore/pkg/apis/core/v1"
@@ -33,6 +34,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -61,6 +63,7 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 
 		return reconcile.Result{}, err
 	}
+	original := resource.DeepCopyObject()
 
 	finalizer := kubernetes.NewFinalizer(t.mgr.GetClient(), finalizerName)
 
@@ -74,7 +77,7 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 		resource.Status.Conditions = core.Components{}
 	}
 
-	requeue, err := func() (bool, error) {
+	result, err := func() (reconcile.Result, error) {
 		logger.Debug("retrieving the gke cluster credential")
 		// @step: first we need to check if we have access to the credentials
 		creds, err := t.GetCredentials(ctx, resource, resource.Namespace)
@@ -87,7 +90,7 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 				Status:  core.FailureStatus,
 			})
 
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		client, err := NewClient(creds, resource)
@@ -101,11 +104,11 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 				Status:  core.FailureStatus,
 			})
 
-			return false, err
+			return reconcile.Result{}, err
 		}
 		logger.Info("checking if the cluster already exists")
 
-		found, err := client.Exists()
+		found, err := client.Exists(ctx)
 		if err != nil {
 			resource.Status.Conditions.SetCondition(core.Component{
 				Detail:  err.Error(),
@@ -114,7 +117,7 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 				Status:  core.FailureStatus,
 			})
 
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		if !found {
@@ -127,10 +130,11 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 				})
 				resource.Status.Status = core.PendingStatus
 
-				return true, nil
+				return reconcile.Result{Requeue: true}, nil
 			}
 
 			logger.Debug("creating a new gke cluster in gcp")
+
 			if _, err = client.Create(ctx); err != nil {
 				logger.WithError(err).Error("attempting to create cluster")
 
@@ -142,15 +146,38 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 				})
 				resource.Status.Status = core.FailureStatus
 
-				return false, err
+				return reconcile.Result{}, err
 			}
-		} else {
-			// else we are updating it
-			if err := client.Update(ctx); err != nil {
-				logger.WithError(err).Error("attempting to update cluster")
 
-				return false, err
-			}
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+
+		cluster, _, err := client.GetCluster(ctx)
+		if err != nil {
+			logger.WithError(err).Error("trying to retrieve the cluster status")
+
+			return reconcile.Result{}, err
+		}
+		logger.WithField("status", cluster.Status).Debug("the current state of the gke cluster is")
+
+		switch cluster.Status {
+		case "PROVISIONING":
+			resource.Status.Status = core.PendingStatus
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		case "RECONCILING":
+			resource.Status.Status = core.PendingStatus
+			return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
+		case "ERROR":
+			resource.Status.Status = core.FailureStatus
+			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+		case "STOPPING":
+			resource.Status.Status = core.DeletingStatus
+			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+		case "RUNNING":
+		default:
+			logger.Warn("cluster is in an unknown state, choosing to requeue instead")
+
+			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 
 		// @step: enable the cloud-nat is required
@@ -159,7 +186,7 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 			if err := client.EnableCloudNAT(); err != nil {
 				logger.WithError(err).Error("trying to ensure the cloud-nat device")
 
-				return false, err
+				return reconcile.Result{}, err
 			}
 
 			logger.Info("cluster has private networking enabled, ensuring a api firewall rules")
@@ -167,21 +194,23 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 			if err := client.EnableFirewallAPIServices(); err != nil {
 				logger.WithError(err).Error("creating firewall rules for api extensions")
 
-				return false, err
+				return reconcile.Result{}, err
 			}
 		}
 
-		// @step: retrieve the cluster spec
-		cluster, found, err := client.GetCluster()
+		// @step: we check the current state against the desired and see if we need to ammend
+		updating, err := client.Update(ctx)
 		if err != nil {
-			logger.WithError(err).Error("trying to retrieve the gke cluster")
+			logger.WithError(err).Error("attempting to update cluster")
 
-			return false, err
+			return reconcile.Result{}, err
 		}
-		if !found {
-			logger.Warn("gke cluster was not found")
+		if updating {
+			logger.Debug("cluster is performing a update")
 
-			return true, nil
+			resource.Status.Status = core.PendingStatus
+
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
 		resource.Status.CACertificate = cluster.MasterAuth.ClusterCaCertificate
@@ -208,13 +237,13 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 		if err != nil {
 			logger.WithError(err).Error("trying to create bootstrap client")
 
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		if err := controllers.NewBootstrap(bc).Run(ctx, t.mgr.GetClient()); err != nil {
 			logger.WithError(err).Error("trying to bootstrap gke cluster")
 
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		resource.Status.Conditions.SetCondition(core.Component{
@@ -223,18 +252,17 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 			Status:  core.SuccessStatus,
 		})
 
-		return false, nil
+		return reconcile.Result{}, nil
 	}()
 	if err != nil {
 		resource.Status.Status = core.FailureStatus
 	}
 
-	if err := t.mgr.GetClient().Status().Update(ctx, resource); err != nil {
+	if err := t.mgr.GetClient().Status().Patch(ctx, resource, client.MergeFrom(original)); err != nil {
 		logger.WithError(err).Error("updating the status of gke cluster")
 
 		return reconcile.Result{}, err
 	}
-
 	if err == nil {
 		if finalizer.NeedToAdd(resource) {
 			logger.Info("adding our finalizer to the team resource")
@@ -247,11 +275,7 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 		}
 	}
 
-	if requeue {
-		return reconcile.Result{Requeue: true}, nil
-	}
-
-	return reconcile.Result{}, nil
+	return result, nil
 }
 
 // GetCredentials returns the cloud credential

--- a/pkg/controllers/cloud/gcp/gke/reconcile.go
+++ b/pkg/controllers/cloud/gcp/gke/reconcile.go
@@ -167,12 +167,13 @@ func (t *gkeCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 		case "RECONCILING":
 			resource.Status.Status = core.PendingStatus
 			return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
-		case "ERROR":
-			resource.Status.Status = core.FailureStatus
-			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		case "STOPPING":
 			resource.Status.Status = core.DeletingStatus
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+		case "ERROR":
+			resource.Status.Status = core.FailureStatus
+			// @choice .. allowing it to run though here as it's in error but might require
+			// an update to fix
 		case "RUNNING":
 		default:
 			logger.Warn("cluster is in an unknown state, choosing to requeue instead")

--- a/pkg/utils/structs.go
+++ b/pkg/utils/structs.go
@@ -80,11 +80,6 @@ func GetRuntimeObject(o interface{}) (runtime.Object, error) {
 	return mo, nil
 }
 
-// IsChanged is shorthand for the below
-func IsChanged(v interface{}) bool {
-	return IsEmpty(v)
-}
-
 // IsEmpty checks if a struct has any values set
 func IsEmpty(v interface{}) bool {
 	t := reflect.ValueOf(v).Elem()

--- a/pkg/utils/structs.go
+++ b/pkg/utils/structs.go
@@ -87,7 +87,7 @@ func IsChanged(v interface{}) (bool, error) {
 		return false, err
 	}
 
-	return empty == false, nil
+	return !empty, nil
 }
 
 // IsEmpty checks if a struct has any values set

--- a/pkg/utils/structs.go
+++ b/pkg/utils/structs.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,7 +63,7 @@ func GetMetaObject(obj interface{}) (metav1.Object, error) {
 		return nil, ErrNotMetaObject
 	}
 
-	return mo, nil
+	return empty == false, nil
 }
 
 // GetRuntimeObject returns the runtime.Object
@@ -77,4 +78,32 @@ func GetRuntimeObject(o interface{}) (runtime.Object, error) {
 	}
 
 	return mo, nil
+}
+
+// IsChanged is shorthand for the below
+func IsChanged(v interface{}) (bool, error) {
+	empty, err := IsEmpty(v)
+	if err != nil {
+		return false, err
+	}
+
+	return empty == false, nil
+}
+
+// IsEmpty checks if a struct has any values set
+func IsEmpty(v interface{}) (bool, error) {
+	if v == nil {
+		return false, errors.New("no struct defined")
+	}
+
+	t := reflect.ValueOf(v).Elem()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsValid() || !field.IsZero() {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/pkg/utils/structs.go
+++ b/pkg/utils/structs.go
@@ -63,7 +63,7 @@ func GetMetaObject(obj interface{}) (metav1.Object, error) {
 		return nil, ErrNotMetaObject
 	}
 
-	return empty == false, nil
+	return mo, nil
 }
 
 // GetRuntimeObject returns the runtime.Object
@@ -81,29 +81,20 @@ func GetRuntimeObject(o interface{}) (runtime.Object, error) {
 }
 
 // IsChanged is shorthand for the below
-func IsChanged(v interface{}) (bool, error) {
-	empty, err := IsEmpty(v)
-	if err != nil {
-		return false, err
-	}
-
-	return !empty, nil
+func IsChanged(v interface{}) bool {
+	return IsEmpty(v)
 }
 
 // IsEmpty checks if a struct has any values set
-func IsEmpty(v interface{}) (bool, error) {
-	if v == nil {
-		return false, errors.New("no struct defined")
-	}
-
+func IsEmpty(v interface{}) bool {
 	t := reflect.ValueOf(v).Elem()
 
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		if !field.IsValid() || !field.IsZero() {
-			return false, nil
+			return false
 		}
 	}
 
-	return true, nil
+	return true
 }

--- a/pkg/utils/structs_test.go
+++ b/pkg/utils/structs_test.go
@@ -24,8 +24,10 @@ import (
 )
 
 type testStruct struct {
-	Name string `json:"name"`
-	Age  int    `json:"age"`
+	Name   string   `json:"name"`
+	Age    int      `json:"age"`
+	Things []string `json:"things"`
+	Ref    *string  `json:"things"`
 }
 
 func TestConvertToMapOK(t *testing.T) {
@@ -42,4 +44,28 @@ func TestConvertToMapOK(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, values)
 	assert.Equal(t, expected, values)
+}
+
+func TestIsStructEmpty(t *testing.T) {
+	message := "hello world"
+
+	cases := []struct {
+		Item     testStruct
+		Expected bool
+	}{
+		{Expected: true, Item: testStruct{}},
+		{Expected: false, Item: testStruct{Name: "hello"}},
+		{Expected: false, Item: testStruct{Age: 32}},
+		{Expected: false, Item: testStruct{Age: 32, Name: "hello"}},
+		{Expected: true, Item: testStruct{Things: nil}},
+		{Expected: false, Item: testStruct{Things: []string{"hello"}}},
+		{Expected: true, Item: testStruct{Ref: nil}},
+		{Expected: false, Item: testStruct{Ref: &message}},
+	}
+	for _, c := range cases {
+		empty, err := IsEmpty(&c.Item)
+		require.NoError(t, err)
+		assert.Equal(t, c.Expected, empty)
+	}
+
 }

--- a/pkg/utils/structs_test.go
+++ b/pkg/utils/structs_test.go
@@ -63,9 +63,7 @@ func TestIsStructEmpty(t *testing.T) {
 		{Expected: false, Item: testStruct{Ref: &message}},
 	}
 	for _, c := range cases {
-		empty, err := IsEmpty(&c.Item)
-		require.NoError(t, err)
-		assert.Equal(t, c.Expected, empty)
+		assert.Equal(t, c.Expected, IsEmpty(&c.Item))
 	}
 
 }


### PR DESCRIPTION
The current implementation use's blocking delete, update and create call. This removes those blocks and uses the current state to dictate next move.

862013e9 GKE Reconcilation Loop
88452697 - fixing up the gke delete

### Testing 

Just need to build and delete an GKE cluster