### PR TITLE
Fixing cluster access guide in the UI

### DIFF
--- a/charts/kore/templates/portal.yml
+++ b/charts/kore/templates/portal.yml
@@ -68,6 +68,8 @@ spec:
           {{- end }}
         - name: KORE_API_URL
           value: http://{{ include "kore.name" . }}-apiserver:10080/api/v1alpha1
+        - name: KORE_API_PUBLIC_URL
+          {{- if and (eq .Values.api.serviceType "LoadBalancer") .Values.api.endpoint.detect}}
         - name: KORE_API_TOKEN
           valueFrom:
             secretKeyRef:

--- a/ui/config.js
+++ b/ui/config.js
@@ -25,6 +25,7 @@ module.exports = {
   },
   koreApi: {
     url: process.env.KORE_API_URL || 'http://localhost:10080/api/v1alpha1',
+    publicUrl: process.env.KORE_API_PUBLIC_URL || 'http://localhost:10080',
     token: process.env.KORE_API_TOKEN || 'password'
   }
 }

--- a/ui/server/controllers/session.js
+++ b/ui/server/controllers/session.js
@@ -15,7 +15,7 @@ function getSessionUser(orgService) {
 
 function getConfig(koreApi) {
   return (req, res) => {
-    res.json({ apiUrl: koreApi.url })
+    res.json({ apiUrl: koreApi.publicUrl })
   }
 }
 


### PR DESCRIPTION
* it should show the publicly accessible API URL
* adding this to the portal deployment in the helm chart so it can be used by the UI