### PR TITLE
Embed required files for korectl local into distribution zips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,10 +110,13 @@ push-images:
 
 release-cli:
 	@echo "--> Compiling CLI static binaries"
-	rm -rf ./cli-release
+	@rm -rf ./cli-release
 	CGO_ENABLED=0 go run github.com/mitchellh/gox -arch="${CLI_ARCHITECTURES}" -os="${CLI_PLATFORMS}" -ldflags "-w ${LFLAGS}" -output=./cli-release/arch/{{.OS}}_{{.Arch}}_${VERSION}/{{.Dir}} ./cmd/korectl/
-	mkdir ./cli-release/output/
-	cd ./cli-release && for f in `ls -1 ./arch/`; do zip -j -m output/korectl_$$f.zip arch/$$f/*; done
+	@mkdir ./cli-release/output/
+	@for f in `ls -1 ./cli-release/arch/`; do \
+		zip -j -m cli-release/output/korectl_$$f.zip cli-release/arch/$$f/*; \
+		zip -ur cli-release/output/korectl_$$f.zip hack/compose/* hack/ca/* hack/kubeconfig.local hack/setup/**/*; \
+	done
 	cd ./cli-release/output && sha256sum *.zip > korectl.sha256sums
 
 push-cli:


### PR DESCRIPTION
Also update quickstart guide to reflect changes. Addresses #324 remaining open items.

To test without tagging a release:

1. Run make release-cli
2. cd ./cli-release/output
3. Unzip relevant zip file for your machine.
4. Follow steps in the updated alpha readme in this PR.

cc @ezodude to take a look at my updates to the alpha quickstart, @lewismarshall to check he's happy with how we're bundling the compose files into the zip (by simply zipping them for now) and @gambol99 to check I've not missed any files from hack required for local (basically included the compose folder and the CA folder).

Tested on mac amd64, all working correctly for a korectl local environment.