### PR TITLE
EKS Reconcilation Loop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ parameters:
     type: boolean
     default: false
 
+#
+# Templates ---
+#
+
 services: &SERVICES
   - image: circleci/golang:1.14
   - name: etcd
@@ -71,6 +75,76 @@ service_env: &SERVICES_ENV
   KORE_UI_PUBLIC_URL: "http://localhost:3000"
   KUBE_API_SERVER: "http://kube-apiserver:8080"
   USERS_DB_URL: "root:pass@tcp(database:3306)/kore?parseTime=true"
+
+e2e_job_template: &E2E_JOB_TEMPLATE
+  parameters:
+    enable_eks:
+      type: boolean
+      default: false
+    enable_gke:
+      type: boolean
+      default: false
+    host:
+      type: string
+      default: http://127.0.0.1:10080
+
+  environment:
+    ENABLE_EKS_E2E: << parameters.enable_eks >>
+    ENABLE_GKE_E2E: << parameters.enable_gke >>
+    GOFLAGS: "-mod=vendor"
+    KORE_ADMIN_TOKEN: "password"
+    KORE_API_PUBLIC_URL_QA: << parameters.host >>
+
+  docker:
+    *SERVICES
+
+  steps:
+    - checkout
+    - run:
+        name: Installing tools
+        command: |
+          sudo apt install -y bash bats curl jq
+    - run:
+        name: Installing kubectl
+        command: |
+          sudo curl -L https://storage.googleapis.com/kubernetes-release/release/v1.15.11/bin/linux/amd64/kubectl -o /bin/kubectl
+          sudo chmod +x /bin/kubectl
+    - run:
+        name: Building binaries
+        command: |
+          make kore-apiserver
+          make kore
+          sudo cp bin/kore /bin/kore
+          /bin/kubectl version --client
+    - run:
+        name: Running the Kore API
+        command: |
+          export AUTH_PROXY_IMAGE="quay.io/appvia/auth-proxy:${CIRCLE_SHA1}"
+          export CLUSTERAPPMAN_IMAGE="quay.io/appvia/kore-apiserver:${CIRCLE_SHA1}"
+          bin/kore-apiserver --disable-json-logging --verbose
+        background: true
+        environment:
+          <<: *SERVICES_ENV
+    - run:
+        name: Waiting for API
+        command: |
+          curl -s \
+            --retry 10 \
+            --retry-connrefused \
+            --retry-delay 5 \
+            ${KORE_API_PUBLIC_URL_QA}/healthz
+    - run:
+        name: Running E2E Suite
+        no_output_timeout: 30m
+        command: |
+          test/e2e/check-suite.sh \
+            --enable-e2e-user ${KORE_E2E_USER} \
+            --enable-gke ${ENABLE_GKE_E2E} \
+            --enable-eks ${ENABLE_EKS_E2E}
+
+#
+# Jobs ---
+#
 
 jobs:
   build:
@@ -305,71 +379,11 @@ jobs:
             VERSION=${CIRCLE_SHA1} make images
             VERSION=${CIRCLE_SHA1} make push-images
 
-  e2e:
-    parameters:
-      enable_eks:
-        type: boolean
-        default: false
-      enable_gke:
-        type: boolean
-        default: false
-      host:
-        type: string
-        default: http://127.0.0.1:10080
+  e2e_gke:
+    <<: *E2E_JOB_TEMPLATE
 
-    environment:
-      ENABLE_EKS_E2E: << parameters.enable_eks >>
-      ENABLE_GKE_E2E: << parameters.enable_gke >>
-      GOFLAGS: "-mod=vendor"
-      KORE_ADMIN_TOKEN: "password"
-      KORE_API_PUBLIC_URL_QA: << parameters.host >>
-
-    docker:
-      *SERVICES
-
-    steps:
-      - checkout
-      - run:
-          name: Installing tools
-          command: |
-            sudo apt install -y bash bats curl jq
-      - run:
-          name: Installing kubectl
-          command: |
-            sudo curl -L https://storage.googleapis.com/kubernetes-release/release/v1.15.11/bin/linux/amd64/kubectl -o /bin/kubectl
-            sudo chmod +x /bin/kubectl
-      - run:
-          name: Building binaries
-          command: |
-            make kore-apiserver
-            make kore
-            sudo cp bin/kore /bin/kore
-            /bin/kubectl version --client
-      - run:
-          name: Running the Kore API
-          command: |
-            export AUTH_PROXY_IMAGE="quay.io/appvia/auth-proxy:${CIRCLE_SHA1}"
-            export CLUSTERAPPMAN_IMAGE="quay.io/appvia/kore-apiserver:${CIRCLE_SHA1}"
-            bin/kore-apiserver --disable-json-logging --verbose
-          background: true
-          environment:
-            <<: *SERVICES_ENV
-      - run:
-          name: Waiting for API
-          command: |
-            curl -s \
-              --retry 10 \
-              --retry-connrefused \
-              --retry-delay 5 \
-              ${KORE_API_PUBLIC_URL_QA}/healthz
-      - run:
-          name: Running E2E Suite
-          no_output_timeout: 30m
-          command: |
-            test/e2e/check-suite.sh \
-              --enable-e2e-user ${KORE_E2E_USER} \
-              --enable-gke ${ENABLE_GKE_E2E} \
-              --enable-eks ${ENABLE_EKS_E2E}
+  e2e_eks:
+    <<: *E2E_JOB_TEMPLATE
 
 workflows:
   version: 2.1
@@ -431,7 +445,7 @@ workflows:
     when: << pipeline.parameters.enable_gke_e2e >>
     jobs:
       - e2e-images
-      - e2e:
+      - e2e_gke:
           enable_gke: true
           requires:
             - e2e-images
@@ -440,8 +454,7 @@ workflows:
     when: << pipeline.parameters.enable_eks_e2e >>
     jobs:
       - e2e-images
-      - e2e:
+      - e2e_eks:
           enable_eks: true
           requires:
             - e2e-images
-

--- a/pkg/controllers/cloud/aws/eks/ensure.go
+++ b/pkg/controllers/cloud/aws/eks/ensure.go
@@ -19,7 +19,6 @@ package eks
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"time"
 
@@ -136,7 +135,7 @@ func (t *eksCtrl) EnsureCluster(client *aws.Client, cluster *eks.EKS) controller
 			})
 			cluster.Status.Status = corev1.FailureStatus
 
-			return reconcile.Result{}, errors.New("cluster has failed to provision")
+			return reconcile.Result{}, nil
 
 		case awseks.ClusterStatusCreating, awseks.ClusterStatusUpdating:
 			cluster.Status.Status = corev1.PendingStatus

--- a/pkg/controllers/cloud/aws/eks/ensure.go
+++ b/pkg/controllers/cloud/aws/eks/ensure.go
@@ -146,7 +146,7 @@ func (t *eksCtrl) EnsureCluster(client *aws.Client, cluster *eks.EKS) controller
 			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
-		// @step: has the desired state drited from the current
+		// @step: has the desired state drifted from the current
 		needupdate, err := client.Update(ctx)
 		if err != nil {
 			logger.WithError(err).Error("trying check or perform an update on the eks cluster")

--- a/pkg/controllers/cloud/aws/eks/reconcile.go
+++ b/pkg/controllers/cloud/aws/eks/reconcile.go
@@ -120,11 +120,8 @@ func (t *eksCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 
 		return reconcile.Result{}, err
 	}
-	if err != nil {
-		return reconcile.Result{}, err
-	}
 
-	return result, nil
+	return result, err
 }
 
 // GetClusterClient returns a EKS cluster client

--- a/pkg/controllers/cloud/aws/eks/reconcile.go
+++ b/pkg/controllers/cloud/aws/eks/reconcile.go
@@ -93,7 +93,8 @@ func (t *eksCtrl) Reconcile(request reconcile.Request) (reconcile.Result, error)
 		ensure := []controllers.EnsureFunc{
 			t.EnsureResourcePending(resource),
 			t.EnsureClusterRoles(resource),
-			t.EnsureCluster(client, resource),
+			t.EnsureClusterCreation(client, resource),
+			t.EnsureClusterInSync(client, resource),
 			t.EnsureClusterBootstrap(client, resource),
 		}
 

--- a/pkg/controllers/cloud/aws/eksnodegroup/ensure.go
+++ b/pkg/controllers/cloud/aws/eksnodegroup/ensure.go
@@ -268,6 +268,7 @@ func (n *ctrl) EnsureDeletion(group *eks.EKSNodeGroup) controllers.EnsureFunc {
 		status := utils.StringValue(state.Status)
 
 		switch status {
+
 		case awseks.NodegroupStatusActive, awseks.NodegroupStatusCreateFailed, awseks.NodegroupStatusDegraded:
 			if err := client.DeleteNodeGroup(ctx, group); err != nil {
 				logger.WithError(err).Error("trying to delete the nodegroup")

--- a/pkg/utils/cloud/aws/eks.go
+++ b/pkg/utils/cloud/aws/eks.go
@@ -224,6 +224,7 @@ func (c *Client) Update(ctx context.Context) (bool, error) {
 	}()
 
 	update := &awseks.UpdateClusterConfigInput{
+		Name: aws.String(c.cluster.Name),
 		ResourcesVpcConfig: &awseks.VpcConfigRequest{
 			PublicAccessCidrs: accessCIDR,
 		},

--- a/pkg/utils/cloud/aws/eks.go
+++ b/pkg/utils/cloud/aws/eks.go
@@ -248,10 +248,12 @@ func (c *Client) Update(ctx context.Context) (bool, error) {
 			if _, err := c.svc.UpdateClusterConfigWithContext(ctx, update); err != nil {
 				return false, err
 			}
+
+			return true, nil
 		}
 	}
 
-	return true, nil
+	return false, nil
 }
 
 // VerifyCredentials is responsible for verifying AWS creds

--- a/pkg/utils/slices.go
+++ b/pkg/utils/slices.go
@@ -16,6 +16,8 @@
 
 package utils
 
+import "sort"
+
 // Contains checks a list has a value in it
 func Contains(v string, l []string) bool {
 	for _, x := range l {
@@ -62,4 +64,14 @@ func Unique(items []string) []string {
 	}
 
 	return list
+}
+
+// StringsSorted returns a 'copy' of a sorted list of strings
+func StringsSorted(list []string) []string {
+	v := make([]string, len(list))
+	copy(v, list)
+
+	sort.Strings(v)
+
+	return v
 }

--- a/pkg/utils/slices_test.go
+++ b/pkg/utils/slices_test.go
@@ -35,3 +35,11 @@ func TestContainsBad(t *testing.T) {
 
 	assert.False(t, Contains("d", list))
 }
+
+func TestStringsSorted(t *testing.T) {
+	a := []string{"a", "c", "b"}
+	expected := []string{"a", "b", "c"}
+	v := StringsSorted(a)
+	assert.Equal(t, []string{"a", "c", "b"}, a)
+	assert.Equal(t, expected, v)
+}

--- a/test/e2e/check-suite.sh
+++ b/test/e2e/check-suite.sh
@@ -18,6 +18,9 @@
 source test/e2e/environment.sh || exit 1
 
 # These are being used across the checks
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID_QA}
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_QA}
+export AWS_DEFAULT_REGION="eu-west-2"
 export CLUSTER="ci-${CIRCLE_BUILD_NUM:-$USER}"
 export E2E_DIR="e2eci"
 export KORE_API_URL=${KORE_API_PUBLIC_URL_QA:-"http://127.0.0.1:10080"}

--- a/test/e2e/integration/auth-proxy.bats
+++ b/test/e2e/integration/auth-proxy.bats
@@ -22,17 +22,11 @@ setup() {
 }
 
 @test "We should be able to retrieve the namespaces from the cluster" {
-  if ${KORE} get clusters ${CLUSTER} -t ${TEAM} -o yaml | grep 1.1.1.1; then
-    skip
-  fi
   runit "${KUBECTL} --context=${CLUSTER} get ns"
   [[ "$status" -eq 0 ]]
 }
 
 @test "We should not be about to access to the cluster with an invalid token" {
-  if ${KORE} get clusters ${CLUSTER} -t ${TEAM} -o yaml | grep 1.1.1.1; then
-    skip
-  fi
   runit "${KUBECTL} --context=${CLUSTER} --token=invalid get no 2>&1 | grep '^Error from server (Forbidden)'"
   [[ "$status" -eq 0 ]]
 }
@@ -56,18 +50,10 @@ setup() {
 }
 
 @test "If we change the auth-proxy allowed range we should lose access to the cluster" {
-  tempfile="${BASE_DIR}/${E2E_DIR}/gke.auth"
-
   if ! ${KORE} get clusters ${CLUSTER} -t ${TEAM} -o yaml | grep 1.1.1.1; then
     runit "${KUBECTL} --context=${CLUSTER} get nodes"
     [[ "$status" -eq 0 ]]
-    runit "${KORE} get clusters ${CLUSTER} -t ${TEAM} -o yaml > ${tempfile}"
-    [[ "$status" -eq 0 ]]
-    runit "sed -i -e '0,/0.0.0.0/{s/0.0.0.0\/0/1.1.1.1\/32/}' ${tempfile}"
-    [[ "$status" -eq 0 ]]
-    runit "grep 1.1.1.1 ${tempfile}"
-    [[ "$status" -eq 0 ]]
-    runit "${KORE} apply -f ${tempfile} -t ${TEAM}"
+    runit "${KORE} alpha patch clusters ${CLUSTER} spec.configuration.authProxyAllowedIPs.0 1.1.1.1/32 -t ${TEAM}
     [[ "$status" -eq 0 ]]
   fi
   retry 10 "${KUBECTL} --context=${CLUSTER} get nodes 2>&1 | grep '^Error from server (Forbidden)'"
@@ -75,17 +61,7 @@ setup() {
 }
 
 @test "If we revert the allowed network range back, we should see the cluster again" {
-  tempfile=${BASE_DIR}/${E2E_DIR}/gke.auth
-
-  runit "${KORE} get clusters ${CLUSTER} -t ${TEAM} -o yaml > ${tempfile}"
-  [[ "$status" -eq 0 ]]
-  runit "sed -i -e '0,/1.1.1.1/{s/1.1.1.1\/32/0.0.0.0\/0/}' ${tempfile}"
-  [[ "$status" -eq 0 ]]
-  runit "${KORE} apply -f ${tempfile} -t ${TEAM}"
-  [[ "$status" -eq 0 ]]
-  retry 20 "${KUBECTL} --context=${CLUSTER} get nodes"
-  [[ "$status" -eq 0 ]]
-  runit "rm -f ${tempfile} || false"
+  runit "${KORE} alpha patch clusters ${CLUSTER} spec.configuration.authProxyAllowedIPs.0 0.0.0.0/0 -t ${TEAM}
   [[ "$status" -eq 0 ]]
   retry 10 "${KUBECTL} --context=${CLUSTER} get nodes 2>&1"
   [[ "$status" -eq 0 ]]

--- a/test/e2e/integration/auth-proxy.bats
+++ b/test/e2e/integration/auth-proxy.bats
@@ -53,7 +53,7 @@ setup() {
   if ! ${KORE} get clusters ${CLUSTER} -t ${TEAM} -o yaml | grep 1.1.1.1; then
     runit "${KUBECTL} --context=${CLUSTER} get nodes"
     [[ "$status" -eq 0 ]]
-    runit "${KORE} alpha patch clusters ${CLUSTER} spec.configuration.authProxyAllowedIPs.0 1.1.1.1/32 -t ${TEAM}
+    runit "${KORE} alpha patch clusters ${CLUSTER} spec.configuration.authProxyAllowedIPs.0 1.1.1.1/32 -t ${TEAM}"
     [[ "$status" -eq 0 ]]
   fi
   retry 10 "${KUBECTL} --context=${CLUSTER} get nodes 2>&1 | grep '^Error from server (Forbidden)'"
@@ -61,7 +61,7 @@ setup() {
 }
 
 @test "If we revert the allowed network range back, we should see the cluster again" {
-  runit "${KORE} alpha patch clusters ${CLUSTER} spec.configuration.authProxyAllowedIPs.0 0.0.0.0/0 -t ${TEAM}
+  runit "${KORE} alpha patch clusters ${CLUSTER} spec.configuration.authProxyAllowedIPs.0 0.0.0.0/0 -t ${TEAM}"
   [[ "$status" -eq 0 ]]
   retry 10 "${KUBECTL} --context=${CLUSTER} get nodes 2>&1"
   [[ "$status" -eq 0 ]]

--- a/test/e2e/integration/eks.bats
+++ b/test/e2e/integration/eks.bats
@@ -35,6 +35,8 @@ setup() {
 }
 
 @test "We should be able to build a cluster in EKS" {
+  ${KORE} get cluster ${CLUSTER} -t ${TEAM} && skip
+
   runit "${KORE} create cluster ${CLUSTER} -t ${TEAM} -a aws -p eks-development --no-wait"
   [[ "$status" -eq 0 ]]
 }
@@ -103,7 +105,7 @@ setup() {
 }
 
 @test "We should see the number of nodes change when I update the desired state" {
-  runit "${KORE} alpha patch cluster ${CLUSTER} spec.nodeGroups.0.desiredSize 2"
+  runit "${KORE} alpha patch cluster ${CLUSTER} spec.configuration.nodeGroups.0.desiredSize 2"
   [[ "$status" -eq 0 ]]
   retry 60 "${KUBECTL} --context=${CLUSTER} get nodes --no-headers | grep Ready | wc -l | grep 2"
   [[ "$status" -eq 0 ]]

--- a/test/e2e/integration/eks.bats
+++ b/test/e2e/integration/eks.bats
@@ -101,3 +101,11 @@ setup() {
   runit "${KUBECTL} --context=${CLUSTER} get psp eks.privileged"
   [[ "$status" -eq 0 ]]
 }
+
+@test "We should see the number of nodes change when I update the desired state" {
+  runit "${KORE} alpha patch cluster ${CLUSTER} spec.nodeGroups.0.desiredSize 2"
+  [[ "$status" -eq 0 ]]
+  retry 60 "${KUBECTL} --context=${CLUSTER} get nodes --no-headers | grep Ready | wc -l | grep 2"
+  [[ "$status" -eq 0 ]]
+}
+

--- a/test/e2e/integration/eks.bats
+++ b/test/e2e/integration/eks.bats
@@ -111,3 +111,85 @@ setup() {
   [[ "$status" -eq 0 ]]
 }
 
+#
+### Disabling for now as this add almost 15 minutes to the E2E .. honestly how can it take
+# 15 MINUTES to update a firewall rule
+#
+#@test "We should be able to update the authorized master list of eks and lose access" {
+#  cat <<EOF > /tmp/plan-policy
+#---
+#apiVersion: config.kore.appvia.io/v1
+#kind: PlanPolicy
+#metadata:
+#  name: eks-open
+#spec:
+#  description: Allows changing the AuthorizedMasterNetworks
+#  summary: Allows changing the AuthorizedMasterNetworks
+#  kind: EKS
+#  properties:
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: authorizedMasterNetworks
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: authProxyAllowedIPs
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: clusterUsers
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: defaultTeamRole
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: description
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: domain
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: nodeGroups
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: privateIPV4Cidr
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: region
+#  - allowUpdate: true
+#    disallowUpdate: false
+#    name: version
+#---
+#apiVersion: config.kore.appvia.io/v1
+#kind: Allocation
+#metadata:
+#  name: eks-open
+#spec:
+#  name: eks-open
+#  resource:
+#    group: config.kore.appvia.io
+#    kind: PlanPolicy
+#    name: eks-open
+#    namespace: kore-admin
+#    version: v1
+#  summary: Allows changing the authorizedMasterNetworks
+#  teams:
+#    - '*'
+#EOF
+#  [[ "$status" -eq 0 ]]
+#  runit "${KORE} apply -f /tmp/plan-policy -t kore-admin"
+#  [[ "$status" -eq 0 ]]
+#  runit "${KORE} alpha patch cluster ${CLUSTER} spec.configuration.authorizedMasterNetworks.0 1.1.1.1/32"
+#  [[ "$status" -eq 0 ]]
+#  retry 60 "aws eks describe-cluster --name ${CLUSTER} | jq -r '.cluster.resourcesVpcConfig.publicAccessCidrs[0]' | grep '1.1.1.1/32'"
+#  [[ "$status" -eq 0 ]]
+#}
+#
+#@test "We should be able to revert the change back and restore access" {
+#  runit "${KORE} delete -f /tmp/plan-policy -t kore-admin"
+#  [[ "$status" -eq 0 ]]
+#  runit "${KORE} alpha patch cluster ${CLUSTER} spec.configuration.authorizedMasterNetworks.0 0.0.0/0"
+#  [[ "$status" -eq 0 ]]
+#  retry 60 "aws eks describe-cluster --name ${CLUSTER} | jq -r '.cluster.resourcesVpcConfig.publicAccessCidrs[0]' | grep '0.0.0.0/0'"
+#  [[ "$status" -eq 0 ]]
+#  runit "rm -f /tmp/plan-policy"
+#  [[ "$status" -eq 0 ]]
+#}

--- a/test/trigger-e2e.sh
+++ b/test/trigger-e2e.sh
@@ -24,10 +24,10 @@ ENABLE_EKS_E2E="false"
 usage() {
   cat <<EOF
   Usage: $(basename $0)
-  --branch <name>      : the branch to run the e2e on (defaults: ${BRANCH})
-  --enable-gke <bool>  : indicates we should run e2e on gke builds (defaults: ${ENABLE_GKE_E2E})
-  --enable-eks <bool>  : indicates we should run e2e on eks (defaults: ${ENABLE_EKS_E2E})
-  -h|--help            : display this usage menu
+  --branch <name>   : the branch to run the e2e on (defaults: ${BRANCH})
+  --enable-gke      : indicates we should run e2e on gke builds (defaults: ${ENABLE_GKE_E2E})
+  --enable-eks      : indicates we should run e2e on eks (defaults: ${ENABLE_EKS_E2E})
+  -h|--help         : display this usage menu
 EOF
   if [[ -n $@ ]]; then
     echo "[error] $@"


### PR DESCRIPTION
EKS Reconciliation Loop

Much like the change the eksnodegroup, this changed the reconcile loop to state based, no long running wait and uses re-queues to ensure exit

- removal of long waits
- added the eks update code to update the version and vpc settings
