### PR TITLE
Run the kore-apiserver on localhost when you run it locally

### DIFF
--- a/hack/bin/run-api-with-env.sh
+++ b/hack/bin/run-api-with-env.sh
@@ -18,6 +18,7 @@ export \
     KORE_IDP_CLIENT_SCOPES
 
 ./bin/kore-apiserver \
+    --listen localhost:10080 \
     --kube-api-server http://127.0.0.1:8080 \
     --verbose \
     --admin-pass password \


### PR DESCRIPTION
This will stop my Mac OS firewall popping up every time I start the server.