### PR TITLE
Delete EKS NodeGroup from an existing cluster if it was removed from the configuration

### DIFF
--- a/pkg/apis/core/v1/status_types.go
+++ b/pkg/apis/core/v1/status_types.go
@@ -157,6 +157,14 @@ func (c Components) GetComponent(name string) (*Component, bool) {
 	return nil, false
 }
 
+func (c *Components) RemoveComponent(name string) {
+	for i, x := range *c {
+		if x.Name == name {
+			*c = append((*c)[:i], (*c)[i+1:]...)
+		}
+	}
+}
+
 func (c Components) Error() error {
 	var messages []string
 	for _, c := range c {


### PR DESCRIPTION
## What

This is missing from the current reconcile loop.

The controller will monitor the component status and remove the component from the cluster's status if it was deleted.