### PR TITLE
Fixing the missing jwks_uri issue

### DIFF
--- a/ui/config.js
+++ b/ui/config.js
@@ -1,3 +1,20 @@
+const getOpenidURL = () => {
+  const envValue = process.env.KORE_IDP_SERVER_URL
+  if (!envValue) {
+    return 'https://my-openid-domain.com'
+  }
+  // the URL is already correct
+  if (envValue.indexOf('.well-known/openid-configuration') !== -1) {
+    return envValue
+  }
+  // check if we need to add trailing slash to the URL before adding the required path
+  let suffix = '.well-known/openid-configuration'
+  if (envValue.lastIndexOf('/') !== envValue.length - 1) {
+    suffix = `/${suffix}`
+  }
+  return `${envValue}${suffix}`
+}
+
 module.exports = {
   server: {
     port: process.env.PORT || '3000',
@@ -10,7 +27,7 @@ module.exports = {
   auth: {
     embedded: process.env.KORE_UI_USE_EMBEDDED_AUTH === 'true' || false,
     openid: {
-      url: process.env.KORE_IDP_SERVER_URL || 'https://my-openid-domain.com',
+      url: getOpenidURL(),
       callbackURL: process.env.KORE_CALLBACK_URL || 'http://localhost:3000/auth/callback',
       clientID: process.env.KORE_IDP_CLIENT_ID || 'my-openid-client-id',
       clientSecret: process.env.KORE_IDP_CLIENT_SECRET || 'my-openid-client-secret',


### PR DESCRIPTION
This came to light when using Okta as an IDP.

When given an OpenID URL the openid-client will setup an Issuer.
If the URL contains `.well-known/openid-configuration` then it will load the config from that endpoint.

If, as in our case the URL set in the config did not contain `.well-known/openid-configuration`, it will load the config from one of `/.well-known/openid-configuration` or `/.well-known/oauth-authorization-server`, depending on which one responds first (no joke)

The latter endpoint, `/.well-known/oauth-authorization-server`, did not have the same config ie. it was missing the `jwks_uri`

This meant that it was pretty much down to luck as to whether the Issuer was setup with the `jwks_uri` or not.
The Issuer is configured once per restart which is why restarting appeared to fix the issue

As a fix for this I've added some additional logic around the `KORE_IDP_SERVER_URL` env var that's used in the config, to ensure it either already contains `.well-known/openid-configuration` or it is appended.