### PR TITLE
Minor changes to look and wording of create cluster page

### DIFF
--- a/ui/__tests__/lib/components/forms/ClusterBuildForm.test.js
+++ b/ui/__tests__/lib/components/forms/ClusterBuildForm.test.js
@@ -53,15 +53,15 @@ describe('ClusterBuildForm', () => {
       // Check API has been accessed as expected.
       apiScope.done()
       expect(form.state.plans).toEqual(plans)
-      expect(form.state.providers.GKE).toEqual([{ ...allocations[0] }])
-      expect(form.state.providers.EKS).toEqual([{ ...allocations[1] }])
+      expect(form.state.credentials.GKE).toEqual([{ ...allocations[0] }])
+      expect(form.state.credentials.EKS).toEqual([{ ...allocations[1] }])
     })
   })
 
   describe('#getClusterResource', () => {
     it('should return a configured cluster object when given valid values', () => {
       form.handleSelectCloud('GKE')
-      const cluster = form.getClusterResource({ provider: 'GKE', plan: plans.items[0].metadata.name, clusterName: 'abc-test-cluster' })
+      const cluster = form.getClusterResource({ credential: 'GKE', plan: plans.items[0].metadata.name, clusterName: 'abc-test-cluster' })
       expect(cluster).toBeDefined()
     })
   })

--- a/ui/assets/styles.less
+++ b/ui/assets/styles.less
@@ -15,3 +15,48 @@
 .top-header {
   background-color: @kore-primary-color;
 }
+
+.cloud-card {
+  height: 100%;
+
+  .ant-card-body {
+    height: inherit;
+
+    .unavailable {
+      text-align: center;
+      opacity: 0.3;
+    }
+
+    .logo {
+      text-align: center;
+    }
+
+    .name {
+      text-align: center;
+      margin-top: 20px;
+    }
+  }
+
+  &.selected {
+    border: 1px solid #999999;
+
+    .ant-card-body {
+      background-color: #f0f2f5
+    }
+  }
+}
+
+.coming-soon {
+  height: inherit;
+  position: absolute;
+  z-index: 1;
+  left: 0;
+  width: 100%;
+  text-align: center;
+
+  .ant-tag {
+    font-size: 18px;
+    font-weight: bold;
+    padding: 5px;
+  }
+}

--- a/ui/lib/components/cluster-build/CloudSelector.js
+++ b/ui/lib/components/cluster-build/CloudSelector.js
@@ -7,57 +7,34 @@ class CloudSelector extends React.Component {
   static propTypes = {
     selectedCloud: PropTypes.string.isRequired,
     handleSelectCloud: PropTypes.func.isRequired,
-    providers: PropTypes.object,
+    credentials: PropTypes.object,
     showCustom: PropTypes.bool
   }
 
-  selectCloud = (cloud) => {
-    return () => {
-      this.props.handleSelectCloud(cloud)
-    }
-  }
+  selectCloud = cloud => () => this.props.handleSelectCloud(cloud)
 
   render() {
-    const { selectedCloud, providers, showCustom } = this.props
+    const { selectedCloud, credentials, showCustom } = this.props
 
-    const getCardStyle = cloud => {
-      const style = {
-        height: '100%'
-      }
-      if (selectedCloud === cloud) {
-        style.border = '1px solid #999999'
-      }
-      return style
-    }
-
-    const getCardBodyStyle = cloud => {
-      const style = {
-        height: 'inherit'
-      }
-      if (selectedCloud === cloud) {
-        style.backgroundColor = '#f0f2f5'
-      }
-      return style
-    }
-
-    const Providers = ({ cloud }) => {
-      if (!providers) {
+    const Credentials = ({ cloud }) => {
+      if (!credentials) {
         return null
       }
-      const cloudProviderCount = providers[cloud].length
+      const credType = cloud === 'GKE' ? 'project' : 'account'
+      const cloudProviderCount = credentials[cloud].length
       return (
         <Paragraph style={{ textAlign: 'center', marginTop: '20px', marginBottom: '0' }}>
           {cloudProviderCount > 0 ?
-            <Tag color="#87d068">{cloudProviderCount} providers</Tag> :
-            <Text type="warning">No providers</Text>
+            <Tag color="#87d068">{cloudProviderCount} {credType} credential{cloudProviderCount > 1 ? 's' : ''}</Tag> :
+            <Text type="warning">No credentials</Text>
           }
         </Paragraph>
       )
     }
 
     const ComingSoon = () => (
-      <div style={{ height: 'inherit', position: 'absolute', zIndex: '1', top: '10px', left: '0', width: '100%', textAlign: 'center' }}>
-        <Tag style={{ fontSize: '18px', fontWeight: 'bold', padding: '5px' }} color="#2db7f5">Coming soon!</Tag>
+      <div className="coming-soon">
+        <Tag color="#2db7f5">Coming soon!</Tag>
       </div>
     )
 
@@ -65,59 +42,55 @@ class CloudSelector extends React.Component {
       <Row gutter={16} type="flex" justify="center" style={{ marginTop: '40px', marginBottom: '40px' }}>
         <Col span={6}>
           <Card
-            style={getCardStyle('GKE')}
             onClick={this.selectCloud('GKE')}
-            bodyStyle={getCardBodyStyle('GKE')}
             hoverable={true}
+            className={ selectedCloud === 'GKE' ? 'cloud-card selected' : 'cloud-card' }
           >
-            <Paragraph style={{ textAlign: 'center' }}>
-              <img src="/static/images/GKE.png" height="80px" />
+            <Paragraph className="logo">
+              <img src="/static/images/GCP.png" height="80px" />
             </Paragraph>
-            <Paragraph strong style={{ textAlign: 'center', marginTop: '20px', marginBottom: '0' }}>Google Kubernetes Engine</Paragraph>
-            <Providers cloud="GKE" />
+            <Paragraph className="name" strong>Google Cloud Platform</Paragraph>
+            <Credentials cloud="GKE" />
           </Card>
         </Col>
         <Col span={6}>
           <Card
-            style={getCardStyle('EKS')}
             onClick={this.selectCloud('EKS')}
-            bodyStyle={getCardBodyStyle('EKS')}
             hoverable={true}
+            className={ selectedCloud === 'EKS' ? 'cloud-card selected' : 'cloud-card' }
           >
-            <Paragraph style={{ textAlign: 'center' }}>
-              <img src="/static/images/EKS.png" height="80px" />
+            <Paragraph className="logo">
+              <img src="/static/images/AWS.png" height="80px" />
             </Paragraph>
-            <Paragraph strong style={{ textAlign: 'center', marginTop: '20px', marginBottom: '0' }}>Elastic Kubernetes Service</Paragraph>
-            <Providers cloud="EKS" />
+            <Paragraph className="name" strong>Amazon Web Services</Paragraph>
+            <Credentials cloud="EKS" />
           </Card>
         </Col>
         <Col span={6}>
           <Card
-            style={getCardStyle('AKS')}
-            bodyStyle={getCardBodyStyle('AKS')}
             hoverable={false}
+            className={ selectedCloud === 'AKS' ? 'cloud-card selected' : 'cloud-card' }
           >
-            <ComingSoon />
-            <div style={{ opacity: '0.3' }}>
-              <Paragraph style={{ textAlign: 'center' }}>
-                <img src="/static/images/AKS.svg" height="80px" />
+            <div className="unavailable">
+              <Paragraph style={{ paddingBottom: '15px', marginTop: '15px' }}>
+                <img src="/static/images/Azure.svg" height="50px" />
               </Paragraph>
-              <Paragraph strong style={{ textAlign: 'center', marginTop: '20px', marginBottom: '0' }}>Azure Kubernetes Service</Paragraph>
+              <Paragraph strong style={{ textAlign: 'center', marginTop: '20px', marginBottom: '0' }}>Microsoft Azure</Paragraph>
             </div>
+            <ComingSoon />
           </Card>
         </Col>
         {showCustom ? (
           <Col span={6}>
             <Card
-              style={getCardStyle('CUSTOM')}
-              bodyStyle={getCardBodyStyle('CUSTOM')}
               hoverable={false}
+              className={ selectedCloud === 'CUSTOM' ? 'cloud-card selected' : 'cloud-card' }
             >
-              <ComingSoon />
-              <div style={{ textAlign: 'center', opacity: '0.3' }}>
+              <div className="unavailable">
                 <Title level={3} style={{ paddingTop: '30px', height: '80px' }}>Custom</Title>
                 <Paragraph strong style={{ marginTop: '20px' }}>Bring your own cluster</Paragraph>
               </div>
+              <ComingSoon />
             </Card>
           </Col>
         ) : null}

--- a/ui/lib/components/cluster-build/ClusterOptionsForm.js
+++ b/ui/lib/components/cluster-build/ClusterOptionsForm.js
@@ -12,7 +12,8 @@ class ClusterOptionsForm extends React.Component {
   static propTypes = {
     form: PropTypes.any.isRequired,
     team: PropTypes.object.isRequired,
-    providers: PropTypes.array.isRequired,
+    selectedCloud: PropTypes.string.isRequired,
+    credentials: PropTypes.array.isRequired,
     plans: PropTypes.array.isRequired,
     teamClusters: PropTypes.array.isRequired,
     onPlanOverridden: PropTypes.func,
@@ -20,8 +21,8 @@ class ClusterOptionsForm extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    // Reset the selected plan if the provider changes:
-    if (this.props.providers !== prevProps.providers) {
+    // Reset the selected plan if the credential changes:
+    if (this.props.credentials !== prevProps.credentials) {
       this.props.form.setFieldsValue({ 'plan': null })
     }
   }
@@ -61,7 +62,7 @@ class ClusterOptionsForm extends React.Component {
 
   render() {
     const { getFieldDecorator, getFieldValue } = this.props.form
-    const { providers, plans } = this.props
+    const { credentials, plans } = this.props
     const selectedPlan = getFieldValue('plan')
 
     const checkForDuplicateName = (rule, value) => {
@@ -73,14 +74,14 @@ class ClusterOptionsForm extends React.Component {
     }
 
     return (
-      <Card title="Choose a provider and plan">
-        <Form.Item label="Provider">
-          {getFieldDecorator('provider', {
-            rules: [{ required: true, message: 'Please select your provider!' }],
-            initialValue: providers.length === 1 ? providers[0].metadata.name : undefined
+      <Card title="Cluster options">
+        <Form.Item label="Credential">
+          {getFieldDecorator('credential', {
+            rules: [{ required: true, message: 'Please select your credential!' }],
+            initialValue: credentials.length === 1 ? credentials[0].metadata.name : undefined
           })(
-            <Select placeholder="Provider">
-              {providers.map(provider => <Option key={provider.metadata.name} value={provider.metadata.name}>{provider.spec.name} - {provider.spec.summary}</Option>)}
+            <Select placeholder="Credential">
+              {credentials.map(c => <Option key={c.metadata.name} value={c.metadata.name}>{c.spec.name} - {c.spec.summary}</Option>)}
             </Select>
           )}
         </Form.Item>

--- a/ui/lib/components/cluster-build/MissingCredential.js
+++ b/ui/lib/components/cluster-build/MissingCredential.js
@@ -2,11 +2,11 @@ import Link from 'next/link'
 import PropTypes from 'prop-types'
 import { Alert, Button } from 'antd'
 
-const MissingProvider = ({ team }) => (
+const MissingCredential = ({ team }) => (
   <div>
     <Alert
-      message="No providers found"
-      description="No providers could be found allocated to this team, therefore you cannot request a cluster build at this time. Please continue to the team dashboard."
+      message="No credentials found"
+      description="No credentials could be found allocated to this team, therefore you cannot request a cluster build at this time. Please continue to the team dashboard."
       type="info"
       showIcon
       style={{ marginBottom: '20px' }}
@@ -19,8 +19,8 @@ const MissingProvider = ({ team }) => (
   </div>
 )
 
-MissingProvider.propTypes = {
+MissingCredential.propTypes = {
   team: PropTypes.string.isRequired
 }
 
-export default MissingProvider
+export default MissingCredential


### PR DESCRIPTION
* choose from a cloud provider at the top, rather then k8s service
* more usage of CSS classes to prevent lots of inline style
* renaming from providers to credentials (I think this makes more sense)

More refactoring of this page will happen when we add project creation

<img width="1055" alt="Screen Shot 2020-04-15 at 11 25 10" src="https://user-images.githubusercontent.com/1334068/79327134-d7327f00-7f0b-11ea-8308-871bd45a29c9.png">

<img width="1066" alt="Screen Shot 2020-04-15 at 11 25 21" src="https://user-images.githubusercontent.com/1334068/79327138-d8fc4280-7f0b-11ea-8877-d83562a901eb.png">

