### PR TITLE
Implement local command on kore CLI

### DIFF
--- a/pkg/cmd/kore/assets/local_compose.go
+++ b/pkg/cmd/kore/assets/local_compose.go
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package assets
+
+// LocalCompose is used by the local start/stop commands to run kore locally in Docker Compose.
+const LocalCompose = `
+---
+version: '3'
+services:
+  etcd:
+    image: bitnami/etcd:3.4.4
+    environment:
+      ALLOW_NONE_AUTHENTICATION: "yes"
+    ports:
+      - 2379:2379
+
+  kube-controller-manager:
+    image: gcr.io/google-containers/kube-controller-manager-amd64:v1.15.11
+    command:
+      - /usr/local/bin/kube-controller-manager
+      - --master=http://kube-apiserver:8080
+
+  kube-apiserver:
+    image: gcr.io/google-containers/kube-apiserver-amd64:v1.15.11
+    command:
+      - /usr/local/bin/kube-apiserver
+      - --address=0.0.0.0
+      - --alsologtostderr
+      - --authorization-mode=RBAC
+      - --bind-address=0.0.0.0
+      - --default-watch-cache-size=200
+      - --delete-collection-workers=10
+      - --etcd-servers=http://etcd:2379
+      - --log-flush-frequency=10s
+      - --runtime-config=autoscaling/v1=false
+      - --runtime-config=autoscaling/v2beta1=false
+      - --runtime-config=autoscaling/v2beta2=false
+      - --runtime-config=batch/v1=false
+      - --runtime-config=batch/v1beta1=false
+      - --runtime-config=networking.k8s.io/v1=false
+      - --runtime-config=networking.k8s.io/v1beta1=false
+      - --runtime-config=node.k8s.io/v1beta1=false
+    ports:
+      - 8080:8080
+      - 6443:6443
+
+  database:
+    image: mariadb:10.5.1
+    environment:
+      MYSQL_ROOT_PASSWORD: pass
+    entrypoint:
+      sh -c "
+        echo 'CREATE DATABASE IF NOT EXISTS kore;' > /docker-entrypoint-initdb.d/init.sql;
+        /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
+    ports:
+      - 3306:3306
+
+  kore-apiserver:
+    image: quay.io/appvia/kore-apiserver:${KORE_TAG}
+    environment:
+      KORE_ADMIN_PASS: password
+      KORE_ADMIN_TOKEN: password
+      KORE_API_PUBLIC_URL: http://localhost:10080
+      KORE_UI_PUBLIC_URL: http://localhost:3000
+      KORE_AUTHENTICATION_PLUGINS: basicauth,admintoken,openid
+      KORE_CERTIFICATE_AUTHORITY: ca/ca.pem
+      KORE_CERTIFICATE_AUTHORITY_KEY: ca/ca-key.pem
+      KUBE_API_SERVER: http://kube-apiserver:8080
+      USERS_DB_URL: root:pass@tcp(database:3306)/kore?parseTime=true
+      VERBOSE: 'true'
+      KORE_IDP_CLIENT_ID: ${KORE_IDP_CLIENT_ID}
+      KORE_IDP_CLIENT_SECRET: ${KORE_IDP_CLIENT_SECRET}
+      KORE_IDP_SERVER_URL: ${KORE_IDP_SERVER_URL}
+      KORE_IDP_USER_CLAIMS: preferred_username,email,name,username
+      KORE_IDP_CLIENT_SCOPES: email,profile,offline_access
+    ports:
+      - 10080:10080
+    restart: always
+    # Used to source in the test certificate authority
+    volumes:
+      - ${KORE_LOCAL_HOME}/ca:/ca
+
+  kore-ui:
+    image: quay.io/appvia/kore-ui:${KORE_TAG}
+    environment:
+      KORE_BASE_URL: http://localhost:3000
+      KORE_API_URL: http://kore-apiserver:10080/api/v1alpha1
+      KORE_API_TOKEN: password
+      REDIS_URL: redis://redis:6379
+      KORE_IDP_CLIENT_ID: ${KORE_IDP_CLIENT_ID}
+      KORE_IDP_CLIENT_SECRET: ${KORE_IDP_CLIENT_SECRET}
+      KORE_IDP_SERVER_URL: ${KORE_IDP_SERVER_URL}
+      KORE_IDP_USER_CLAIMS: preferred_username,email,name,username
+      KORE_IDP_CLIENT_SCOPES: email,profile,offline_access
+    ports:
+      - 3000:3000
+    restart: always
+
+  redis:
+    image: redis:5
+    ports:
+      - 6379:6379
+    restart: always
+
+  dex-operator:
+    image: quay.io/appvia/dex:v2.20.0-master_grpc-connectors
+    working_dir: /
+    command:
+      - serve
+      - ./dex/config.yaml
+    restart: always
+    ports:
+      - 5556:5556
+      - 5557:5557
+    volumes:
+      - ${KORE_LOCAL_HOME}/dex:/dex
+`

--- a/pkg/cmd/kore/assets/local_support.go
+++ b/pkg/cmd/kore/assets/local_support.go
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package assets
+
+// LocalSupport indexes all of the required files for a local setup to run.
+var LocalSupport = map[string]string{
+	"dex/config.yaml":      LocalDexConfig,
+	"dex/kubeconfig.local": LocalKubeConfigFile,
+	"ca/ca.pem":            LocalDummyCAPEM,
+	"ca/ca-key.pem":        LocalDummyCAPEMKey,
+}
+
+// LocalDexConfig is used by the local start command.
+const LocalDexConfig = `
+# DEX config file
+issuer: http://localhost:5556/
+storage:
+  type: kubernetes
+  config:
+    kubeConfigFile: ./dex/kubeconfig.local
+  waitForResources: true
+web:
+  http: 0.0.0.0:5556
+oauth2:
+  skipApprovalScreen: true
+grpc:
+  # Cannot be the same address as an HTTP(S) service.
+  addr: 0.0.0.0:5557
+  # Server certs. If TLS credentials aren't provided dex will run in plaintext (HTTP) mode.
+  #tlsCert: /etc/dex/grpc.crt
+  #tlsKey: /etc/dex/grpc.key
+  # Client auth CA.
+  #tlsClientCA: /etc/dex/client.crt
+  # enable reflection
+  reflection: true
+enablePasswordDB: true
+logger:
+  level: "debug"
+`
+
+// LocalKubeConfigFile is used by the local start command.
+const LocalKubeConfigFile = `
+apiVersion: v1
+clusters:
+- cluster:
+    server: http://kube-apiserver:8080
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: local
+  name: local
+current-context: local
+kind: Config
+preferences: {}
+users:
+- name: local
+`
+
+// LocalDummyCAPEM is used by the local start command.
+const LocalDummyCAPEM = `
+-----BEGIN CERTIFICATE-----
+MIID6TCCAtGgAwIBAgIUUyy/2cR/bI6TxoE6UCdBHei7V7AwDQYJKoZIhvcNAQEL
+BQAwgYMxCzAJBgNVBAYTAkdCMQswCQYDVQQIDAJHQjEPMA0GA1UEBwwGTG9uZG9u
+MRMwEQYDVQQKDApBcHB2aWEgTHRkMQswCQYDVQQLDAJJVDEVMBMGA1UEAwwMY2Eu
+YXBwdmlhLmlvMR0wGwYJKoZIhvcNAQkBFg5pbmZvQGFwcHZpYS5pbzAeFw0yMDAx
+MjExMjUzMzlaFw0yODA0MDgxMjUzMzlaMIGDMQswCQYDVQQGEwJHQjELMAkGA1UE
+CAwCR0IxDzANBgNVBAcMBkxvbmRvbjETMBEGA1UECgwKQXBwdmlhIEx0ZDELMAkG
+A1UECwwCSVQxFTATBgNVBAMMDGNhLmFwcHZpYS5pbzEdMBsGCSqGSIb3DQEJARYO
+aW5mb0BhcHB2aWEuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDN
+iQatCOO9HdKyqFt/kqP/8wM3ZvcWwoacq+/YrwTHM07PyyG0+Lc+LoxBVtIVJUbA
+yuTAma2rtTEEY1CbMPCrGfLXiSlALh/2HASgd/eO/XH0WgJorlnbJ8+Fr1dGjU8i
+7Xn3Wo6WFvs2s2D+Qu1/KpaCqbKZ4ltB7CLz3kp0cSBzVKVenrwQHEeeQKD7rjY1
+zuAZeagsKANpz9ksg1xqGFBiODJclWVBUr9Pti57oaXmlCL3C4biWcdWheUc8c+1
+Ml9LSwx9cL3Wq6V7zcNj6M5oIVWjtzaCiVnJMep/uU+TlEIqnoPkcyfXSe6rs2v+
+FRixU4vBuZKO0aR0TCO5AgMBAAGjUzBRMB0GA1UdDgQWBBSAsZSsPIt1To3WWK2q
+sf+rN14JLjAfBgNVHSMEGDAWgBSAsZSsPIt1To3WWK2qsf+rN14JLjAPBgNVHRMB
+Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBUrroaM9EjtSNLI9jFX66Hne8g
+VB0D7+C7O69lfisfy6wtBaYJOTaWWdb1BTWI0SzWCmKhxjconvVn043ypnfDoqSS
+f8c7yYxnN/yBvgiotZ/QkXkweZR1/sYTK+pcOw5c6zH9eK0KsVKWtyFDwhYS/hA2
+wymDlSBXYHD7/VjcUH4UYIqILDGjFEm11z5Wxzrxvokdx9KXj47NdmkLONV7yvNR
+dzlB9KWIEipea4R3z12Mjrio//i9vkNNtpTVUKyPe5uKZvjEIsALqAMoi6ITiYpI
+rPcsVye6WJkym/wBRdjXu/mgXIQ7bT5GLsw4STIhNpJtYQ/IghFRAco9W+q4
+-----END CERTIFICATE-----
+`
+
+// LocalDummyCAPEMKey is used by the local start command.
+const LocalDummyCAPEMKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAzYkGrQjjvR3Ssqhbf5Kj//MDN2b3FsKGnKvv2K8ExzNOz8sh
+tPi3Pi6MQVbSFSVGwMrkwJmtq7UxBGNQmzDwqxny14kpQC4f9hwEoHf3jv1x9FoC
+aK5Z2yfPha9XRo1PIu1591qOlhb7NrNg/kLtfyqWgqmymeJbQewi895KdHEgc1Sl
+Xp68EBxHnkCg+642Nc7gGXmoLCgDac/ZLINcahhQYjgyXJVlQVK/T7Yue6Gl5pQi
+9wuG4lnHVoXlHPHPtTJfS0sMfXC91qule83DY+jOaCFVo7c2golZyTHqf7lPk5RC
+Kp6D5HMn10nuq7Nr/hUYsVOLwbmSjtGkdEwjuQIDAQABAoIBADixTCscYZz/heeL
+srlMnHnz8PYuK4eWnoTGlEDDfeDoURvV3vVJCVpYgo1fQlFc19hD3rcVbKcJMn0Q
+W+KCrE+1t5smFT/DuUMsVUZh8OH7HJyW20U+mkBuCbrJM5ydS6/JqzPEQcI6ko5z
+ChT4JwRFngBqiH4TxrI3TSjRLt5Q+xY2uQpx3upPbgyyu8/bRUXtUtZbj1tVhXfJ
+XPSWKd2RrNDaaIkw+5WX6byAwgymwg+4NAqSUNa2wYD5T5cVa0v8nJ/idyfj/N8C
+B5y2bJcxBrMsHByOozU5XSQtfmV6qmFiYF6rOqLifb2S9tAT0676wqmVm0XMLbvG
+2A97BdUCgYEA9eCsFBTcn6/PL9F9aEVabfJGjcG1ae/IOEp21wujNCxt+NQncICS
+5M90GEn0fjc4dZxz4zigkwJZ8zHwk+XsrskD92FjwgRBg7GpIOT49gG+cGkibEMY
+0odSVkHevqTATSeOE2cNjHSJg5JXVftxo2ZfjNPFVHeYf9LcqwUOAvsCgYEA1f8u
+jBaizvrw/qWfdMcNDqT0xlwJquKtE4ptHxqWDpyyTz+tduhSs8lo80qL/nKmwNvm
+9FJ1Ykr7a9xDK/bW3w0Q3seLyr6Wsgl+w22T8ArdSXHZb5eOJoWQ6B5ALCOUHBio
+c0Nd2lVX91cxKDdV96BMivfoEtiPgyZjPTxjFdsCgYATuQ70mWvNH2QmOM6vc4i6
+cwm3y0cLFWHhKg/4VgWkZL/5isMTIi0mT4HHhP8otLNBs+gT3PH8eN7QRDxBENt4
+dcVsrZI7+O1sa+7eJZ/W0/L7v2M0fflaweIX6za74ilOxxJ9efG7R4nUVQPOcNn/
+unGFsWMN0H4aGsb6rPAfywKBgQC294Hy4P++/KvE7hMSI4a0eLGYT+UsKLdWt8pp
+B7A5OhzyyT0lJ6pecdy794cOvTR6PQqQ51fZ/MZPCHqeQmShPWipMfACH0Z1Xsz1
+huEwIfnl6+O/F9PAd/7Xl9XCZ4EhLKwKMRUzsjiOEAzFl9p26KXJRAE269Z4if/b
+wZ/udQKBgC/K5w3zOzdi8XVF5gkn/rcsvp2yRJpBR1sVcCpLV8uqiVwMTM4R114p
+QDj0xfAUTv2AFcnL+JszB7XWwMEAD00rc3BP1Zb/ORNgpTYlW2+iGtEc4JBCTK58
+kqm2kB+ymWKkKGI9JAXTFEOuuCS2pqvW+rlzs/9weJdn6JpNOn58
+-----END RSA PRIVATE KEY-----
+`

--- a/pkg/cmd/kore/create/create.go
+++ b/pkg/cmd/kore/create/create.go
@@ -39,6 +39,8 @@ func NewCmdCreate(factory cmdutil.Factory) *cobra.Command {
 		NewCmdCreateCluster(factory),
 		NewCmdCreateNamespace(factory),
 		NewCmdCreateUser(factory),
+		NewCmdGKECredentials(factory),
+		NewCmdEKSCredentials(factory),
 	)
 
 	return command

--- a/pkg/cmd/kore/create/ekscredential.go
+++ b/pkg/cmd/kore/create/ekscredential.go
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	confv1 "github.com/appvia/kore/pkg/apis/config/v1"
+	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
+	eks "github.com/appvia/kore/pkg/apis/eks/v1alpha1"
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	"github.com/appvia/kore/pkg/kore"
+	"github.com/manifoldco/promptui"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateEKSCredentialsOptions is used to provision a team
+type CreateEKSCredentialsOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+	// Name is the name of the credential
+	Name string
+	// Description is a description of the credential
+	Description string
+	// AccountID is the AWS numerical account ID
+	AccountID string
+	// AccessKeyID is the ID for the AWS access key
+	AccessKeyID string
+	// SecretAccessKey is the secret AWS access key
+	SecretAccessKey string
+	// AllocateToTeams allows the credential to be allocated to the specified list of teams.
+	AllocateToTeams []string
+	// AllocateToAll controls if a default allocation should be set for this to allocate to all teams.
+	AllocateToAll bool
+	// NoWait indicates if we should wait for a resource to provision
+	NoWait bool
+}
+
+// NewCmdEKSCredentials returns the create EKS credentials command
+func NewCmdEKSCredentials(factory cmdutil.Factory) *cobra.Command {
+	o := &CreateEKSCredentialsOptions{Factory: factory}
+
+	command := &cobra.Command{
+		Use:     "ekscredentials",
+		Aliases: []string{"ekscredential"},
+		Short:   "Creates a set of EKS / AWS credentials in Kore",
+		Example: "kore create gkecredentials <name> -d <description> -i <aws account id> -k <aws access key id> -s <aws secret key> --all-teams",
+		PreRunE: cmdutil.RequireName,
+		Run:     cmdutil.DefaultRunFunc(o),
+	}
+
+	command.Flags().StringVarP(&o.Description, "description", "d", "", "the description of the credential")
+	command.Flags().StringVarP(&o.AccountID, "account-id", "i", "", "the AWS numerical account ID")
+	command.Flags().StringVarP(&o.AccessKeyID, "key-id", "k", "", "the AWS access key ID")
+	command.Flags().StringVarP(&o.SecretAccessKey, "secret-key", "s", "", "the AWS secret access key - will prompt if not provided")
+
+	command.Flags().StringArrayVarP(&o.AllocateToTeams, "allocate", "a", []string{}, "list of teams to allocate to, e.g. team1,team2")
+	command.Flags().BoolVar(&o.AllocateToAll, "all-teams", false, "make these credentials available to all teams in kore (if not set, you must create an allocation for these credentials for them to be usable)")
+
+	cmdutil.MustMarkFlagRequired(command, "account-id")
+	cmdutil.MustMarkFlagRequired(command, "key-id")
+
+	return command
+}
+
+// Run is responsible for creating the credentials
+func (o CreateEKSCredentialsOptions) Run() error {
+	found, err := o.Client().Team(kore.HubAdminTeam).Resource("ekscredential").Name(o.Name).Exists()
+	if err != nil {
+		return err
+	}
+	if found {
+		return fmt.Errorf("%q already exists, please edit instead", o.Name)
+	}
+
+	if o.SecretAccessKey == "" {
+		runner := promptui.Prompt{
+			Label:   "Secret Access Key",
+			Default: "",
+			Validate: func(in string) error {
+				if len(in) == 0 {
+					return fmt.Errorf("Secret access key must be set")
+				}
+				return nil
+			},
+		}
+		key, err := runner.Run()
+		if err != nil {
+			return err
+		}
+		o.SecretAccessKey = strings.TrimSpace(key)
+	}
+
+	cred := &eks.EKSCredentials{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EKSCredentials",
+			APIVersion: eks.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.Name,
+			Namespace: kore.HubAdminTeam,
+		},
+		Spec: eks.EKSCredentialsSpec{
+			AccountID:       o.AccountID,
+			AccessKeyID:     o.AccessKeyID,
+			SecretAccessKey: o.SecretAccessKey,
+		},
+	}
+
+	o.Println("Storing credentials in Kore")
+	err = o.WaitForCreation(
+		o.Client().
+			Team(kore.HubAdminTeam).
+			Resource("ekscredential").
+			Name(o.Name).
+			Payload(cred).
+			Result(&eks.EKSCredentials{}),
+		o.NoWait,
+	)
+	if err != nil {
+		o.Println("Error while creating credential")
+		return err
+	}
+
+	if !o.AllocateToAll && len(o.AllocateToTeams) == 0 {
+		return nil
+	}
+
+	// Create allocation
+	teams := o.AllocateToTeams
+	if o.AllocateToAll {
+		teams = []string{"*"}
+	}
+	alloc := &confv1.Allocation{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Allocation",
+			APIVersion: confv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.Name,
+			Namespace: kore.HubAdminTeam,
+		},
+		Spec: confv1.AllocationSpec{
+			Name:    o.Name,
+			Summary: o.Description,
+			Teams:   teams,
+			Resource: corev1.Ownership{
+				Group:     eks.GroupVersion.Group,
+				Version:   eks.GroupVersion.Version,
+				Kind:      "EKSCredentials",
+				Name:      o.Name,
+				Namespace: kore.HubAdminTeam,
+			},
+		},
+	}
+
+	o.Println("Storing credential allocation in Kore")
+	return o.WaitForCreation(
+		o.Client().
+			Team(kore.HubAdminTeam).
+			Resource("allocation").
+			Name(o.Name).
+			Payload(alloc).
+			Result(&confv1.Allocation{}),
+		o.NoWait,
+	)
+}

--- a/pkg/cmd/kore/create/ekscredential.go
+++ b/pkg/cmd/kore/create/ekscredential.go
@@ -61,7 +61,7 @@ func NewCmdEKSCredentials(factory cmdutil.Factory) *cobra.Command {
 		Use:     "ekscredentials",
 		Aliases: []string{"ekscredential"},
 		Short:   "Creates a set of EKS / AWS credentials in Kore",
-		Example: "kore create gkecredentials <name> -d <description> -i <aws account id> -k <aws access key id> -s <aws secret key> --all-teams",
+		Example: "kore create ekscredentials <name> -d <description> -i <aws account id> -k <aws access key id> -s <aws secret key> --all-teams",
 		PreRunE: cmdutil.RequireName,
 		Run:     cmdutil.DefaultRunFunc(o),
 	}
@@ -135,8 +135,7 @@ func (o CreateEKSCredentialsOptions) Run() error {
 		o.NoWait,
 	)
 	if err != nil {
-		o.Println("Error while creating credential")
-		return err
+		return fmt.Errorf("Error while creating credential: %s", err)
 	}
 
 	if !o.AllocateToAll && len(o.AllocateToTeams) == 0 {

--- a/pkg/cmd/kore/create/gkecredential.go
+++ b/pkg/cmd/kore/create/gkecredential.go
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package create
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	confv1 "github.com/appvia/kore/pkg/apis/config/v1"
+	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
+	gke "github.com/appvia/kore/pkg/apis/gke/v1alpha1"
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	"github.com/appvia/kore/pkg/kore"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateGKECredentialsOptions is used to provision a team
+type CreateGKECredentialsOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+	// Name is the name of the credential
+	Name string
+	// Description is a description of the credential
+	Description string
+	// ProjectName is the name of the GCP project
+	ProjectName string
+	// Region is the GCP region for the account
+	Region string
+	// ServiceAccountJSON is a reference to a file containing the JSON service account details.
+	ServiceAccountJSON string
+	// AllocateToTeams allows the credential to be allocated to the specified list of teams.
+	AllocateToTeams []string
+	// AllocateToAll controls if a default allocation should be set for this to allocate to all teams.
+	AllocateToAll bool
+	// NoWait indicates if we should wait for a resource to provision
+	NoWait bool
+}
+
+// NewCmdGKECredentials returns the create GCP project credentials command
+func NewCmdGKECredentials(factory cmdutil.Factory) *cobra.Command {
+	o := &CreateGKECredentialsOptions{Factory: factory}
+
+	command := &cobra.Command{
+		Use:     "gkecredentials",
+		Aliases: []string{"gkecredential"},
+		Short:   "Creates a set of GKE project-level credentials in Kore",
+		Example: "kore create gkecredentials <name> -d <description> -p <gcp project> --cred-file ./service-account.json",
+		PreRunE: cmdutil.RequireName,
+		Run:     cmdutil.DefaultRunFunc(o),
+	}
+
+	command.Flags().StringVarP(&o.Description, "description", "d", "", "the description of the credential")
+	command.Flags().StringVarP(&o.ProjectName, "project", "p", "", "the GCP project for these credentials")
+	command.Flags().StringVarP(&o.Region, "region", "r", "europe-west2", "the GCP region for these credentials, e.g. europe-west2")
+	command.Flags().StringVarP(&o.ServiceAccountJSON, "cred-file", "c", "", "the service account JSON file containing the credentials to import")
+	command.Flags().StringArrayVarP(&o.AllocateToTeams, "allocate", "a", []string{}, "list of teams to allocate to, e.g. team1,team2")
+	command.Flags().BoolVar(&o.AllocateToAll, "all-teams", false, "make these credentials available to all teams in kore (if not set, you must create an allocation for these credentials for them to be usable)")
+
+	cmdutil.MustMarkFlagRequired(command, "project")
+	cmdutil.MustMarkFlagRequired(command, "region")
+	cmdutil.MustMarkFlagRequired(command, "cred-file")
+
+	return command
+}
+
+// Run is responsible for creating the credentials
+func (o CreateGKECredentialsOptions) Run() error {
+	found, err := o.Client().Team(kore.HubAdminTeam).Resource("gkecredential").Name(o.Name).Exists()
+	if err != nil {
+		return err
+	}
+	if found {
+		return fmt.Errorf("%q already exists, please edit instead", o.Name)
+	}
+
+	json, err := ioutil.ReadFile(o.ServiceAccountJSON)
+	if err != nil {
+		o.Println("Error reading service account from %v", o.ServiceAccountJSON)
+		return err
+	}
+
+	cred := &gke.GKECredentials{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GKECredentials",
+			APIVersion: gke.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.Name,
+			Namespace: kore.HubAdminTeam,
+		},
+		Spec: gke.GKECredentialsSpec{
+			Project: o.ProjectName,
+			Account: string(json),
+		},
+	}
+
+	o.Println("Storing credentials in Kore")
+	err = o.WaitForCreation(
+		o.Client().
+			Team(kore.HubAdminTeam).
+			Resource("gkecredential").
+			Name(o.Name).
+			Payload(cred).
+			Result(&gke.GKECredentials{}),
+		o.NoWait,
+	)
+	if err != nil {
+		o.Println("Error while creating credential")
+		return err
+	}
+
+	if !o.AllocateToAll && len(o.AllocateToTeams) == 0 {
+		return nil
+	}
+
+	// Create allocation
+	teams := o.AllocateToTeams
+	if o.AllocateToAll {
+		teams = []string{"*"}
+	}
+	alloc := &confv1.Allocation{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Allocation",
+			APIVersion: confv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.Name,
+			Namespace: kore.HubAdminTeam,
+		},
+		Spec: confv1.AllocationSpec{
+			Name:    o.Name,
+			Summary: o.Description,
+			Teams:   teams,
+			Resource: corev1.Ownership{
+				Group:     gke.GroupVersion.Group,
+				Version:   gke.GroupVersion.Version,
+				Kind:      "GKECredentials",
+				Name:      o.Name,
+				Namespace: kore.HubAdminTeam,
+			},
+		},
+	}
+
+	o.Println("Storing credential allocation in Kore")
+	return o.WaitForCreation(
+		o.Client().
+			Team(kore.HubAdminTeam).
+			Resource("allocation").
+			Name(o.Name).
+			Payload(alloc).
+			Result(&confv1.Allocation{}),
+		o.NoWait,
+	)
+}

--- a/pkg/cmd/kore/delete/delete.go
+++ b/pkg/cmd/kore/delete/delete.go
@@ -88,22 +88,18 @@ func (o *DeleteOptions) Run() error {
 		return o.DeleteByPath()
 	}
 
-	o.Println("pluralise")
 	plural := utils.Pluralize(o.Resource)
-	o.Println("pluralised %s", plural)
 
 	// @step: we lookup the resource type
 	resource, err := o.Resources().Lookup(plural)
 	if err != nil {
 		return err
 	}
-	o.Println("res type %v", resource)
 
 	request := o.Client().Resource(plural).Name(o.Name)
 	if resource.IsTeamScoped() {
 		request.Team(o.Team)
 	}
-	o.Println("req %v", request)
 
 	return o.WaitForDeletion(request, o.Name, o.NoWait)
 }

--- a/pkg/cmd/kore/delete/delete.go
+++ b/pkg/cmd/kore/delete/delete.go
@@ -88,18 +88,22 @@ func (o *DeleteOptions) Run() error {
 		return o.DeleteByPath()
 	}
 
+	o.Println("pluralise")
 	plural := utils.Pluralize(o.Resource)
+	o.Println("pluralised %s", plural)
 
 	// @step: we lookup the resource type
 	resource, err := o.Resources().Lookup(plural)
 	if err != nil {
 		return err
 	}
+	o.Println("res type %v", resource)
 
 	request := o.Client().Resource(plural).Name(o.Name)
 	if resource.IsTeamScoped() {
 		request.Team(o.Team)
 	}
+	o.Println("req %v", request)
 
 	return o.WaitForDeletion(request, o.Name, o.NoWait)
 }

--- a/pkg/cmd/kore/kore.go
+++ b/pkg/cmd/kore/kore.go
@@ -28,6 +28,7 @@ import (
 	"github.com/appvia/kore/pkg/cmd/kore/edit"
 	"github.com/appvia/kore/pkg/cmd/kore/get"
 	"github.com/appvia/kore/pkg/cmd/kore/kubeconfig"
+	"github.com/appvia/kore/pkg/cmd/kore/local"
 	"github.com/appvia/kore/pkg/cmd/kore/login"
 	"github.com/appvia/kore/pkg/cmd/kore/profiles"
 	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
@@ -105,6 +106,7 @@ func NewKoreCommand(streams cmdutils.Streams) (*cobra.Command, error) {
 		NewCmdWhoami(factory),
 		apiresources.NewCmdAPIResources(factory),
 		NewCmdVersion(factory),
+		local.NewCmdCreateLocal(factory),
 	)
 
 	// @step: seriously cobra is pretty damn awesome

--- a/pkg/cmd/kore/local/local.go
+++ b/pkg/cmd/kore/local/local.go
@@ -17,7 +17,19 @@
 package local
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/appvia/kore/pkg/client/config"
+	"github.com/appvia/kore/pkg/cmd/kore/assets"
 	cmdutils "github.com/appvia/kore/pkg/cmd/utils"
+	"github.com/appvia/kore/pkg/version"
 
 	"github.com/spf13/cobra"
 )
@@ -39,5 +51,83 @@ func NewCmdCreateLocal(factory cmdutils.Factory) *cobra.Command {
 		Run:     cmdutils.RunHelp,
 	}
 
+	command.AddCommand(
+		NewCmdLocalConfigure(factory),
+		NewCmdLocalStart(factory),
+		NewCmdLocalStop(factory),
+		NewCmdLocalLogs(factory),
+	)
+
 	return command
+}
+
+// Shared functions used by stop and start:
+
+// writeSupportFiles populates ~/.korectl/local/ with the supporting files to be mounted into containers used by kore local.
+func writeSupportFiles() error {
+	localPath := filepath.Dir(config.GetClientConfigurationPath()) + "/local/"
+	for k, v := range assets.LocalSupport {
+		f := filepath.Join(localPath, k)
+		_ = os.MkdirAll(filepath.Dir(f), os.ModePerm)
+		err := ioutil.WriteFile(f, []byte(v), 0644)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getComposeCmd(conf *config.Config, args ...string) (*exec.Cmd, error) {
+	baseArgs := []string{"-f", "-", "-p", "korelocal"}
+	cmd := exec.Command("docker-compose",
+		append(baseArgs, args...)...,
+	)
+	localPath := filepath.Dir(config.GetClientConfigurationPath()) + "/local"
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_TAG=%s", version.Release))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_IDP_CLIENT_ID=%s", conf.AuthInfos[LocalProfileName].OIDC.ClientID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_IDP_CLIENT_SECRET=%s", conf.AuthInfos[LocalProfileName].OIDC.ClientID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_IDP_SERVER_URL=%s", conf.AuthInfos[LocalProfileName].OIDC.AuthorizeURL))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_LOCAL_HOME=%s", localPath))
+	if err := pipeComposeToCmd(cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func pipeComposeToCmd(cmd *exec.Cmd) error {
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, assets.LocalCompose)
+	}()
+	return nil
+}
+
+func startChecks(conf *config.Config) error {
+	if !conf.HasProfile(LocalProfileName) {
+		return errors.New("a 'local' profile has not been found in ~/.korectl/config - try running: kore local configure")
+	}
+
+	if !conf.HasAuthInfo(LocalProfileName) || !conf.IsOIDCProviderConfigured(LocalProfileName) {
+		return errors.New("no OpenId provider was configured for your 'local' profile in ~/.korectl/config - try running: kore local configure")
+	}
+	return nil
+}
+
+func isKoreStarted(conf *config.Config) (bool, error) {
+	cmd, err := getComposeCmd(conf, "ps")
+	if err != nil {
+		return false, err
+	}
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("%s", stdoutStderr)
+		return false, err
+	}
+
+	return strings.Contains(string(stdoutStderr), "/kore-apiserver"), nil
 }

--- a/pkg/cmd/kore/local/local.go
+++ b/pkg/cmd/kore/local/local.go
@@ -86,7 +86,7 @@ func getComposeCmd(conf *config.Config, args ...string) (*exec.Cmd, error) {
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_TAG=%s", version.Release))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_IDP_CLIENT_ID=%s", conf.AuthInfos[LocalProfileName].OIDC.ClientID))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_IDP_CLIENT_SECRET=%s", conf.AuthInfos[LocalProfileName].OIDC.ClientID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_IDP_CLIENT_SECRET=%s", conf.AuthInfos[LocalProfileName].OIDC.ClientSecret))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_IDP_SERVER_URL=%s", conf.AuthInfos[LocalProfileName].OIDC.AuthorizeURL))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KORE_LOCAL_HOME=%s", localPath))
 	if err := pipeComposeToCmd(cmd); err != nil {

--- a/pkg/cmd/kore/local/logs.go
+++ b/pkg/cmd/kore/local/logs.go
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package local
+
+import (
+	"os"
+
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// LocalLogsOptions is used to run the demo local environment
+type LocalLogsOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+	// Follow indicates we should follow the logs rather than just outputting them
+	Follow bool
+}
+
+// NewCmdLocalLogs returns the local logs command
+func NewCmdLocalLogs(factory cmdutil.Factory) *cobra.Command {
+	o := &LocalLogsOptions{Factory: factory}
+
+	command := &cobra.Command{
+		Use:     "logs",
+		Short:   "Shows the current logs ",
+		Example: "kore local logs",
+
+		Run: cmdutil.DefaultRunFunc(o),
+	}
+
+	flags := command.Flags()
+	flags.BoolVarP(&o.Follow, "follow", "f", false, "set to follow the log `BOOL`")
+
+	return command
+}
+
+// Run implements the command action
+func (o *LocalLogsOptions) Run() error {
+	conf := o.Config()
+	// @step: read variables from config file and explode if not present.
+	if err := startChecks(conf); err != nil {
+		return err
+	}
+	conf.CurrentProfile = LocalProfileName
+
+	// @step: write out the support files to ~/.korectl/local/
+	if err := writeSupportFiles(); err != nil {
+		return err
+	}
+
+	running, err := isKoreStarted(conf)
+	if err != nil {
+		return err
+	}
+	if !running {
+		o.Println("...No logs are available (Kore is not running).")
+		return nil
+	}
+
+	logsArgs := []string{"logs"}
+	if o.Follow {
+		logsArgs = append(logsArgs, "--follow")
+	}
+	logsCmd, err := getComposeCmd(conf, logsArgs...)
+	if err != nil {
+		return err
+	}
+
+	logsCmd.Stdout = os.Stdout
+	logsCmd.Stderr = os.Stderr
+
+	return logsCmd.Run()
+}

--- a/pkg/cmd/kore/local/start.go
+++ b/pkg/cmd/kore/local/start.go
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package local
+
+import (
+	"time"
+
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// LocalStartOptions is used to run the demo local environment
+type LocalStartOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+}
+
+// NewCmdLocalStart returns the local start command
+func NewCmdLocalStart(factory cmdutil.Factory) *cobra.Command {
+	o := &LocalStartOptions{Factory: factory}
+
+	command := &cobra.Command{
+		Use:     "start",
+		Short:   "Starts a local instance of Kore running for demonstration and proof of concept purposes",
+		Example: "kore local start",
+
+		Run: cmdutil.DefaultRunFunc(o),
+	}
+
+	return command
+}
+
+// Run implements the command action
+func (o *LocalStartOptions) Run() error {
+	conf := o.Config()
+	// @step: read variables from config file and explode if not present.
+	if err := startChecks(conf); err != nil {
+		return err
+	}
+	conf.CurrentProfile = LocalProfileName
+
+	// @step: write out the support files to ~/.korectl/local/
+	if err := writeSupportFiles(); err != nil {
+		return err
+	}
+
+	// @step: prepare command
+	cmd, err := getComposeCmd(conf, "up", "--force-recreate", "-d")
+	if err != nil {
+		return err
+	}
+
+	// @step: Execute command
+	o.Println("...Starting Kore.")
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		o.Println("%s", stdoutStderr)
+		return err
+	}
+
+	// We pause here to give the services time to initialise
+	// @TODO: Ping for the API being available instead.
+	time.Sleep(time.Second * 35)
+
+	o.Println("...Kore is now started locally")
+	o.Println("UI:  http://localhost:3000/")
+	o.Println("API: http://localhost:10080/")
+	return nil
+}

--- a/pkg/cmd/kore/local/start.go
+++ b/pkg/cmd/kore/local/start.go
@@ -74,7 +74,7 @@ func (o *LocalStartOptions) Run() error {
 	}
 
 	// We pause here to give the services time to initialise
-	// @TODO: Ping for the API being available instead.
+	// @TODO: Perhaps ping for the API and UI for being available instead?
 	time.Sleep(time.Second * 35)
 
 	o.Println("...Kore is now started locally")

--- a/pkg/cmd/kore/local/stop.go
+++ b/pkg/cmd/kore/local/stop.go
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package local
+
+import (
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// LocalStopOptions is used to stop the demo local environment
+type LocalStopOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+}
+
+// NewCmdLocalStop returns the local stop command
+func NewCmdLocalStop(factory cmdutil.Factory) *cobra.Command {
+	o := &LocalStopOptions{Factory: factory}
+
+	command := &cobra.Command{
+		Use:     "stop",
+		Short:   "Stops a local demonstration instance of Kore",
+		Example: "kore local stop",
+
+		Run: cmdutil.DefaultRunFunc(o),
+	}
+
+	return command
+}
+
+// Run implements the command action
+func (o *LocalStopOptions) Run() error {
+	conf := o.Config()
+	// @step: read variables from config file and explode if not present.
+	if err := startChecks(conf); err != nil {
+		return err
+	}
+	conf.CurrentProfile = LocalProfileName
+
+	// @step: write out the support files to ~/.korectl/local/
+	if err := writeSupportFiles(); err != nil {
+		return err
+	}
+
+	// @step: prepare command
+	cmd, err := getComposeCmd(conf, "down")
+	if err != nil {
+		return err
+	}
+
+	// @step: Execute command
+	o.Println("...Stopping Kore.")
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		o.Println("%s", stdoutStderr)
+		return err
+	}
+
+	o.Println("...Kore is now stopped.")
+	return nil
+}

--- a/pkg/cmd/kore/profiles/configure.go
+++ b/pkg/cmd/kore/profiles/configure.go
@@ -72,7 +72,7 @@ func (o *ConfigureOptions) Run() error {
 	}
 
 	// @step: ask for the endpoint
-	o.Printf("Please enter the Kore API: (e.g https://api.domain.com): ")
+	o.Printf("Please enter the Kore API URL (e.g https://api.domain.com): ")
 
 	endpoint, err := bufio.NewReader(o.Stdin()).ReadString('\n')
 	if err != nil {

--- a/pkg/cmd/utils/prompts.go
+++ b/pkg/cmd/utils/prompts.go
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+)
+
+type Prompt struct {
+	Id          string
+	LabelSuffix string
+	ErrMsg      string
+	Value       *string
+}
+
+func (p *Prompt) Do() error {
+	var value string
+	if p.Value != nil {
+		value = *p.Value
+	}
+	runner := promptui.Prompt{
+		Label:     p.Id + " " + p.LabelSuffix,
+		AllowEdit: true,
+		Default:   value,
+		Validate: func(in string) error {
+			if len(in) == 0 {
+				return fmt.Errorf(p.ErrMsg, p.Id)
+			}
+			return nil
+		},
+	}
+
+	gathered, err := runner.Run()
+	if err != nil {
+		return err
+	}
+
+	*p.Value = strings.TrimSpace(gathered)
+	return nil
+}
+
+type Prompts []*Prompt
+
+func (p Prompts) Collect() error {
+	for _, p := range p {
+		if err := p.Do(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/utils/prompts.go
+++ b/pkg/cmd/utils/prompts.go
@@ -28,6 +28,7 @@ type Prompt struct {
 	LabelSuffix string
 	ErrMsg      string
 	Value       *string
+	AllowEdit   bool
 }
 
 func (p *Prompt) Do() error {
@@ -37,7 +38,7 @@ func (p *Prompt) Do() error {
 	}
 	runner := promptui.Prompt{
 		Label:     p.Id + " " + p.LabelSuffix,
-		AllowEdit: true,
+		AllowEdit: p.AllowEdit,
 		Default:   value,
 		Validate: func(in string) error {
 			if len(in) == 0 {

--- a/pkg/kore/ekscredentials.go
+++ b/pkg/kore/ekscredentials.go
@@ -64,6 +64,7 @@ func (h *eksCredsImpl) Delete(ctx context.Context, name string) error {
 	if err := h.Store().Client().Get(ctx,
 		store.GetOptions.InNamespace(h.team),
 		store.GetOptions.InTo(creds),
+		store.GetOptions.WithName(name),
 	); err != nil {
 		logger.WithError(err).Error("trying to retrieve the credentials")
 


### PR DESCRIPTION
Also added gkecredentials and ekscredentials to kore CLI so we can do the full end-to-end flow without writing files containing credentials out to disk then applying them as per the previous local workflow.

To test:

1. unset VERSION and unset AUTHOR in the terminal, just in case, then run make kore.
2. bin/kore local configure
3. bin/kore local start
4. Use kore via CLI and via UI.
5. bin/kore local stop

Also included bugfix for eks credential deletion.

Addresses #598 and #547 