### PR TITLE
Reenable errcheck linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,3 @@ issues:
   exclude:
     - "not declared by package utf8"
     - "unicode/utf8/utf8.go"
-
-linters:
-  disable:
-    - errcheck

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,6 @@ require (
 	google.golang.org/grpc v1.27.0
 	gopkg.in/resty.v1 v1.12.0
 	gopkg.in/yaml.v2 v2.2.8
-	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.17.0
 	k8s.io/apiextensions-apiserver v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/pkg/cmd/kore/completion.go
+++ b/pkg/cmd/kore/completion.go
@@ -46,7 +46,9 @@ func NewCmdCompletionsBash(factory cmdutil.Factory) *cobra.Command {
 		Example: "source <(kore completion bash)",
 
 		Run: func(cmd *cobra.Command, args []string) {
-			root.GenBashCompletion(factory.Writer())
+			if err := root.GenBashCompletion(factory.Writer()); err != nil {
+				panic(err)
+			}
 		},
 	}
 
@@ -61,7 +63,9 @@ func NewCmdCompletionsZsh(factory cmdutil.Factory) *cobra.Command {
 		Example: "source <(kore completion zsh)",
 
 		Run: func(cmd *cobra.Command, args []string) {
-			root.GenZshCompletion(factory.Writer())
+			if err := root.GenZshCompletion(factory.Writer()); err != nil {
+				panic(err)
+			}
 		},
 	}
 

--- a/pkg/cmd/kore/create/admin.go
+++ b/pkg/cmd/kore/create/admin.go
@@ -47,7 +47,7 @@ func NewCmdCreateAdmin(factory cmdutils.Factory) *cobra.Command {
 
 	flags := command.Flags()
 	flags.StringVarP(&o.Username, "username", "u", "", "The username of the person being added to the team")
-	command.MarkFlagRequired("username")
+	cmdutils.MustMarkFlagRequired(command, "username")
 
 	return command
 }

--- a/pkg/cmd/kore/create/cluster.go
+++ b/pkg/cmd/kore/create/cluster.go
@@ -116,7 +116,7 @@ func NewCmdCreateCluster(factory cmdutil.Factory) *cobra.Command {
 	cmdutils.MustMarkFlagRequired(command, "plan")
 
 	// @step: register the autocompletions
-	command.RegisterFlagCompletionFunc("allocation", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
+	cmdutils.MustRegisterFlagCompletionFunc(command, "allocation", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
 		list := &configv1.AllocationList{}
 		if err := o.Client().Team(cmdutil.GetTeam(cmd)).Resource("allocation").Result(list).Get().Error(); err != nil {
 			return nil, cobra.BashCompDirectiveError
@@ -133,7 +133,7 @@ func NewCmdCreateCluster(factory cmdutil.Factory) *cobra.Command {
 	})
 
 	// @TODO would be nice to filter on the allocation here as well - i.e. chosen GKE, only show GKE plans etc
-	command.RegisterFlagCompletionFunc("plan", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
+	cmdutils.MustRegisterFlagCompletionFunc(command, "plan", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
 		suggestions, err := o.Resources().LookupResourceNames("plan", "")
 		if err != nil {
 			return nil, cobra.BashCompDirectiveError

--- a/pkg/cmd/kore/create/cluster.go
+++ b/pkg/cmd/kore/create/cluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/appvia/kore/pkg/apiserver/types"
 	"github.com/appvia/kore/pkg/cmd/errors"
 	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
 
 	"github.com/spf13/cobra"
 	apiexts "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -111,8 +112,8 @@ func NewCmdCreateCluster(factory cmdutil.Factory) *cobra.Command {
 	flags.StringSliceVar(&o.Namespaces, "namespaces", []string{}, "used to override the plan parameters `KEY=VALUE`")
 	flags.BoolVarP(&o.ShowTime, "show-time", "T", false, "shows the time it took to successfully provision a new cluster `BOOL`")
 
-	command.MarkFlagRequired("allocation")
-	command.MarkFlagRequired("plan")
+	cmdutils.MustMarkFlagRequired(command, "allocation")
+	cmdutils.MustMarkFlagRequired(command, "plan")
 
 	// @step: register the autocompletions
 	command.RegisterFlagCompletionFunc("allocation", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {

--- a/pkg/cmd/kore/create/member.go
+++ b/pkg/cmd/kore/create/member.go
@@ -50,7 +50,7 @@ func NewCmdCreateMember(factory cmdutils.Factory) *cobra.Command {
 	flags.StringVarP(&o.Username, "username", "u", "", "the username of the person being added to the team")
 	flags.BoolVarP(&o.Invite, "invite", "i", true, "if the user doesn't exist an invitation url will be automatically generated")
 
-	command.MarkFlagRequired("username")
+	cmdutils.MustMarkFlagRequired(command, "username")
 
 	command.RegisterFlagCompletionFunc("username", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
 		if len(complete) < 3 {

--- a/pkg/cmd/kore/create/member.go
+++ b/pkg/cmd/kore/create/member.go
@@ -52,7 +52,7 @@ func NewCmdCreateMember(factory cmdutils.Factory) *cobra.Command {
 
 	cmdutils.MustMarkFlagRequired(command, "username")
 
-	command.RegisterFlagCompletionFunc("username", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
+	cmdutils.MustRegisterFlagCompletionFunc(command, "username", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
 		if len(complete) < 3 {
 			return nil, cobra.BashCompDirectiveDefault
 		}

--- a/pkg/cmd/kore/create/namespace.go
+++ b/pkg/cmd/kore/create/namespace.go
@@ -80,7 +80,7 @@ func NewCmdCreateNamespace(factory cmdutil.Factory) *cobra.Command {
 	cmdutils.MustMarkFlagRequired(command, "cluster")
 
 	// @step: add auto complete on the cluster name
-	command.RegisterFlagCompletionFunc("cluster", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
+	cmdutils.MustRegisterFlagCompletionFunc(command, "cluster", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
 		suggestions, err := o.Resources().LookupResourceNames("cluster", cmdutil.GetTeam(cmd))
 		if err != nil {
 			return nil, cobra.BashCompDirectiveError

--- a/pkg/cmd/kore/create/namespace.go
+++ b/pkg/cmd/kore/create/namespace.go
@@ -23,6 +23,7 @@ import (
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 	"github.com/appvia/kore/pkg/cmd/errors"
 	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,7 +77,7 @@ func NewCmdCreateNamespace(factory cmdutil.Factory) *cobra.Command {
 	}
 
 	command.Flags().StringVarP(&o.Cluster, "cluster", "c", "", "the name of the cluster you are creating the namespace on `NAME`")
-	command.MarkFlagRequired("cluster")
+	cmdutils.MustMarkFlagRequired(command, "cluster")
 
 	// @step: add auto complete on the cluster name
 	command.RegisterFlagCompletionFunc("cluster", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {

--- a/pkg/cmd/kore/create/secret.go
+++ b/pkg/cmd/kore/create/secret.go
@@ -28,6 +28,7 @@ import (
 
 	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
 	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -89,7 +90,7 @@ func NewCmdCreateSecret(factory cmdutil.Factory) *cobra.Command {
 	flags.StringVar(&o.File, "from-file", "", "builds a secret from the key reference `KEY=PATH`")
 	flags.StringVar(&o.File, "from-env-file", "", "builds a secret from the environment file, `KEY=PATH`")
 
-	command.MarkFlagRequired("description")
+	cmdutils.MustMarkFlagRequired(command, "description")
 
 	return command
 }

--- a/pkg/cmd/kore/create/user.go
+++ b/pkg/cmd/kore/create/user.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
-	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
 	"github.com/appvia/kore/pkg/kore"
 	"github.com/appvia/kore/pkg/utils"
 
@@ -40,8 +40,8 @@ $ kore create username test -e test@appiva.io
 
 // CreateUserOptions is used to provision a team
 type CreateUserOptions struct {
-	cmdutil.Factory
-	cmdutil.DefaultHandler
+	cmdutils.Factory
+	cmdutils.DefaultHandler
 	// Name is the username to add
 	Name string
 	// Email is the user email address
@@ -51,7 +51,7 @@ type CreateUserOptions struct {
 }
 
 // NewCmdCreateUser returns the create user command
-func NewCmdCreateUser(factory cmdutil.Factory) *cobra.Command {
+func NewCmdCreateUser(factory cmdutils.Factory) *cobra.Command {
 	o := &CreateUserOptions{Factory: factory}
 
 	command := &cobra.Command{
@@ -59,12 +59,12 @@ func NewCmdCreateUser(factory cmdutil.Factory) *cobra.Command {
 		Short:   "Adds to the user to kore",
 		Long:    userLongDesciption,
 		Example: "kore create user <username> -e <email> [-t team]",
-		PreRunE: cmdutil.RequireName,
-		Run:     cmdutil.DefaultRunFunc(o),
+		PreRunE: cmdutils.RequireName,
+		Run:     cmdutils.DefaultRunFunc(o),
 	}
 
 	command.Flags().StringVarP(&o.Email, "email", "e", "", "an email address for the user `EMAIL`")
-	command.MarkFlagRequired("email")
+	cmdutils.MustMarkFlagRequired(command, "email")
 
 	// @step: register the autocompletions
 	command.RegisterFlagCompletionFunc("email", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {

--- a/pkg/cmd/kore/create/user.go
+++ b/pkg/cmd/kore/create/user.go
@@ -67,7 +67,7 @@ func NewCmdCreateUser(factory cmdutils.Factory) *cobra.Command {
 	cmdutils.MustMarkFlagRequired(command, "email")
 
 	// @step: register the autocompletions
-	command.RegisterFlagCompletionFunc("email", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
+	cmdutils.MustRegisterFlagCompletionFunc(command, "email", func(cmd *cobra.Command, args []string, complete string) ([]string, cobra.BashCompDirective) {
 		name := cmd.Flags().Arg(0)
 		if name == "" {
 			return []string{}, cobra.BashCompDirectiveNoFileComp

--- a/pkg/cmd/kore/delete/delete_admin.go
+++ b/pkg/cmd/kore/delete/delete_admin.go
@@ -17,33 +17,33 @@
 package delete
 
 import (
-	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
 
 	"github.com/spf13/cobra"
 )
 
 // DeleteAdminOptions the are the options for a delete command
 type DeleteAdminOptions struct {
-	cmdutil.Factory
-	cmdutil.DefaultHandler
+	cmdutils.Factory
+	cmdutils.DefaultHandler
 	// Username of the user you are removing as an admin
 	Username string
 }
 
 // NewCmdDeleteAdmin creates and returns the delete admin command
-func NewCmdDeleteAdmin(factory cmdutil.Factory) *cobra.Command {
+func NewCmdDeleteAdmin(factory cmdutils.Factory) *cobra.Command {
 	o := &DeleteAdminOptions{Factory: factory}
 
 	command := &cobra.Command{
 		Use:     "admin",
 		Short:   "Delete a user from being an admin in kore",
 		Example: "kore delete admin --username|-u <username>",
-		Run:     cmdutil.DefaultRunFunc(o),
+		Run:     cmdutils.DefaultRunFunc(o),
 	}
 
 	flags := command.Flags()
 	flags.StringVarP(&o.Username, "username", "u", "", "the user you wish to remove from being an admin `USERNAME`")
-	command.MarkFlagRequired("username")
+	cmdutils.MustMarkFlagRequired(command, "username")
 
 	return command
 }

--- a/pkg/cmd/kore/kore.go
+++ b/pkg/cmd/kore/kore.go
@@ -30,7 +30,7 @@ import (
 	"github.com/appvia/kore/pkg/cmd/kore/kubeconfig"
 	"github.com/appvia/kore/pkg/cmd/kore/login"
 	"github.com/appvia/kore/pkg/cmd/kore/profiles"
-	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
 	"github.com/appvia/kore/pkg/utils/render"
 	"github.com/appvia/kore/pkg/version"
 
@@ -43,7 +43,7 @@ var (
 )
 
 // NewKoreCommand creates and returns the kore command
-func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
+func NewKoreCommand(streams cmdutils.Streams) (*cobra.Command, error) {
 	// @step: create or read in the client configuration
 	config, err := config.GetOrCreateClientConfiguration()
 	if err != nil {
@@ -56,7 +56,7 @@ func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
 	}
 
 	// @step: create a factory for the commands
-	factory, err := cmdutil.NewFactory(client, streams, *config)
+	factory, err := cmdutils.NewFactory(client, streams, *config)
 	if err != nil {
 		return nil, err
 	}
@@ -67,13 +67,13 @@ func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
 		Short:        "kore provides a cli for the " + version.Prog,
 		Example:      "kore command [options] [-t|--team]",
 		SilenceUsage: true,
-		Run:          cmdutil.RunHelp,
+		Run:          cmdutils.RunHelp,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if cmdutil.GetVerbose(cmd) {
+			if cmdutils.GetVerbose(cmd) {
 				log.SetLevel(log.DebugLevel)
 			}
-			if cmdutil.GetDebug(cmd) {
+			if cmdutils.GetDebug(cmd) {
 				log.SetLevel(log.TraceLevel)
 			}
 
@@ -108,7 +108,7 @@ func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
 	)
 
 	// @step: seriously cobra is pretty damn awesome
-	root.RegisterFlagCompletionFunc("team", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.BashCompDirective) {
+	cmdutils.MustRegisterFlagCompletionFunc(root, "team", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.BashCompDirective) {
 		list, err := factory.Resources().LookupResourceNames("team", "")
 		if err != nil {
 			return nil, cobra.BashCompDirectiveError
@@ -117,7 +117,7 @@ func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
 		return list, cobra.BashCompDirectiveDefault
 	})
 
-	root.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.BashCompDirective) {
+	cmdutils.MustRegisterFlagCompletionFunc(root, "output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.BashCompDirective) {
 		return render.SupportedFormats(), cobra.BashCompDirectiveDefault
 	})
 

--- a/pkg/cmd/utils/helper.go
+++ b/pkg/cmd/utils/helper.go
@@ -30,12 +30,12 @@ import (
 
 // RunHelp is shorthand for displaying the usage
 func RunHelp(cmd *cobra.Command, args []string) {
-	cmd.Help()
+	_ = cmd.Help()
 }
 
 // RunHelpE is shorthand for display the usage but with error return
 func RunHelpE(cmd *cobra.Command, args []string) error {
-	cmd.Help()
+	_ = cmd.Help()
 
 	return nil
 }
@@ -84,7 +84,7 @@ func PreRunEFilters() func(*cobra.Command, []string) error {
 // RequireName ensures a name positional argument
 func RequireName(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		cmd.Help()
+		_ = cmd.Help()
 
 		return errors.ErrMissingResourceName
 	}

--- a/pkg/cmd/utils/helper.go
+++ b/pkg/cmd/utils/helper.go
@@ -99,6 +99,16 @@ func MustMarkFlagRequired(cmd *cobra.Command, name string) {
 	}
 }
 
+func MustRegisterFlagCompletionFunc(
+	cmd *cobra.Command,
+	flagName string,
+	f func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.BashCompDirective),
+) {
+	if err := cmd.RegisterFlagCompletionFunc(flagName, f); err != nil {
+		panic(err)
+	}
+}
+
 // ParseDocument returns a collection of parsed documents and the api endpoints
 func ParseDocument(f Factory, src io.Reader) ([]*ResourceDocument, error) {
 	var list []*ResourceDocument

--- a/pkg/cmd/utils/helper.go
+++ b/pkg/cmd/utils/helper.go
@@ -92,6 +92,13 @@ func RequireName(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// MustMarkFlagRequired calls MarkFlagRequired and panics if it returns an error
+func MustMarkFlagRequired(cmd *cobra.Command, name string) {
+	if err := cmd.MarkFlagRequired(name); err != nil {
+		panic(err)
+	}
+}
+
 // ParseDocument returns a collection of parsed documents and the api endpoints
 func ParseDocument(f Factory, src io.Reader) ([]*ResourceDocument, error) {
 	var list []*ResourceDocument


### PR DESCRIPTION
## What

The errcheck linter is a cheap way to catch some trivial bugs, so I think we should keep it.