### PR TITLE
Bug Cluster Controller

### DIFF
--- a/pkg/controllers/management/cluster/reconcile.go
+++ b/pkg/controllers/management/cluster/reconcile.go
@@ -194,10 +194,11 @@ func (a *Controller) loadComponent(ctx context.Context, cluster *clustersv1.Clus
 
 // createOrUpdateComponent is responsible for maintaining the components
 func (a *Controller) createOrUpdateComponent(ctx context.Context, cluster *clustersv1.Cluster, resource clustersv1.ClusterComponent) error {
-	found, err := kubernetes.CheckIfExists(ctx, a.mgr.GetClient(), resource)
+	found, err := kubernetes.CheckIfExists(ctx, a.mgr.GetClient(), resource.DeepCopyObject())
 	if err != nil {
 		return err
 	}
+
 	if !found {
 		setClusterResourceVersion(resource, cluster.ResourceVersion)
 


### PR DESCRIPTION
- we introduced a regressive bug in https://github.com/appvia/kore/pull/527/files#diff-9ea9eead3dbf6972775d3b10acfdc388R197 as we are not deepcopying and thus overwriting the change

### Testing

```shell
[jest@starfury kore]$ kore get cluster dev -o json | jq '.spec'^C
[jest@starfury kore]$ kore get cluster dev -o json | jq '.spec.configuration.authProxyAllowedIPs'
[
  "0.0.0.0/0"
]
[jest@starfury kore]$ kore edit cluster dev
clusters.compute.kore.appvia.io/v1/dev no changes
[jest@starfury kore]$ kore get kubernetes dev -o json | jq '.spec.authProxyAllowedIPs'
[
  "0.0.0.0/0"
]
[jest@starfury kore]$ kore edit cluster dev
clusters.compute.kore.appvia.io/v1/dev configured
[jest@starfury kore]$ kore get kubernetes dev -o json | jq '.spec.authProxyAllowedIPs'
[
  "1.1.1.1/32"
]
```

PR https://github.com/appvia/kore/pull/527 which caused the bug