### PR TITLE
Cluster visibility and editability through the UI.

### DIFF
--- a/pkg/kore/assets/plan_schema_eks.go
+++ b/pkg/kore/assets/plan_schema_eks.go
@@ -186,12 +186,14 @@ const EKSPlanSchema = `
 		"privateIPV4Cidr": {
 			"type": "string",
 			"description": "The range of IPv4 addresses for your EKS cluster in CIDR block format",
-			"format": "1.2.3.4/16"
+			"format": "1.2.3.4/16",
+			"immutable": true
 		},
 		"region": {
 			"type": "string",
 			"description": "The AWS region in which this cluster will reside (e.g. eu-west-2).",
-			"minLength": 1
+			"minLength": 1,
+			"immutable": true
 		},
 		"version": {
 			"type": "string",

--- a/pkg/kore/assets/plan_schema_gke.go
+++ b/pkg/kore/assets/plan_schema_gke.go
@@ -203,7 +203,8 @@ const GKEPlanSchema = `
 		},
 		"region": {
 			"type": "string",
-			"minLength": 1
+			"minLength": 1,
+			"immutable": true
 		},
 		"size": {
 			"type": "number",

--- a/ui/kore-api-swagger.json
+++ b/ui/kore-api-swagger.json
@@ -1,1 +1,6043 @@
-{"swagger":"2.0","info":{"description":"Kore API provides the frontend API for the Appvia Kore (kore.appvia.io)","title":"Appvia Kore API","contact":{"name":"Appvia Ltd","url":"https://appvia.io","email":"info@appvia.io"},"license":{"name":"Apache 2.0","url":"http://www.apache.org/licenses/LICENSE-2.0"},"version":"0.0.1"},"paths":{"/api/v1alpha1/audits":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return all the audit event across all the teams","operationId":"ListAuditEvents","parameters":[{"type":"string","default":"60m","description":"The time duration to return the events within, to a resolution of minutes","name":"since","in":"query"}],"responses":{"200":{"description":"A collection of events from the team","schema":{"$ref":"#/definitions/v1.AuditEventList"}},"400":{"description":"Validation error of supplied parameters/body","schema":{"$ref":"#/definitions/validation.Error"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/idp/clients/{name}":{"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Updates the definition for a specific idp client","operationId":"UpdateIDPClient","parameters":[{"type":"string","description":"The name of the IDP client provider to update","name":"name","in":"path","required":true},{"description":"The definition for the idp client","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.IDPClient"}}],"responses":{"200":{"description":"The configured client in the kore","schema":{"$ref":"#/definitions/v1.IDPClient"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/idp/configured":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a list of all the configured identity providers in the kore","operationId":"ListIDPs","responses":{"200":{"description":"A list of all the configured identity providers","schema":{"type":"array","items":{"$ref":"#/definitions/v1.IDP"}}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/idp/configured/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns the definition for a specific identity provider","operationId":"GetIDP","parameters":[{"type":"string","description":"The name of the configured IDP provider to retrieve","name":"name","in":"path","required":true}],"responses":{"200":{"description":"the specified identity provider","schema":{"$ref":"#/definitions/v1.IDP"}},"404":{"description":"Indicate the class was not found in the kore"},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns the definition for a specific ID provider","operationId":"UpdateIDP","parameters":[{"type":"string","description":"The name of the configured IDP provider to update","name":"name","in":"path","required":true},{"description":"The definition for the ID provider","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.IDP"}}],"responses":{"200":{"description":"A list of all the IDPs in the kore","schema":{"$ref":"#/definitions/v1.IDP"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/idp/default":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns the default identity provider configured in the kore","operationId":"GetDefaultIDP","responses":{"200":{"description":"The default configured identity provider","schema":{"$ref":"#/definitions/v1.IDP"}},"404":{"description":"Indicate the class was not found in the kore"},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/idp/types":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a list of all the possible identity providers supported in the kore","operationId":"ListIDPTypes","responses":{"200":{"description":"A list of all the possible identity provider types","schema":{"type":"array","items":{"$ref":"#/definitions/v1.IDPConfig"}}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/planpolicies":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns all the plan policies","operationId":"ListPlanPolicies","parameters":[{"type":"string","description":"Returns all plan policies for a specific resource type","name":"kind","in":"query"}],"responses":{"200":{"description":"A list of all the plan policies in the kore","schema":{"$ref":"#/definitions/v1.PlanPolicyList"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/planpolicies/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a specific plan policy from the kore","operationId":"GetPlanPolicy","parameters":[{"type":"string","description":"The name of the plan policy you wish to retrieve","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the plan policy definition from the kore","schema":{"$ref":"#/definitions/v1.PlanPolicy"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to create or update a plan policy in the kore","operationId":"UpdatePlanPolicy","parameters":[{"type":"string","description":"The name of the plan policy you wish to update","name":"name","in":"path","required":true},{"description":"The specification for the plan policy you are updating","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.PlanPolicy"}}],"responses":{"200":{"description":"Contains the plan policy definition from the kore","schema":{"$ref":"#/definitions/v1.PlanPolicy"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to delete a plan policy from the kore","operationId":"RemovePlanPolicy","parameters":[{"type":"string","description":"The name of the plan policy you wish to delete","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the plan policy definition from the kore","schema":{"$ref":"#/definitions/v1.PlanPolicy"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/plans":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns all the classes available to initialized in the kore","operationId":"ListPlans","parameters":[{"type":"string","description":"Returns all plans for a specific resource type","name":"kind","in":"query"}],"responses":{"200":{"description":"A list of all the plans","schema":{"$ref":"#/definitions/v1.PlanList"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/plans/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a specific class plan from the kore","operationId":"GetPlan","parameters":[{"type":"string","description":"The name of the plan you wish to retrieve","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the plan definition","schema":{"$ref":"#/definitions/v1.Plan"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"the plan with the given name doesn't exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to create or update a plan in the kore","operationId":"UpdatePlan","parameters":[{"type":"string","description":"The name of the plan you wish to create or update","name":"name","in":"path","required":true},{"description":"The specification for the plan you are creating or updating","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.Plan"}}],"responses":{"200":{"description":"Contains the plan definition","schema":{"$ref":"#/definitions/v1.Plan"}},"400":{"description":"Validation error of supplied parameters/body","schema":{"$ref":"#/definitions/validation.Error"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to delete a plan from the kore","operationId":"RemovePlan","parameters":[{"type":"string","description":"The name of the plan you wish to delete","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the plan definition","schema":{"$ref":"#/definitions/v1.Plan"}},"400":{"description":"Validation error of supplied parameters/body","schema":{"$ref":"#/definitions/validation.Error"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"the plan with the given name doesn't exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/planschemas/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a specific plan schema from the kore","operationId":"GetPlanSchema","parameters":[{"type":"string","description":"The name of the plan schema you wish to retrieve","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the plan schema definition from the kore","schema":{"$ref":"#/definitions/v1.PlanPolicy"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns all the teams in the kore","operationId":"ListTeams","responses":{"200":{"description":"A list of all the teams in the kore","schema":{"$ref":"#/definitions/v1.TeamList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/invitation/{token}":{"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to verify and handle the team invitation generated links","operationId":"InvitationSubmit","parameters":[{"type":"string","description":"The generated base64 invitation token which was provided from the team","name":"token","in":"path","required":true}],"responses":{"200":{"description":"Indicates the generated link is valid and the user has been granted access","schema":{"$ref":"#/definitions/types.TeamInvitationResponse"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Return information related to the specific team in the kore","operationId":"GetTeam","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the team definition from the kore","schema":{"$ref":"#/definitions/v1.Team"}},"404":{"description":"Team does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to create or update a team in the kore","operationId":"UpdateTeam","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"description":"Contains the definition for a team in the kore","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.Team"}}],"responses":{"200":{"description":"Contains the team definition from the kore","schema":{"$ref":"#/definitions/v1.Team"}},"304":{"description":"Indicates the request was processed but no changes applied","schema":{"$ref":"#/definitions/v1.Team"}},"400":{"description":"Validation error of supplied parameters/body","schema":{"$ref":"#/definitions/validation.Error"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"Team does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to delete a team from the kore","operationId":"RemoveTeam","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.Team"}},"404":{"description":"Team does not exist"},"406":{"description":"Indicates you cannot delete the team for one or more reasons","schema":{"$ref":"#/definitions/apiserver.Error"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/allocations":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return a list of all the allocations in the team","operationId":"ListAllocations","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Retrieves all allocations which have been assigned to you","name":"assigned","in":"query"}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.AllocationList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/allocations/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return an allocation within the team","operationId":"GetAllocation","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is the name of the allocation you wish to return","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.Allocation"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to create/update an allocation within the team.","operationId":"UpdateAllocation","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is the name of the allocation you wish to update","name":"name","in":"path","required":true},{"description":"The definition of the Allocation","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.Allocation"}}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.Allocation"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Remove an allocation from a team","operationId":"RemoveAllocation","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is the name of the allocation you wish to delete","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.Allocation"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/audits":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return a collection of events against the team","operationId":"ListTeamAudit","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","default":"60m","description":"The duration to retrieve from the audit log","name":"since","in":"query"}],"responses":{"200":{"description":"A collection of audit events against the team","schema":{"$ref":"#/definitions/v1.AuditEventList"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"Team does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/clusters":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Lists all clusters for a team","operationId":"ListClusters","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"List of all clusters for a team","schema":{"$ref":"#/definitions/v1.ClusterList"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/clusters/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a cluster","operationId":"GetCluster","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the kubernetes cluster you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"The requested cluster details","schema":{"$ref":"#/definitions/v1.Cluster"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"the cluster with the given name doesn't exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Creates or updates a cluster","operationId":"UpdateCluster","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the cluster","name":"name","in":"path","required":true},{"description":"The definition for kubernetes cluster","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.Cluster"}}],"responses":{"200":{"description":"The cluster details","schema":{"$ref":"#/definitions/v1.Cluster"}},"400":{"description":"Validation error of supplied parameters/body","schema":{"$ref":"#/definitions/validation.Error"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Deletes a cluster","operationId":"RemoveCluster","parameters":[{"type":"string","description":"Is the name of the cluster","name":"name","in":"path","required":true},{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former cluster definition from the kore","schema":{"$ref":"#/definitions/v1.Cluster"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"the cluster with the given name doesn't exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/ekscredentials":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used tor return a list of Amazon EKS credentials which thhe team has access","operationId":"ListEKSCredentials","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSCredentialsList"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/ekscredentials/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used tor return a list of EKS Credentials which the team has access","operationId":"GetEKSCredentials","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the EKS Credentials you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSCredentials"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to provision or update a EKS credentials in the kore","operationId":"UpdateEKSCredentials","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the EKS credentials you are acting upon","name":"name","in":"path","required":true},{"description":"The definition for EKS Credentials","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1alpha1.EKSCredentials"}}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSCredentials"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to delete a EKS credentials from the kore","operationId":"DeleteEKSCredentials","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the EKS credentials you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSCredentials"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/eksnodegroups":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used tor return a list of Amazon EKS clusters which the team has access","operationId":"findEKSNodeGroups","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSNodeGroupList"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/eksnodegroups/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used to return a EKS cluster which the team has access","operationId":"findEKSNodeGroup","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is the name of the EKS nodegroup","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSNodeGroup"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/ekss":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used to return a list of Amazon EKS clusters which thhe team has access","operationId":"findEKSs","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSList"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/ekss/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used to return a EKS cluster which the team has access","operationId":"findEKS","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the EKS cluster you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKS"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/eksvpcs":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used to return a list of Amazon EKS VPC which thhe team has access","operationId":"findEKSVPCs","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSVPCList"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/eksvpcs/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used to return a EKS VPC which the team has access","operationId":"findEKSVPC","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the EKS VPC you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSVPC"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to provision or update a EKS VPC in the kore","operationId":"updateEKSVPC","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the EKS VPC you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSVPC"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to delete a EKS VPC from the kore","operationId":"deleteEKSVPC","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the EKS VPC you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.EKSVPC"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/gkecredentials":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a list of GKE Credentials to which the team has access","operationId":"ListGKECredentials","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.GKECredentialsList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/gkecredentials/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a specific GKE Credential to which the team has access","operationId":"GetGKECredential","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the GKE cluster you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.GKECredentials"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Creates or updates a specific GKE Credential to which the team has access","operationId":"UpdateGKECredential","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the GKE cluster you are acting upon","name":"name","in":"path","required":true},{"description":"The definition for GKE Credentials","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1alpha1.GKECredentials"}}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.GKECredentials"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Deletes a specific GKE Credential from the team","operationId":"RemoveGKECredential","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the GKE cluster you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.GKECredentials"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/gkes":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a list of Google Container Engine clusters which the team has access","operationId":"ListGKEs","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.GKEList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/gkes/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a specific Google Container Engine cluster to which the team has access","operationId":"GetGKE","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the GKE cluster you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.GKE"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/invites/generate":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to generate a link which provides automatic membership of the team","operationId":"GenerateInviteLink","parameters":[{"type":"string","description":"The name of the team you are creating an invition link","name":"team","in":"path","required":true},{"type":"string","default":"1h","description":"The expiration of the generated link","name":"expire","in":"query"}],"responses":{"200":{"description":"A generated URI which can be used to join a team","schema":{"type":"string"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/invites/generate/{user}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to generate for a specific user to join a team","operationId":"GenerateInviteLinkForUser","parameters":[{"type":"string","description":"The name of the team you are creating an invition link","name":"team","in":"path","required":true},{"type":"string","description":"The username of the user the link should be limited for","name":"user","in":"path","required":true}],"responses":{"200":{"description":"A generated URI which users can use to join the team","schema":{"type":"string"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/invites/user":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return a list of all the users whom have pending invitations","operationId":"ListInvites","parameters":[{"type":"string","description":"The name of the team you are pulling the invitations for","name":"team","in":"path","required":true}],"responses":{"200":{"description":"A list of users whom have an invitation for the team","schema":{"$ref":"#/definitions/v1.TeamInvitationList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/invites/user/{user}":{"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to create an invitation for the team","operationId":"InviteUser","parameters":[{"type":"string","description":"The name of the team you are creating an invition","name":"team","in":"path","required":true},{"type":"string","description":"The name of the username of the user the invitation is for","name":"user","in":"path","required":true},{"type":"string","default":"1h","description":"The expiration of the generated link","name":"expire","in":"query"}],"responses":{"200":{"description":"Indicates the team invitation for the user has been successful"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to remove a user invitation for the team","operationId":"RemoveInvite","parameters":[{"type":"string","description":"The name of the team you are deleting the invitation","name":"team","in":"path","required":true},{"type":"string","description":"The username of the user whos invitation you are removing","name":"user","in":"path","required":true}],"responses":{"200":{"description":"Indicates the team invitation has been successful removed"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/kubernetes":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Lists all Kubernetes objects available for a team","operationId":"ListKubernetes","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.KubernetesList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/kubernetes/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"returns a specific Kubernetes object","operationId":"GetKubernetes","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the kubernetes object you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.Kubernetes"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/members":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a list of user memberships in the team","operationId":"ListTeamMembers","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains a collection of team memberships for this team","schema":{"$ref":"#/definitions/apiserver.List"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"Team does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/members/{user}":{"put":{"consumes":["application/json","*/*"],"produces":["application/json"],"summary":"Used to add a user to the team via membership","operationId":"AddTeamMember","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is the user you are adding to the team","name":"user","in":"path","required":true}],"responses":{"200":{"description":"The user has been successfully added to the team","schema":{"$ref":"#/definitions/v1.TeamMember"}},"400":{"description":"Validation error of supplied parameters/body","schema":{"$ref":"#/definitions/validation.Error"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"Team does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to remove team membership from the team","operationId":"RemoveTeamMember","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is the user you are removing from the team","name":"user","in":"path","required":true}],"responses":{"200":{"description":"The user has been successfully removed from the team","schema":{"$ref":"#/definitions/v1.TeamMember"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/namespaceclaims":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return all namespaces for the team","operationId":"ListNamespaces","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former definition from the kore","schema":{"$ref":"#/definitions/v1.NamespaceClaimList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/namespaceclaims/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return the details of a namespace within a team","operationId":"GetNamespace","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the namespace claim you are acting upon","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1.NamespaceClaim"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to create or update the details of a namespace within a team","operationId":"UpdateNamespace","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the namespace claim you are acting upon","name":"name","in":"path","required":true},{"description":"The definition for namespace claim","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.NamespaceClaim"}}],"responses":{"200":{"description":"Contains the definition from the kore","schema":{"$ref":"#/definitions/v1.NamespaceClaim"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to remove a namespace from a team","operationId":"RemoveNamespace","parameters":[{"type":"string","description":"Is name the of the namespace claim you are acting upon","name":"name","in":"path","required":true},{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former definition from the kore","schema":{"$ref":"#/definitions/v1.NamespaceClaim"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/organizations":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used tor return a list of gcp organizations","operationId":"ListGCPOrganizations","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.OrganizationList"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/organizations/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used tor return a specific gcp organization","operationId":"GetGCPOrganization","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the resource you are acting on","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.Organization"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to provision or update a gcp organization","operationId":"UpdateGCPOrganization","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the resource you are acting on","name":"name","in":"path","required":true},{"description":"The definition for GCP organization","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1alpha1.Organization"}}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.Organization"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to delete a managed gcp organization","operationId":"DeleteGCPOrganization","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the resource you are acting on","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.Organization"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/plans/{plan}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns the plan, the JSON schema of the plan, and what what parameters are allowed to be edited by this team when using the plan","operationId":"GetTeamPlanDetails","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the plan you're interested in","name":"plan","in":"path","required":true}],"responses":{"200":{"description":"Contains details of the plan","schema":{"$ref":"#/definitions/apiserver.TeamPlan"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"Team or plan doesn't exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/projectclaims":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used tor return a list of Google Container Engine clusters which thhe team has access","operationId":"findProjectClaims","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.ProjectClaimList"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/projectclaims/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is the used tor return a list of Google Container Engine clusters which thhe team has access","operationId":"findProjectClaim","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the resource you are acting on","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.ProjectClaim"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to provision or update a gcp project claim","operationId":"updateProjectClaim","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the resource you are acting on","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.ProjectClaim"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Is used to delete a managed gcp project claim","operationId":"deleteProjectClaim","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the resource you are acting on","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the former team definition from the kore","schema":{"$ref":"#/definitions/v1alpha1.ProjectClaim"}},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/secrets":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to return all the secrets within the team","operationId":"ListTeamSecrets","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the definition for the resource","schema":{"$ref":"#/definitions/v1.Secret"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/teams/{team}/secrets/{name}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to retrieve the secret from the team","operationId":"GetTeamSecret","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of the secert in the name","name":"name","in":"path","required":true}],"responses":{"200":{"description":"Contains the definition for the resource","schema":{"$ref":"#/definitions/v1.Secret"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to update the secret in the team","operationId":"UpdateTeamSecret","parameters":[{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true},{"type":"string","description":"Is name the of secret you are creating / updating","name":"name","in":"path","required":true},{"description":"The definition for the secret you are creating or updating","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.Secret"}}],"responses":{"200":{"description":"Contains updated definition of the secret","schema":{"$ref":"#/definitions/v1.Secret"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to delete the secret from team","operationId":"DeleteTeamSecret","parameters":[{"type":"string","description":"Is name the of the secret you are acting upon","name":"name","in":"path","required":true},{"type":"string","description":"Is the name of the team you are acting within","name":"team","in":"path","required":true}],"responses":{"200":{"description":"Contains the former definition of the secret","schema":{"$ref":"#/definitions/v1.Secret"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/users":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns all the users in the kore","operationId":"ListUsers","responses":{"200":{"description":"A list of all the users in the kore","schema":{"$ref":"#/definitions/v1.UserList"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/users/{user}":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Return information related to the specific user in the kore","operationId":"GetUser","parameters":[{"type":"string","description":"The name of the user you wish to retrieve","name":"user","in":"path","required":true}],"responses":{"200":{"description":"Contains the user definition from the kore","schema":{"$ref":"#/definitions/v1.User"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"User does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"put":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to create or update a user in the kore","operationId":"UpdateUser","parameters":[{"type":"string","description":"The name of the user you are updating or creating in the kore","name":"user","in":"path","required":true},{"description":"The specification for a user in the kore","name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/v1.User"}}],"responses":{"200":{"description":"Contains the user definition from the kore","schema":{"$ref":"#/definitions/v1.User"}},"400":{"description":"Validation error of supplied parameters/body","schema":{"$ref":"#/definitions/validation.Error"}},"401":{"description":"If not authenticated"},"403":{"description":"If authenticated but not authorized"},"404":{"description":"User does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}},"delete":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to delete a user from the kore","operationId":"RemoveUser","parameters":[{"type":"string","description":"The name of the user you are deleting from the kore","name":"user","in":"path","required":true}],"responses":{"200":{"description":"Contains the former user definition from the kore","schema":{"$ref":"#/definitions/v1.User"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/users/{user}/teams":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns a list of teams the user is a member of","operationId":"ListUserTeams","parameters":[{"type":"string","description":"The name of the user whos team membership you wish to see","name":"user","in":"path","required":true}],"responses":{"200":{"description":"Response is a team list containing the teams the user is a member of","schema":{"$ref":"#/definitions/v1.TeamList"}},"404":{"description":"User does not exist"},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/api/v1alpha1/whoami":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Returns information about who the user is and what teams they are a member","operationId":"WhoAmI","responses":{"200":{"description":"A list of all the users in the kore","schema":{"$ref":"#/definitions/types.WhoAmI"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/healthz":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to start the authorization flow for user authentication","operationId":"GetHealth","responses":{"200":{"description":"Health check response","schema":{"$ref":"#/definitions/types.Health"}},"500":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/oauth/authorize":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to start the authorization flow for user authentication","operationId":"LoginAttempted","parameters":[{"type":"string","description":"The rediection url, i.e. the location to redirect post","name":"redirect_url","in":"query","required":true}],"responses":{"200":{"description":"OK"},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}},"/oauth/callback":{"get":{"consumes":["application/json"],"produces":["application/json"],"summary":"Used to handle the authorization callback from the identity provider","operationId":"LoginCallback","parameters":[{"type":"string","description":"The authorization code returned from the identity provider","name":"code","in":"query","required":true},{"type":"string","description":"The state parameter which was passed on authorization request","name":"state","in":"query","required":true}],"responses":{"200":{"description":"OK"},"default":{"description":"A generic API error containing the cause of the error","schema":{"$ref":"#/definitions/apiserver.Error"}}}}}},"definitions":{"apiserver.Error":{"required":["code","detail","message","uri","verb"],"properties":{"code":{"type":"integer","format":"int32"},"detail":{"type":"string"},"message":{"type":"string"},"uri":{"type":"string"},"verb":{"type":"string"}}},"apiserver.List":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"type":"string"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"apiserver.TeamPlan":{"required":["schema","parameterEditable"],"properties":{"parameterEditable":{"type":"object","additionalProperties":{"type":"boolean"}},"plan":{"$ref":"#/definitions/v1.PlanSpec"},"schema":{"type":"string"}}},"types.Health":{"required":["healthy"],"properties":{"healthy":{"type":"boolean"}}},"types.TeamInvitationResponse":{"required":["team"],"properties":{"team":{"type":"string"}}},"types.WhoAmI":{"properties":{"email":{"type":"string"},"teams":{"type":"array","items":{"type":"string"}},"username":{"type":"string"}}},"v1.Allocation":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.AllocationSpec"},"status":{"$ref":"#/definitions/v1.AllocationStatus"}}},"v1.AllocationList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.Allocation"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.AllocationSpec":{"required":["name","summary","resource","teams"],"properties":{"name":{"type":"string"},"resource":{"$ref":"#/definitions/v1.Ownership"},"summary":{"type":"string"},"teams":{"type":"array","items":{"type":"string"}}}},"v1.AllocationStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.AuditEvent":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.AuditEventSpec"}}},"v1.AuditEventList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.AuditEvent"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.AuditEventSpec":{"properties":{"apiVersion":{"type":"string"},"completedAt":{"type":"string"},"createdAt":{"type":"string"},"id":{"type":"integer","format":"int32"},"message":{"type":"string"},"operation":{"type":"string"},"resource":{"type":"string"},"resourceURI":{"type":"string"},"responseCode":{"type":"integer","format":"int32"},"startedAt":{"type":"string"},"team":{"type":"string"},"user":{"type":"string"},"verb":{"type":"string"}}},"v1.Cluster":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.ClusterSpec"},"status":{"$ref":"#/definitions/v1.ClusterStatus"}}},"v1.ClusterList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.Cluster"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.ClusterSpec":{"required":["kind","plan","configuration","credentials"],"properties":{"configuration":{"type":"object"},"credentials":{"$ref":"#/definitions/v1.Ownership"},"kind":{"type":"string"},"plan":{"type":"string"}}},"v1.ClusterStatus":{"properties":{"apiEndpoint":{"type":"string"},"authProxyEndpoint":{"type":"string"},"caCertificate":{"type":"string"},"components":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"message":{"type":"string"},"status":{"type":"string"}}},"v1.ClusterUser":{"required":["username","roles"],"properties":{"roles":{"type":"array","items":{"type":"string"}},"username":{"type":"string"}}},"v1.Component":{"properties":{"detail":{"type":"string"},"message":{"type":"string"},"name":{"type":"string"},"status":{"type":"string"}}},"v1.Condition":{"required":["message","detail"],"properties":{"detail":{"type":"string"},"message":{"type":"string"}}},"v1.GithubIDP":{"required":["clientID","clientSecret","orgs"],"properties":{"clientID":{"type":"string"},"clientSecret":{"type":"string"},"orgs":{"type":"array","items":{"type":"string"}}}},"v1.GoogleIDP":{"required":["clientID","clientSecret","domains"],"properties":{"clientID":{"type":"string"},"clientSecret":{"type":"string"},"domains":{"type":"array","items":{"type":"string"}}}},"v1.IDP":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.IDPSpec"},"status":{"$ref":"#/definitions/v1.IDPStatus"}}},"v1.IDPClient":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.IDPClientSpec"},"status":{"$ref":"#/definitions/v1.IDPClientStatus"}}},"v1.IDPClientSpec":{"required":["displayName","secret","id","redirectURIs"],"properties":{"displayName":{"type":"string"},"id":{"type":"string"},"redirectURIs":{"type":"array","items":{"type":"string"}},"secret":{"type":"string"}}},"v1.IDPClientStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.IDPConfig":{"properties":{"github":{"$ref":"#/definitions/v1.GithubIDP"},"google":{"$ref":"#/definitions/v1.GoogleIDP"},"oidc":{"$ref":"#/definitions/v1.OIDCIDP"},"oidcdirect":{"$ref":"#/definitions/v1.StaticOIDCIDP"},"saml":{"$ref":"#/definitions/v1.SAMLIDP"}}},"v1.IDPSpec":{"required":["displayName","config"],"properties":{"config":{"$ref":"#/definitions/v1.IDPConfig"},"displayName":{"type":"string"}}},"v1.IDPStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.Kubernetes":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.KubernetesSpec"},"status":{"$ref":"#/definitions/v1.KubernetesStatus"}}},"v1.KubernetesList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.Kubernetes"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.KubernetesSpec":{"properties":{"authProxyAllowedIPs":{"type":"array","items":{"type":"string"}},"authProxyImage":{"type":"string"},"cluster":{"$ref":"#/definitions/v1.Ownership"},"clusterUsers":{"type":"array","items":{"$ref":"#/definitions/v1.ClusterUser"}},"defaultTeamRole":{"type":"string"},"domain":{"type":"string"},"enableDefaultTrafficBlock":{"type":"boolean"},"inheritTeamMembers":{"type":"boolean"},"provider":{"$ref":"#/definitions/v1.Ownership"}}},"v1.KubernetesStatus":{"properties":{"apiEndpoint":{"type":"string"},"caCertificate":{"type":"string"},"components":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"endpoint":{"type":"string"},"status":{"type":"string"}}},"v1.ListMeta":{"description":"ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.","properties":{"continue":{"description":"continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.","type":"string"},"remainingItemCount":{"description":"remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.","type":"integer","format":"int64"},"resourceVersion":{"description":"String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency","type":"string"},"selfLink":{"description":"selfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.","type":"string"}}},"v1.ManagedFieldsEntry":{"description":"ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.","properties":{"apiVersion":{"description":"APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.","type":"string"},"fieldsType":{"description":"FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"","type":"string"},"fieldsV1":{"description":"FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.","type":"string"},"manager":{"description":"Manager is an identifier of the workflow managing these fields.","type":"string"},"operation":{"description":"Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.","type":"string"},"time":{"description":"Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'","type":"string"}}},"v1.NamespaceClaim":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.NamespaceClaimSpec"},"status":{"$ref":"#/definitions/v1.NamespaceClaimStatus"}}},"v1.NamespaceClaimList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.NamespaceClaim"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.NamespaceClaimSpec":{"required":["cluster","name"],"properties":{"annotations":{"type":"object","additionalProperties":{"type":"string"}},"cluster":{"$ref":"#/definitions/v1.Ownership"},"labels":{"type":"object","additionalProperties":{"type":"string"}},"name":{"type":"string"}}},"v1.NamespaceClaimStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.OIDCIDP":{"required":["clientID","clientSecret","issuer","clientScopes","userClaims"],"properties":{"clientID":{"type":"string"},"clientScopes":{"type":"array","items":{"type":"string"}},"clientSecret":{"type":"string"},"issuer":{"type":"string"},"userClaims":{"type":"array","items":{"type":"string"}}}},"v1.ObjectMeta":{"description":"ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.","properties":{"annotations":{"description":"Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations","type":"object","additionalProperties":{"type":"string"}},"clusterName":{"description":"The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.","type":"string"},"creationTimestamp":{"description":"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata","type":"string"},"deletionGracePeriodSeconds":{"description":"Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.","type":"integer","format":"int64"},"deletionTimestamp":{"description":"DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata","type":"string"},"finalizers":{"description":"Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.","type":"array","items":{"type":"string"}},"generateName":{"description":"GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency","type":"string"},"generation":{"description":"A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.","type":"integer","format":"int64"},"labels":{"description":"Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels","type":"object","additionalProperties":{"type":"string"}},"managedFields":{"description":"ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.","type":"array","items":{"$ref":"#/definitions/v1.ManagedFieldsEntry"}},"name":{"description":"Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names","type":"string"},"namespace":{"description":"Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces","type":"string"},"ownerReferences":{"description":"List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.","type":"array","items":{"$ref":"#/definitions/v1.OwnerReference"}},"resourceVersion":{"description":"An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency","type":"string"},"selfLink":{"description":"SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.","type":"string"},"uid":{"description":"UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids","type":"string"}}},"v1.OwnerReference":{"description":"OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.","required":["apiVersion","kind","name","uid"],"properties":{"apiVersion":{"description":"API version of the referent.","type":"string"},"blockOwnerDeletion":{"description":"If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.","type":"boolean"},"controller":{"description":"If true, this reference points to the managing controller.","type":"boolean"},"kind":{"description":"Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"name":{"description":"Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names","type":"string"},"uid":{"description":"UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids","type":"string"}}},"v1.Ownership":{"required":["group","version","kind","namespace","name"],"properties":{"group":{"type":"string"},"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"},"version":{"type":"string"}}},"v1.Plan":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.PlanSpec"},"status":{"$ref":"#/definitions/v1.PlanStatus"}}},"v1.PlanList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.Plan"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.PlanPolicy":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.PlanPolicySpec"},"status":{"$ref":"#/definitions/v1.PlanPolicyStatus"}}},"v1.PlanPolicyList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.PlanPolicy"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.PlanPolicyProperty":{"required":["name","allowUpdate","disallowUpdate"],"properties":{"allowUpdate":{"type":"boolean"},"disallowUpdate":{"type":"boolean"},"name":{"type":"string"}}},"v1.PlanPolicySpec":{"required":["kind","summary","description","properties"],"properties":{"description":{"type":"string"},"kind":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}},"properties":{"type":"array","items":{"$ref":"#/definitions/v1.PlanPolicyProperty"}},"summary":{"type":"string"}}},"v1.PlanPolicyStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.PlanSpec":{"required":["kind","description","summary","configuration"],"properties":{"configuration":{"type":"object"},"description":{"type":"string"},"kind":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}},"summary":{"type":"string"}}},"v1.PlanStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.SAMLIDP":{"required":["ssoURL","caData","usernameAttr","emailAttr"],"properties":{"allowedGroups":{"type":"array","items":{"type":"string"}},"caData":{"type":"string"},"emailAttr":{"type":"string"},"groupsAttr":{"type":"string"},"groupsDelim":{"type":"string"},"ssoURL":{"type":"string"},"usernameAttr":{"type":"string"}}},"v1.Secret":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.SecretSpec"},"status":{"$ref":"#/definitions/v1.SecretStatus"}}},"v1.SecretReference":{"description":"SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace","properties":{"name":{"description":"Name is unique within a namespace to reference a secret resource.","type":"string"},"namespace":{"description":"Namespace defines the space within which the secret name must be unique.","type":"string"}}},"v1.SecretSpec":{"required":["type","description"],"properties":{"data":{"type":"object","additionalProperties":{"type":"string"}},"description":{"type":"string"},"type":{"type":"string"}}},"v1.SecretStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"},"systemManaged":{"type":"boolean"},"verified":{"type":"boolean"}}},"v1.StaticOIDCIDP":{"required":["clientID","clientSecret","issuer","clientScopes","userClaims"],"properties":{"clientID":{"type":"string"},"clientScopes":{"type":"array","items":{"type":"string"}},"clientSecret":{"type":"string"},"issuer":{"type":"string"},"userClaims":{"type":"array","items":{"type":"string"}}}},"v1.Team":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.TeamSpec"},"status":{"$ref":"#/definitions/v1.TeamStatus"}}},"v1.TeamInvitation":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.TeamInvitationSpec"},"status":{"$ref":"#/definitions/v1.TeamInvitationStatus"}}},"v1.TeamInvitationList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.TeamInvitation"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.TeamInvitationSpec":{"required":["username","team"],"properties":{"team":{"type":"string"},"username":{"type":"string"}}},"v1.TeamInvitationStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.TeamList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.Team"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.TeamMember":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.TeamMemberSpec"},"status":{"$ref":"#/definitions/v1.TeamMemberStatus"}}},"v1.TeamMemberSpec":{"required":["roles","team","username"],"properties":{"roles":{"type":"array","items":{"type":"string"}},"team":{"type":"string"},"username":{"type":"string"}}},"v1.TeamMemberStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.TeamSpec":{"required":["summary","description"],"properties":{"description":{"type":"string"},"summary":{"type":"string"}}},"v1.TeamStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1.User":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1.UserSpec"},"status":{"$ref":"#/definitions/v1.UserStatus"}}},"v1.UserList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1.User"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1.UserSpec":{"required":["disabled","email","username"],"properties":{"disabled":{"type":"boolean"},"email":{"type":"string"},"username":{"type":"string"}}},"v1.UserStatus":{"required":["conditions","status"],"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"}}},"v1alpha1.AuthorizedNetwork":{"required":["name","cidr"],"properties":{"cidr":{"type":"string"},"name":{"type":"string"}}},"v1alpha1.EKS":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.EKSSpec"},"status":{"$ref":"#/definitions/v1alpha1.EKSStatus"}}},"v1alpha1.EKSCredentials":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.EKSCredentialsSpec"},"status":{"$ref":"#/definitions/v1alpha1.EKSCredentialsStatus"}}},"v1alpha1.EKSCredentialsList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.EKSCredentials"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.EKSCredentialsSpec":{"required":["secretAccessKey","accessKeyID","accountID"],"properties":{"accessKeyID":{"type":"string"},"accountID":{"type":"string"},"secretAccessKey":{"type":"string"}}},"v1alpha1.EKSCredentialsStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"},"verified":{"type":"boolean"}}},"v1alpha1.EKSList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.EKS"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.EKSNodeGroup":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.EKSNodeGroupSpec"},"status":{"$ref":"#/definitions/v1alpha1.EKSNodeGroupStatus"}}},"v1alpha1.EKSNodeGroupList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.EKSNodeGroup"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.EKSNodeGroupSpec":{"required":["amiType","diskSize","desiredSize","maxSize","minSize","subnets","region","eC2SSHKey","credentials"],"properties":{"amiType":{"type":"string"},"cluster":{"$ref":"#/definitions/v1.Ownership"},"credentials":{"$ref":"#/definitions/v1.Ownership"},"desiredSize":{"type":"integer","format":"int64"},"diskSize":{"type":"integer","format":"int64"},"eC2SSHKey":{"type":"string"},"instanceType":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}},"maxSize":{"type":"integer","format":"int64"},"minSize":{"type":"integer","format":"int64"},"region":{"type":"string"},"releaseVersion":{"type":"string"},"sshSourceSecurityGroups":{"type":"array","items":{"type":"string"}},"subnets":{"type":"array","items":{"type":"string"}},"tags":{"type":"object","additionalProperties":{"type":"string"}},"version":{"type":"string"}}},"v1alpha1.EKSNodeGroupStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"nodeIAMRole":{"type":"string"},"status":{"type":"string"}}},"v1alpha1.EKSSpec":{"required":["region","subnetIDs","credentials"],"properties":{"authorizedMasterNetworks":{"type":"array","items":{"type":"string"}},"cluster":{"$ref":"#/definitions/v1.Ownership"},"credentials":{"$ref":"#/definitions/v1.Ownership"},"region":{"type":"string"},"securityGroupIDs":{"type":"array","items":{"type":"string"}},"subnetIDs":{"type":"array","items":{"type":"string"}},"version":{"type":"string"}}},"v1alpha1.EKSStatus":{"properties":{"caCertificate":{"type":"string"},"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"endpoint":{"type":"string"},"roleARN":{"type":"string"},"status":{"type":"string"}}},"v1alpha1.EKSVPC":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.EKSVPCSpec"},"status":{"$ref":"#/definitions/v1alpha1.EKSVPCStatus"}}},"v1alpha1.EKSVPCList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.EKSVPC"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.EKSVPCSpec":{"required":["credentials","privateIPV4Cidr","region"],"properties":{"cluster":{"$ref":"#/definitions/v1.Ownership"},"credentials":{"$ref":"#/definitions/v1.Ownership"},"privateIPV4Cidr":{"type":"string"},"region":{"type":"string"}}},"v1alpha1.EKSVPCStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"infra":{"$ref":"#/definitions/v1alpha1.Infra"},"status":{"type":"string"}}},"v1alpha1.GKE":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.GKESpec"},"status":{"$ref":"#/definitions/v1alpha1.GKEStatus"}}},"v1alpha1.GKECredentials":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.GKECredentialsSpec"},"status":{"$ref":"#/definitions/v1alpha1.GKECredentialsStatus"}}},"v1alpha1.GKECredentialsList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.GKECredentials"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.GKECredentialsSpec":{"required":["account","project"],"properties":{"account":{"type":"string"},"project":{"type":"string"},"region":{"type":"string"}}},"v1alpha1.GKECredentialsStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Condition"}},"status":{"type":"string"},"verified":{"type":"boolean"}}},"v1alpha1.GKEList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.GKE"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.GKESpec":{"required":["credentials","description","version","size","maxSize","diskSize","imageType","machineType","authorizedMasterNetworks","network","subnetwork","servicesIPV4Cidr","clusterIPV4Cidr","enableAutorepair","enableAutoscaler","enableAutoupgrade","enableHorizontalPodAutoscaler","enableHTTPLoadBalancer","enableIstio","enableShieldedNodes","enableStackDriverLogging","enableStackDriverMetrics","enablePrivateEndpoint","enablePrivateNetwork","masterIPV4Cidr","maintenanceWindow"],"properties":{"authorizedMasterNetworks":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.AuthorizedNetwork"}},"cluster":{"$ref":"#/definitions/v1.Ownership"},"clusterIPV4Cidr":{"type":"string"},"credentials":{"$ref":"#/definitions/v1.Ownership"},"description":{"type":"string"},"diskSize":{"type":"integer","format":"int64"},"enableAutorepair":{"type":"boolean"},"enableAutoscaler":{"type":"boolean"},"enableAutoupgrade":{"type":"boolean"},"enableHTTPLoadBalancer":{"type":"boolean"},"enableHorizontalPodAutoscaler":{"type":"boolean"},"enableIstio":{"type":"boolean"},"enablePrivateEndpoint":{"type":"boolean"},"enablePrivateNetwork":{"type":"boolean"},"enableShieldedNodes":{"type":"boolean"},"enableStackDriverLogging":{"type":"boolean"},"enableStackDriverMetrics":{"type":"boolean"},"imageType":{"type":"string"},"machineType":{"type":"string"},"maintenanceWindow":{"type":"string"},"masterIPV4Cidr":{"type":"string"},"maxSize":{"type":"integer","format":"int64"},"network":{"type":"string"},"region":{"type":"string"},"servicesIPV4Cidr":{"type":"string"},"size":{"type":"integer","format":"int64"},"subnetwork":{"type":"string"},"tags":{"type":"object","additionalProperties":{"type":"string"}},"version":{"type":"string"}}},"v1alpha1.GKEStatus":{"properties":{"caCertificate":{"type":"string"},"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"endpoint":{"type":"string"},"status":{"type":"string"}}},"v1alpha1.Infra":{"properties":{"ipv4EgressAddresses":{"type":"array","items":{"type":"string"}},"privateSubnetIDs":{"type":"array","items":{"type":"string"}},"publicSubnetIDs":{"type":"array","items":{"type":"string"}},"securityGroupIDs":{"type":"array","items":{"type":"string"}}}},"v1alpha1.Organization":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.OrganizationSpec"},"status":{"$ref":"#/definitions/v1alpha1.OrganizationStatus"}}},"v1alpha1.OrganizationList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.Organization"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.OrganizationSpec":{"required":["parentType","parentID","billingAccount","serviceAccount","credentialsRef"],"properties":{"billingAccount":{"type":"string"},"credentialsRef":{"$ref":"#/definitions/v1.SecretReference"},"parentID":{"type":"string"},"parentType":{"type":"string"},"serviceAccount":{"type":"string"},"tokenRef":{"$ref":"#/definitions/v1.SecretReference"}}},"v1alpha1.OrganizationStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"projectID":{"type":"string"},"status":{"type":"string"}}},"v1alpha1.ProjectClaim":{"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ObjectMeta"},"spec":{"$ref":"#/definitions/v1alpha1.ProjectClaimSpec"},"status":{"$ref":"#/definitions/v1alpha1.ProjectClaimStatus"}}},"v1alpha1.ProjectClaimList":{"required":["items"],"properties":{"apiVersion":{"description":"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources","type":"string"},"items":{"type":"array","items":{"$ref":"#/definitions/v1alpha1.ProjectClaim"}},"kind":{"description":"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds","type":"string"},"metadata":{"$ref":"#/definitions/v1.ListMeta"}}},"v1alpha1.ProjectClaimSpec":{"required":["organization"],"properties":{"organization":{"$ref":"#/definitions/v1.Ownership"}}},"v1alpha1.ProjectClaimStatus":{"properties":{"conditions":{"type":"array","items":{"$ref":"#/definitions/v1.Component"}},"credentialRef":{"$ref":"#/definitions/v1.SecretReference"},"projectID":{"type":"string"},"status":{"type":"string"}}},"validation.Error":{"required":["code","message","fieldErrors"],"properties":{"code":{"type":"integer","format":"int32"},"fieldErrors":{"type":"array","items":{"$ref":"#/definitions/validation.FieldError"}},"message":{"type":"string"}}},"validation.FieldError":{"required":["field","errCode","message"],"properties":{"errCode":{"type":"string"},"field":{"type":"string"},"message":{"type":"string"}}}},"securityDefinitions":{"OAuth2":{"type":"oauth2","flow":"accessCode","authorizationUrl":"http://localhost:10080/auth","tokenUrl":"http://localhost:10080/token","scopes":{"admin":"Admin scope","team":"Team scope"}}},"security":[{"OAuth2":["admin","team"]}]}
+{
+ "swagger": "2.0",
+ "info": {
+  "description": "Kore API provides the frontend API for the Appvia Kore (kore.appvia.io)",
+  "title": "Appvia Kore API",
+  "contact": {
+   "name": "Appvia Ltd",
+   "url": "https://appvia.io",
+   "email": "info@appvia.io"
+  },
+  "license": {
+   "name": "Apache 2.0",
+   "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
+  "version": "0.0.1"
+ },
+ "paths": {
+  "/api/v1alpha1/audits": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return all the audit event across all the teams",
+    "operationId": "ListAuditEvents",
+    "parameters": [
+     {
+      "type": "string",
+      "default": "60m",
+      "description": "The time duration to return the events within, to a resolution of minutes",
+      "name": "since",
+      "in": "query"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A collection of events from the team",
+      "schema": {
+       "$ref": "#/definitions/v1.AuditEventList"
+      }
+     },
+     "400": {
+      "description": "Validation error of supplied parameters/body",
+      "schema": {
+       "$ref": "#/definitions/validation.Error"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/idp/clients/{name}": {
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Updates the definition for a specific idp client",
+    "operationId": "UpdateIDPClient",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the IDP client provider to update",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for the idp client",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.IDPClient"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "The configured client in the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.IDPClient"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/idp/configured": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a list of all the configured identity providers in the kore",
+    "operationId": "ListIDPs",
+    "responses": {
+     "200": {
+      "description": "A list of all the configured identity providers",
+      "schema": {
+       "type": "array",
+       "items": {
+        "$ref": "#/definitions/v1.IDP"
+       }
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/idp/configured/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns the definition for a specific identity provider",
+    "operationId": "GetIDP",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the configured IDP provider to retrieve",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "the specified identity provider",
+      "schema": {
+       "$ref": "#/definitions/v1.IDP"
+      }
+     },
+     "404": {
+      "description": "Indicate the class was not found in the kore"
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns the definition for a specific ID provider",
+    "operationId": "UpdateIDP",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the configured IDP provider to update",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for the ID provider",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.IDP"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A list of all the IDPs in the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.IDP"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/idp/default": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns the default identity provider configured in the kore",
+    "operationId": "GetDefaultIDP",
+    "responses": {
+     "200": {
+      "description": "The default configured identity provider",
+      "schema": {
+       "$ref": "#/definitions/v1.IDP"
+      }
+     },
+     "404": {
+      "description": "Indicate the class was not found in the kore"
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/idp/types": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a list of all the possible identity providers supported in the kore",
+    "operationId": "ListIDPTypes",
+    "responses": {
+     "200": {
+      "description": "A list of all the possible identity provider types",
+      "schema": {
+       "type": "array",
+       "items": {
+        "$ref": "#/definitions/v1.IDPConfig"
+       }
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/planpolicies": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns all the plan policies",
+    "operationId": "ListPlanPolicies",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Returns all plan policies for a specific resource type",
+      "name": "kind",
+      "in": "query"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A list of all the plan policies in the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.PlanPolicyList"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/planpolicies/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a specific plan policy from the kore",
+    "operationId": "GetPlanPolicy",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the plan policy you wish to retrieve",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the plan policy definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.PlanPolicy"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to create or update a plan policy in the kore",
+    "operationId": "UpdatePlanPolicy",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the plan policy you wish to update",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The specification for the plan policy you are updating",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.PlanPolicy"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the plan policy definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.PlanPolicy"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to delete a plan policy from the kore",
+    "operationId": "RemovePlanPolicy",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the plan policy you wish to delete",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the plan policy definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.PlanPolicy"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/plans": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns all the classes available to initialized in the kore",
+    "operationId": "ListPlans",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Returns all plans for a specific resource type",
+      "name": "kind",
+      "in": "query"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A list of all the plans",
+      "schema": {
+       "$ref": "#/definitions/v1.PlanList"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/plans/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a specific class plan from the kore",
+    "operationId": "GetPlan",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the plan you wish to retrieve",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the plan definition",
+      "schema": {
+       "$ref": "#/definitions/v1.Plan"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "the plan with the given name doesn't exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to create or update a plan in the kore",
+    "operationId": "UpdatePlan",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the plan you wish to create or update",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The specification for the plan you are creating or updating",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.Plan"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the plan definition",
+      "schema": {
+       "$ref": "#/definitions/v1.Plan"
+      }
+     },
+     "400": {
+      "description": "Validation error of supplied parameters/body",
+      "schema": {
+       "$ref": "#/definitions/validation.Error"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to delete a plan from the kore",
+    "operationId": "RemovePlan",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the plan you wish to delete",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the plan definition",
+      "schema": {
+       "$ref": "#/definitions/v1.Plan"
+      }
+     },
+     "400": {
+      "description": "Validation error of supplied parameters/body",
+      "schema": {
+       "$ref": "#/definitions/validation.Error"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "the plan with the given name doesn't exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/planschemas/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a specific plan schema from the kore",
+    "operationId": "GetPlanSchema",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the plan schema you wish to retrieve",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the plan schema definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.PlanPolicy"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns all the teams in the kore",
+    "operationId": "ListTeams",
+    "responses": {
+     "200": {
+      "description": "A list of all the teams in the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.TeamList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/invitation/{token}": {
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to verify and handle the team invitation generated links",
+    "operationId": "InvitationSubmit",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The generated base64 invitation token which was provided from the team",
+      "name": "token",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Indicates the generated link is valid and the user has been granted access",
+      "schema": {
+       "$ref": "#/definitions/types.TeamInvitationResponse"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Return information related to the specific team in the kore",
+    "operationId": "GetTeam",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Team"
+      }
+     },
+     "404": {
+      "description": "Team does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to create or update a team in the kore",
+    "operationId": "UpdateTeam",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "Contains the definition for a team in the kore",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.Team"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Team"
+      }
+     },
+     "304": {
+      "description": "Indicates the request was processed but no changes applied",
+      "schema": {
+       "$ref": "#/definitions/v1.Team"
+      }
+     },
+     "400": {
+      "description": "Validation error of supplied parameters/body",
+      "schema": {
+       "$ref": "#/definitions/validation.Error"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "Team does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to delete a team from the kore",
+    "operationId": "RemoveTeam",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Team"
+      }
+     },
+     "404": {
+      "description": "Team does not exist"
+     },
+     "406": {
+      "description": "Indicates you cannot delete the team for one or more reasons",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/allocations": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return a list of all the allocations in the team",
+    "operationId": "ListAllocations",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Retrieves all allocations which have been assigned to you",
+      "name": "assigned",
+      "in": "query"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.AllocationList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/allocations/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return an allocation within the team",
+    "operationId": "GetAllocation",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the name of the allocation you wish to return",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Allocation"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to create/update an allocation within the team.",
+    "operationId": "UpdateAllocation",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the name of the allocation you wish to update",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition of the Allocation",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.Allocation"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Allocation"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Remove an allocation from a team",
+    "operationId": "RemoveAllocation",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the name of the allocation you wish to delete",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Allocation"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/audits": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return a collection of events against the team",
+    "operationId": "ListTeamAudit",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "default": "60m",
+      "description": "The duration to retrieve from the audit log",
+      "name": "since",
+      "in": "query"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A collection of audit events against the team",
+      "schema": {
+       "$ref": "#/definitions/v1.AuditEventList"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "Team does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/clusters": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Lists all clusters for a team",
+    "operationId": "ListClusters",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "List of all clusters for a team",
+      "schema": {
+       "$ref": "#/definitions/v1.ClusterList"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/clusters/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a cluster",
+    "operationId": "GetCluster",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the kubernetes cluster you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "The requested cluster details",
+      "schema": {
+       "$ref": "#/definitions/v1.Cluster"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "the cluster with the given name doesn't exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Creates or updates a cluster",
+    "operationId": "UpdateCluster",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the cluster",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for kubernetes cluster",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.Cluster"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "The cluster details",
+      "schema": {
+       "$ref": "#/definitions/v1.Cluster"
+      }
+     },
+     "400": {
+      "description": "Validation error of supplied parameters/body",
+      "schema": {
+       "$ref": "#/definitions/validation.Error"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Deletes a cluster",
+    "operationId": "RemoveCluster",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the cluster",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former cluster definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Cluster"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "the cluster with the given name doesn't exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/ekscredentials": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used tor return a list of Amazon EKS credentials which thhe team has access",
+    "operationId": "ListEKSCredentials",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSCredentialsList"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/ekscredentials/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used tor return a list of EKS Credentials which the team has access",
+    "operationId": "GetEKSCredentials",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the EKS Credentials you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSCredentials"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to provision or update a EKS credentials in the kore",
+    "operationId": "UpdateEKSCredentials",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the EKS credentials you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for EKS Credentials",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSCredentials"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSCredentials"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to delete a EKS credentials from the kore",
+    "operationId": "DeleteEKSCredentials",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the EKS credentials you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSCredentials"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/eksnodegroups": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used tor return a list of Amazon EKS clusters which the team has access",
+    "operationId": "findEKSNodeGroups",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSNodeGroupList"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/eksnodegroups/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used to return a EKS cluster which the team has access",
+    "operationId": "findEKSNodeGroup",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the name of the EKS nodegroup",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSNodeGroup"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/ekss": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used to return a list of Amazon EKS clusters which thhe team has access",
+    "operationId": "findEKSs",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSList"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/ekss/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used to return a EKS cluster which the team has access",
+    "operationId": "findEKS",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the EKS cluster you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKS"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/eksvpcs": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used to return a list of Amazon EKS VPC which thhe team has access",
+    "operationId": "findEKSVPCs",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSVPCList"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/eksvpcs/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used to return a EKS VPC which the team has access",
+    "operationId": "findEKSVPC",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the EKS VPC you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSVPC"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to provision or update a EKS VPC in the kore",
+    "operationId": "updateEKSVPC",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the EKS VPC you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSVPC"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to delete a EKS VPC from the kore",
+    "operationId": "deleteEKSVPC",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the EKS VPC you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.EKSVPC"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/gkecredentials": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a list of GKE Credentials to which the team has access",
+    "operationId": "ListGKECredentials",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.GKECredentialsList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/gkecredentials/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a specific GKE Credential to which the team has access",
+    "operationId": "GetGKECredential",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the GKE cluster you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.GKECredentials"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Creates or updates a specific GKE Credential to which the team has access",
+    "operationId": "UpdateGKECredential",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the GKE cluster you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for GKE Credentials",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.GKECredentials"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.GKECredentials"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Deletes a specific GKE Credential from the team",
+    "operationId": "RemoveGKECredential",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the GKE cluster you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.GKECredentials"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/gkes": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a list of Google Container Engine clusters which the team has access",
+    "operationId": "ListGKEs",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.GKEList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/gkes/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a specific Google Container Engine cluster to which the team has access",
+    "operationId": "GetGKE",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the GKE cluster you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.GKE"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/invites/generate": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to generate a link which provides automatic membership of the team",
+    "operationId": "GenerateInviteLink",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the team you are creating an invition link",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "default": "1h",
+      "description": "The expiration of the generated link",
+      "name": "expire",
+      "in": "query"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A generated URI which can be used to join a team",
+      "schema": {
+       "type": "string"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/invites/generate/{user}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to generate for a specific user to join a team",
+    "operationId": "GenerateInviteLinkForUser",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the team you are creating an invition link",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "The username of the user the link should be limited for",
+      "name": "user",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A generated URI which users can use to join the team",
+      "schema": {
+       "type": "string"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/invites/user": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return a list of all the users whom have pending invitations",
+    "operationId": "ListInvites",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the team you are pulling the invitations for",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "A list of users whom have an invitation for the team",
+      "schema": {
+       "$ref": "#/definitions/v1.TeamInvitationList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/invites/user/{user}": {
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to create an invitation for the team",
+    "operationId": "InviteUser",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the team you are creating an invition",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "The name of the username of the user the invitation is for",
+      "name": "user",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "default": "1h",
+      "description": "The expiration of the generated link",
+      "name": "expire",
+      "in": "query"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Indicates the team invitation for the user has been successful"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to remove a user invitation for the team",
+    "operationId": "RemoveInvite",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the team you are deleting the invitation",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "The username of the user whos invitation you are removing",
+      "name": "user",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Indicates the team invitation has been successful removed"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/kubernetes": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Lists all Kubernetes objects available for a team",
+    "operationId": "ListKubernetes",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.KubernetesList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/kubernetes/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "returns a specific Kubernetes object",
+    "operationId": "GetKubernetes",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the kubernetes object you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.Kubernetes"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/members": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a list of user memberships in the team",
+    "operationId": "ListTeamMembers",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains a collection of team memberships for this team",
+      "schema": {
+       "$ref": "#/definitions/apiserver.List"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "Team does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/members/{user}": {
+   "put": {
+    "consumes": [
+     "application/json",
+     "*/*"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to add a user to the team via membership",
+    "operationId": "AddTeamMember",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the user you are adding to the team",
+      "name": "user",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "The user has been successfully added to the team",
+      "schema": {
+       "$ref": "#/definitions/v1.TeamMember"
+      }
+     },
+     "400": {
+      "description": "Validation error of supplied parameters/body",
+      "schema": {
+       "$ref": "#/definitions/validation.Error"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "Team does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to remove team membership from the team",
+    "operationId": "RemoveTeamMember",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the user you are removing from the team",
+      "name": "user",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "The user has been successfully removed from the team",
+      "schema": {
+       "$ref": "#/definitions/v1.TeamMember"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/namespaceclaims": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return all namespaces for the team",
+    "operationId": "ListNamespaces",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.NamespaceClaimList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/namespaceclaims/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return the details of a namespace within a team",
+    "operationId": "GetNamespace",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the namespace claim you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.NamespaceClaim"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to create or update the details of a namespace within a team",
+    "operationId": "UpdateNamespace",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the namespace claim you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for namespace claim",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.NamespaceClaim"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.NamespaceClaim"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to remove a namespace from a team",
+    "operationId": "RemoveNamespace",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is name the of the namespace claim you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.NamespaceClaim"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/organizations": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used tor return a list of gcp organizations",
+    "operationId": "ListGCPOrganizations",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.OrganizationList"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/organizations/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used tor return a specific gcp organization",
+    "operationId": "GetGCPOrganization",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the resource you are acting on",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.Organization"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to provision or update a gcp organization",
+    "operationId": "UpdateGCPOrganization",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the resource you are acting on",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for GCP organization",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.Organization"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.Organization"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to delete a managed gcp organization",
+    "operationId": "DeleteGCPOrganization",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the resource you are acting on",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.Organization"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/plans/{plan}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns the plan, the JSON schema of the plan, and what what parameters are allowed to be edited by this team when using the plan",
+    "operationId": "GetTeamPlanDetails",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the plan you're interested in",
+      "name": "plan",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains details of the plan",
+      "schema": {
+       "$ref": "#/definitions/apiserver.TeamPlan"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "Team or plan doesn't exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/projectclaims": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used tor return a list of Google Container Engine clusters which thhe team has access",
+    "operationId": "findProjectClaims",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.ProjectClaimList"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/projectclaims/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is the used tor return a list of Google Container Engine clusters which thhe team has access",
+    "operationId": "findProjectClaim",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the resource you are acting on",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.ProjectClaim"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to provision or update a gcp project claim",
+    "operationId": "updateProjectClaim",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the resource you are acting on",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.ProjectClaim"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Is used to delete a managed gcp project claim",
+    "operationId": "deleteProjectClaim",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the resource you are acting on",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former team definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1alpha1.ProjectClaim"
+      }
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/secrets": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to return all the secrets within the team",
+    "operationId": "ListTeamSecrets",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the definition for the resource",
+      "schema": {
+       "$ref": "#/definitions/v1.Secret"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/teams/{team}/secrets/{name}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to retrieve the secret from the team",
+    "operationId": "GetTeamSecret",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of the secert in the name",
+      "name": "name",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the definition for the resource",
+      "schema": {
+       "$ref": "#/definitions/v1.Secret"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to update the secret in the team",
+    "operationId": "UpdateTeamSecret",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is name the of secret you are creating / updating",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The definition for the secret you are creating or updating",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.Secret"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains updated definition of the secret",
+      "schema": {
+       "$ref": "#/definitions/v1.Secret"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to delete the secret from team",
+    "operationId": "DeleteTeamSecret",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "Is name the of the secret you are acting upon",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "Is the name of the team you are acting within",
+      "name": "team",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former definition of the secret",
+      "schema": {
+       "$ref": "#/definitions/v1.Secret"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/users": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns all the users in the kore",
+    "operationId": "ListUsers",
+    "responses": {
+     "200": {
+      "description": "A list of all the users in the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.UserList"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/users/{user}": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Return information related to the specific user in the kore",
+    "operationId": "GetUser",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the user you wish to retrieve",
+      "name": "user",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the user definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.User"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "User does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to create or update a user in the kore",
+    "operationId": "UpdateUser",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the user you are updating or creating in the kore",
+      "name": "user",
+      "in": "path",
+      "required": true
+     },
+     {
+      "description": "The specification for a user in the kore",
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.User"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the user definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.User"
+      }
+     },
+     "400": {
+      "description": "Validation error of supplied parameters/body",
+      "schema": {
+       "$ref": "#/definitions/validation.Error"
+      }
+     },
+     "401": {
+      "description": "If not authenticated"
+     },
+     "403": {
+      "description": "If authenticated but not authorized"
+     },
+     "404": {
+      "description": "User does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   },
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to delete a user from the kore",
+    "operationId": "RemoveUser",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the user you are deleting from the kore",
+      "name": "user",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contains the former user definition from the kore",
+      "schema": {
+       "$ref": "#/definitions/v1.User"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/users/{user}/teams": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns a list of teams the user is a member of",
+    "operationId": "ListUserTeams",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The name of the user whos team membership you wish to see",
+      "name": "user",
+      "in": "path",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Response is a team list containing the teams the user is a member of",
+      "schema": {
+       "$ref": "#/definitions/v1.TeamList"
+      }
+     },
+     "404": {
+      "description": "User does not exist"
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/api/v1alpha1/whoami": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Returns information about who the user is and what teams they are a member",
+    "operationId": "WhoAmI",
+    "responses": {
+     "200": {
+      "description": "A list of all the users in the kore",
+      "schema": {
+       "$ref": "#/definitions/types.WhoAmI"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/healthz": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to start the authorization flow for user authentication",
+    "operationId": "GetHealth",
+    "responses": {
+     "200": {
+      "description": "Health check response",
+      "schema": {
+       "$ref": "#/definitions/types.Health"
+      }
+     },
+     "500": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/oauth/authorize": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to start the authorization flow for user authentication",
+    "operationId": "LoginAttempted",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The rediection url, i.e. the location to redirect post",
+      "name": "redirect_url",
+      "in": "query",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "OK"
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  },
+  "/oauth/callback": {
+   "get": {
+    "consumes": [
+     "application/json"
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "summary": "Used to handle the authorization callback from the identity provider",
+    "operationId": "LoginCallback",
+    "parameters": [
+     {
+      "type": "string",
+      "description": "The authorization code returned from the identity provider",
+      "name": "code",
+      "in": "query",
+      "required": true
+     },
+     {
+      "type": "string",
+      "description": "The state parameter which was passed on authorization request",
+      "name": "state",
+      "in": "query",
+      "required": true
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "OK"
+     },
+     "default": {
+      "description": "A generic API error containing the cause of the error",
+      "schema": {
+       "$ref": "#/definitions/apiserver.Error"
+      }
+     }
+    }
+   }
+  }
+ },
+ "definitions": {
+  "apiserver.Error": {
+   "required": [
+    "code",
+    "detail",
+    "message",
+    "uri",
+    "verb"
+   ],
+   "properties": {
+    "code": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "detail": {
+     "type": "string"
+    },
+    "message": {
+     "type": "string"
+    },
+    "uri": {
+     "type": "string"
+    },
+    "verb": {
+     "type": "string"
+    }
+   }
+  },
+  "apiserver.List": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "apiserver.TeamPlan": {
+   "required": [
+    "schema",
+    "parameterEditable"
+   ],
+   "properties": {
+    "parameterEditable": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "boolean"
+     }
+    },
+    "plan": {
+     "$ref": "#/definitions/v1.PlanSpec"
+    },
+    "schema": {
+     "type": "string"
+    }
+   }
+  },
+  "types.Health": {
+   "required": [
+    "healthy"
+   ],
+   "properties": {
+    "healthy": {
+     "type": "boolean"
+    }
+   }
+  },
+  "types.TeamInvitationResponse": {
+   "required": [
+    "team"
+   ],
+   "properties": {
+    "team": {
+     "type": "string"
+    }
+   }
+  },
+  "types.WhoAmI": {
+   "properties": {
+    "email": {
+     "type": "string"
+    },
+    "teams": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "username": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.Allocation": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.AllocationSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.AllocationStatus"
+    }
+   }
+  },
+  "v1.AllocationList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Allocation"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.AllocationSpec": {
+   "required": [
+    "name",
+    "summary",
+    "resource",
+    "teams"
+   ],
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "resource": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "summary": {
+     "type": "string"
+    },
+    "teams": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "v1.AllocationStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.AuditEvent": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.AuditEventSpec"
+    }
+   }
+  },
+  "v1.AuditEventList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.AuditEvent"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.AuditEventSpec": {
+   "properties": {
+    "apiVersion": {
+     "type": "string"
+    },
+    "completedAt": {
+     "type": "string"
+    },
+    "createdAt": {
+     "type": "string"
+    },
+    "id": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "message": {
+     "type": "string"
+    },
+    "operation": {
+     "type": "string"
+    },
+    "resource": {
+     "type": "string"
+    },
+    "resourceURI": {
+     "type": "string"
+    },
+    "responseCode": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "startedAt": {
+     "type": "string"
+    },
+    "team": {
+     "type": "string"
+    },
+    "user": {
+     "type": "string"
+    },
+    "verb": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.Cluster": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.ClusterSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.ClusterStatus"
+    }
+   }
+  },
+  "v1.ClusterList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Cluster"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.ClusterSpec": {
+   "required": [
+    "kind",
+    "plan",
+    "configuration",
+    "credentials"
+   ],
+   "properties": {
+    "configuration": {
+     "type": "object"
+    },
+    "credentials": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "kind": {
+     "type": "string"
+    },
+    "plan": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.ClusterStatus": {
+   "properties": {
+    "apiEndpoint": {
+     "type": "string"
+    },
+    "authProxyEndpoint": {
+     "type": "string"
+    },
+    "caCertificate": {
+     "type": "string"
+    },
+    "components": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "message": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.ClusterUser": {
+   "required": [
+    "username",
+    "roles"
+   ],
+   "properties": {
+    "roles": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "username": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.Component": {
+   "properties": {
+    "detail": {
+     "type": "string"
+    },
+    "message": {
+     "type": "string"
+    },
+    "name": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.Condition": {
+   "required": [
+    "message",
+    "detail"
+   ],
+   "properties": {
+    "detail": {
+     "type": "string"
+    },
+    "message": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.GithubIDP": {
+   "required": [
+    "clientID",
+    "clientSecret",
+    "orgs"
+   ],
+   "properties": {
+    "clientID": {
+     "type": "string"
+    },
+    "clientSecret": {
+     "type": "string"
+    },
+    "orgs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "v1.GoogleIDP": {
+   "required": [
+    "clientID",
+    "clientSecret",
+    "domains"
+   ],
+   "properties": {
+    "clientID": {
+     "type": "string"
+    },
+    "clientSecret": {
+     "type": "string"
+    },
+    "domains": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "v1.IDP": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.IDPSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.IDPStatus"
+    }
+   }
+  },
+  "v1.IDPClient": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.IDPClientSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.IDPClientStatus"
+    }
+   }
+  },
+  "v1.IDPClientSpec": {
+   "required": [
+    "displayName",
+    "secret",
+    "id",
+    "redirectURIs"
+   ],
+   "properties": {
+    "displayName": {
+     "type": "string"
+    },
+    "id": {
+     "type": "string"
+    },
+    "redirectURIs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "secret": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.IDPClientStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.IDPConfig": {
+   "properties": {
+    "github": {
+     "$ref": "#/definitions/v1.GithubIDP"
+    },
+    "google": {
+     "$ref": "#/definitions/v1.GoogleIDP"
+    },
+    "oidc": {
+     "$ref": "#/definitions/v1.OIDCIDP"
+    },
+    "oidcdirect": {
+     "$ref": "#/definitions/v1.StaticOIDCIDP"
+    },
+    "saml": {
+     "$ref": "#/definitions/v1.SAMLIDP"
+    }
+   }
+  },
+  "v1.IDPSpec": {
+   "required": [
+    "displayName",
+    "config"
+   ],
+   "properties": {
+    "config": {
+     "$ref": "#/definitions/v1.IDPConfig"
+    },
+    "displayName": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.IDPStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.Kubernetes": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.KubernetesSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.KubernetesStatus"
+    }
+   }
+  },
+  "v1.KubernetesList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Kubernetes"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.KubernetesSpec": {
+   "properties": {
+    "authProxyAllowedIPs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "authProxyImage": {
+     "type": "string"
+    },
+    "cluster": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "clusterUsers": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.ClusterUser"
+     }
+    },
+    "defaultTeamRole": {
+     "type": "string"
+    },
+    "domain": {
+     "type": "string"
+    },
+    "enableDefaultTrafficBlock": {
+     "type": "boolean"
+    },
+    "inheritTeamMembers": {
+     "type": "boolean"
+    },
+    "provider": {
+     "$ref": "#/definitions/v1.Ownership"
+    }
+   }
+  },
+  "v1.KubernetesStatus": {
+   "properties": {
+    "apiEndpoint": {
+     "type": "string"
+    },
+    "caCertificate": {
+     "type": "string"
+    },
+    "components": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "endpoint": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.ListMeta": {
+   "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+   "properties": {
+    "continue": {
+     "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+     "type": "string"
+    },
+    "remainingItemCount": {
+     "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+     "type": "integer",
+     "format": "int64"
+    },
+    "resourceVersion": {
+     "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+     "type": "string"
+    },
+    "selfLink": {
+     "description": "selfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+     "type": "string"
+    }
+   }
+  },
+  "v1.ManagedFieldsEntry": {
+   "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+     "type": "string"
+    },
+    "fieldsType": {
+     "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+     "type": "string"
+    },
+    "fieldsV1": {
+     "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+     "type": "string"
+    },
+    "manager": {
+     "description": "Manager is an identifier of the workflow managing these fields.",
+     "type": "string"
+    },
+    "operation": {
+     "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+     "type": "string"
+    },
+    "time": {
+     "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'",
+     "type": "string"
+    }
+   }
+  },
+  "v1.NamespaceClaim": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.NamespaceClaimSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.NamespaceClaimStatus"
+    }
+   }
+  },
+  "v1.NamespaceClaimList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.NamespaceClaim"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.NamespaceClaimSpec": {
+   "required": [
+    "cluster",
+    "name"
+   ],
+   "properties": {
+    "annotations": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "cluster": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "labels": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "name": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.NamespaceClaimStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.OIDCIDP": {
+   "required": [
+    "clientID",
+    "clientSecret",
+    "issuer",
+    "clientScopes",
+    "userClaims"
+   ],
+   "properties": {
+    "clientID": {
+     "type": "string"
+    },
+    "clientScopes": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "clientSecret": {
+     "type": "string"
+    },
+    "issuer": {
+     "type": "string"
+    },
+    "userClaims": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "v1.ObjectMeta": {
+   "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+   "properties": {
+    "annotations": {
+     "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "clusterName": {
+     "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+     "type": "string"
+    },
+    "creationTimestamp": {
+     "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+     "type": "string"
+    },
+    "deletionGracePeriodSeconds": {
+     "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+     "type": "integer",
+     "format": "int64"
+    },
+    "deletionTimestamp": {
+     "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+     "type": "string"
+    },
+    "finalizers": {
+     "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "generateName": {
+     "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+     "type": "string"
+    },
+    "generation": {
+     "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+     "type": "integer",
+     "format": "int64"
+    },
+    "labels": {
+     "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "managedFields": {
+     "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.ManagedFieldsEntry"
+     }
+    },
+    "name": {
+     "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+     "type": "string"
+    },
+    "namespace": {
+     "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+     "type": "string"
+    },
+    "ownerReferences": {
+     "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.OwnerReference"
+     }
+    },
+    "resourceVersion": {
+     "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+     "type": "string"
+    },
+    "selfLink": {
+     "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+     "type": "string"
+    },
+    "uid": {
+     "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+     "type": "string"
+    }
+   }
+  },
+  "v1.OwnerReference": {
+   "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+   "required": [
+    "apiVersion",
+    "kind",
+    "name",
+    "uid"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "API version of the referent.",
+     "type": "string"
+    },
+    "blockOwnerDeletion": {
+     "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+     "type": "boolean"
+    },
+    "controller": {
+     "description": "If true, this reference points to the managing controller.",
+     "type": "boolean"
+    },
+    "kind": {
+     "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "name": {
+     "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+     "type": "string"
+    },
+    "uid": {
+     "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+     "type": "string"
+    }
+   }
+  },
+  "v1.Ownership": {
+   "required": [
+    "group",
+    "version",
+    "kind",
+    "namespace",
+    "name"
+   ],
+   "properties": {
+    "group": {
+     "type": "string"
+    },
+    "kind": {
+     "type": "string"
+    },
+    "name": {
+     "type": "string"
+    },
+    "namespace": {
+     "type": "string"
+    },
+    "version": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.Plan": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.PlanSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.PlanStatus"
+    }
+   }
+  },
+  "v1.PlanList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Plan"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.PlanPolicy": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.PlanPolicySpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.PlanPolicyStatus"
+    }
+   }
+  },
+  "v1.PlanPolicyList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.PlanPolicy"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.PlanPolicyProperty": {
+   "required": [
+    "name",
+    "allowUpdate",
+    "disallowUpdate"
+   ],
+   "properties": {
+    "allowUpdate": {
+     "type": "boolean"
+    },
+    "disallowUpdate": {
+     "type": "boolean"
+    },
+    "name": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.PlanPolicySpec": {
+   "required": [
+    "kind",
+    "summary",
+    "description",
+    "properties"
+   ],
+   "properties": {
+    "description": {
+     "type": "string"
+    },
+    "kind": {
+     "type": "string"
+    },
+    "labels": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "properties": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.PlanPolicyProperty"
+     }
+    },
+    "summary": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.PlanPolicyStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.PlanSpec": {
+   "required": [
+    "kind",
+    "description",
+    "summary",
+    "configuration"
+   ],
+   "properties": {
+    "configuration": {
+     "type": "object"
+    },
+    "description": {
+     "type": "string"
+    },
+    "kind": {
+     "type": "string"
+    },
+    "labels": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "summary": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.PlanStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.SAMLIDP": {
+   "required": [
+    "ssoURL",
+    "caData",
+    "usernameAttr",
+    "emailAttr"
+   ],
+   "properties": {
+    "allowedGroups": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "caData": {
+     "type": "string"
+    },
+    "emailAttr": {
+     "type": "string"
+    },
+    "groupsAttr": {
+     "type": "string"
+    },
+    "groupsDelim": {
+     "type": "string"
+    },
+    "ssoURL": {
+     "type": "string"
+    },
+    "usernameAttr": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.Secret": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.SecretSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.SecretStatus"
+    }
+   }
+  },
+  "v1.SecretReference": {
+   "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
+   "properties": {
+    "name": {
+     "description": "Name is unique within a namespace to reference a secret resource.",
+     "type": "string"
+    },
+    "namespace": {
+     "description": "Namespace defines the space within which the secret name must be unique.",
+     "type": "string"
+    }
+   }
+  },
+  "v1.SecretSpec": {
+   "required": [
+    "type",
+    "description"
+   ],
+   "properties": {
+    "data": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "description": {
+     "type": "string"
+    },
+    "type": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.SecretStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    },
+    "systemManaged": {
+     "type": "boolean"
+    },
+    "verified": {
+     "type": "boolean"
+    }
+   }
+  },
+  "v1.StaticOIDCIDP": {
+   "required": [
+    "clientScopes",
+    "userClaims",
+    "clientID",
+    "clientSecret",
+    "issuer"
+   ],
+   "properties": {
+    "clientID": {
+     "type": "string"
+    },
+    "clientScopes": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "clientSecret": {
+     "type": "string"
+    },
+    "issuer": {
+     "type": "string"
+    },
+    "userClaims": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "v1.Team": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.TeamSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.TeamStatus"
+    }
+   }
+  },
+  "v1.TeamInvitation": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.TeamInvitationSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.TeamInvitationStatus"
+    }
+   }
+  },
+  "v1.TeamInvitationList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.TeamInvitation"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.TeamInvitationSpec": {
+   "required": [
+    "username",
+    "team"
+   ],
+   "properties": {
+    "team": {
+     "type": "string"
+    },
+    "username": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.TeamInvitationStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.TeamList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Team"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.TeamMember": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.TeamMemberSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.TeamMemberStatus"
+    }
+   }
+  },
+  "v1.TeamMemberSpec": {
+   "required": [
+    "roles",
+    "team",
+    "username"
+   ],
+   "properties": {
+    "roles": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "team": {
+     "type": "string"
+    },
+    "username": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.TeamMemberStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.TeamSpec": {
+   "required": [
+    "summary",
+    "description"
+   ],
+   "properties": {
+    "description": {
+     "type": "string"
+    },
+    "summary": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.TeamStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.User": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1.UserSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1.UserStatus"
+    }
+   }
+  },
+  "v1.UserList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.User"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1.UserSpec": {
+   "required": [
+    "disabled",
+    "email",
+    "username"
+   ],
+   "properties": {
+    "disabled": {
+     "type": "boolean"
+    },
+    "email": {
+     "type": "string"
+    },
+    "username": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.UserStatus": {
+   "required": [
+    "conditions",
+    "status"
+   ],
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.AuthorizedNetwork": {
+   "required": [
+    "name",
+    "cidr"
+   ],
+   "properties": {
+    "cidr": {
+     "type": "string"
+    },
+    "name": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.EKS": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.EKSSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.EKSStatus"
+    }
+   }
+  },
+  "v1alpha1.EKSCredentials": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.EKSCredentialsSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.EKSCredentialsStatus"
+    }
+   }
+  },
+  "v1alpha1.EKSCredentialsList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.EKSCredentials"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.EKSCredentialsSpec": {
+   "required": [
+    "secretAccessKey",
+    "accessKeyID",
+    "accountID"
+   ],
+   "properties": {
+    "accessKeyID": {
+     "type": "string"
+    },
+    "accountID": {
+     "type": "string"
+    },
+    "secretAccessKey": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.EKSCredentialsStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    },
+    "verified": {
+     "type": "boolean"
+    }
+   }
+  },
+  "v1alpha1.EKSList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.EKS"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.EKSNodeGroup": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.EKSNodeGroupSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.EKSNodeGroupStatus"
+    }
+   }
+  },
+  "v1alpha1.EKSNodeGroupList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.EKSNodeGroup"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.EKSNodeGroupSpec": {
+   "required": [
+    "amiType",
+    "diskSize",
+    "desiredSize",
+    "maxSize",
+    "minSize",
+    "subnets",
+    "region",
+    "eC2SSHKey",
+    "credentials"
+   ],
+   "properties": {
+    "amiType": {
+     "type": "string"
+    },
+    "cluster": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "credentials": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "desiredSize": {
+     "type": "integer",
+     "format": "int64"
+    },
+    "diskSize": {
+     "type": "integer",
+     "format": "int64"
+    },
+    "eC2SSHKey": {
+     "type": "string"
+    },
+    "instanceType": {
+     "type": "string"
+    },
+    "labels": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "maxSize": {
+     "type": "integer",
+     "format": "int64"
+    },
+    "minSize": {
+     "type": "integer",
+     "format": "int64"
+    },
+    "region": {
+     "type": "string"
+    },
+    "releaseVersion": {
+     "type": "string"
+    },
+    "sshSourceSecurityGroups": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "subnets": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "tags": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "version": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.EKSNodeGroupStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "nodeIAMRole": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.EKSSpec": {
+   "required": [
+    "region",
+    "subnetIDs",
+    "credentials"
+   ],
+   "properties": {
+    "authorizedMasterNetworks": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "cluster": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "credentials": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "region": {
+     "type": "string"
+    },
+    "securityGroupIDs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "subnetIDs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "version": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.EKSStatus": {
+   "properties": {
+    "caCertificate": {
+     "type": "string"
+    },
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "endpoint": {
+     "type": "string"
+    },
+    "roleARN": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.EKSVPC": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.EKSVPCSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.EKSVPCStatus"
+    }
+   }
+  },
+  "v1alpha1.EKSVPCList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.EKSVPC"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.EKSVPCSpec": {
+   "required": [
+    "credentials",
+    "privateIPV4Cidr",
+    "region"
+   ],
+   "properties": {
+    "cluster": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "credentials": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "privateIPV4Cidr": {
+     "type": "string"
+    },
+    "region": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.EKSVPCStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "infra": {
+     "$ref": "#/definitions/v1alpha1.Infra"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.GKE": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.GKESpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.GKEStatus"
+    }
+   }
+  },
+  "v1alpha1.GKECredentials": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.GKECredentialsSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.GKECredentialsStatus"
+    }
+   }
+  },
+  "v1alpha1.GKECredentialsList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.GKECredentials"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.GKECredentialsSpec": {
+   "required": [
+    "account",
+    "project"
+   ],
+   "properties": {
+    "account": {
+     "type": "string"
+    },
+    "project": {
+     "type": "string"
+    },
+    "region": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.GKECredentialsStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Condition"
+     }
+    },
+    "status": {
+     "type": "string"
+    },
+    "verified": {
+     "type": "boolean"
+    }
+   }
+  },
+  "v1alpha1.GKEList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.GKE"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.GKESpec": {
+   "required": [
+    "credentials",
+    "description",
+    "version",
+    "size",
+    "maxSize",
+    "diskSize",
+    "imageType",
+    "machineType",
+    "authorizedMasterNetworks",
+    "network",
+    "subnetwork",
+    "servicesIPV4Cidr",
+    "clusterIPV4Cidr",
+    "enableAutorepair",
+    "enableAutoscaler",
+    "enableAutoupgrade",
+    "enableHorizontalPodAutoscaler",
+    "enableHTTPLoadBalancer",
+    "enableIstio",
+    "enableShieldedNodes",
+    "enableStackDriverLogging",
+    "enableStackDriverMetrics",
+    "enablePrivateEndpoint",
+    "enablePrivateNetwork",
+    "masterIPV4Cidr",
+    "maintenanceWindow"
+   ],
+   "properties": {
+    "authorizedMasterNetworks": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.AuthorizedNetwork"
+     }
+    },
+    "cluster": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "clusterIPV4Cidr": {
+     "type": "string"
+    },
+    "credentials": {
+     "$ref": "#/definitions/v1.Ownership"
+    },
+    "description": {
+     "type": "string"
+    },
+    "diskSize": {
+     "type": "integer",
+     "format": "int64"
+    },
+    "enableAutorepair": {
+     "type": "boolean"
+    },
+    "enableAutoscaler": {
+     "type": "boolean"
+    },
+    "enableAutoupgrade": {
+     "type": "boolean"
+    },
+    "enableHTTPLoadBalancer": {
+     "type": "boolean"
+    },
+    "enableHorizontalPodAutoscaler": {
+     "type": "boolean"
+    },
+    "enableIstio": {
+     "type": "boolean"
+    },
+    "enablePrivateEndpoint": {
+     "type": "boolean"
+    },
+    "enablePrivateNetwork": {
+     "type": "boolean"
+    },
+    "enableShieldedNodes": {
+     "type": "boolean"
+    },
+    "enableStackDriverLogging": {
+     "type": "boolean"
+    },
+    "enableStackDriverMetrics": {
+     "type": "boolean"
+    },
+    "imageType": {
+     "type": "string"
+    },
+    "machineType": {
+     "type": "string"
+    },
+    "maintenanceWindow": {
+     "type": "string"
+    },
+    "masterIPV4Cidr": {
+     "type": "string"
+    },
+    "maxSize": {
+     "type": "integer",
+     "format": "int64"
+    },
+    "network": {
+     "type": "string"
+    },
+    "region": {
+     "type": "string"
+    },
+    "servicesIPV4Cidr": {
+     "type": "string"
+    },
+    "size": {
+     "type": "integer",
+     "format": "int64"
+    },
+    "subnetwork": {
+     "type": "string"
+    },
+    "tags": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "version": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.GKEStatus": {
+   "properties": {
+    "caCertificate": {
+     "type": "string"
+    },
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "endpoint": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.Infra": {
+   "properties": {
+    "ipv4EgressAddresses": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "privateSubnetIDs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "publicSubnetIDs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    },
+    "securityGroupIDs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "v1alpha1.Organization": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.OrganizationSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.OrganizationStatus"
+    }
+   }
+  },
+  "v1alpha1.OrganizationList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.Organization"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.OrganizationSpec": {
+   "required": [
+    "parentType",
+    "parentID",
+    "billingAccount",
+    "serviceAccount",
+    "credentialsRef"
+   ],
+   "properties": {
+    "billingAccount": {
+     "type": "string"
+    },
+    "credentialsRef": {
+     "$ref": "#/definitions/v1.SecretReference"
+    },
+    "parentID": {
+     "type": "string"
+    },
+    "parentType": {
+     "type": "string"
+    },
+    "serviceAccount": {
+     "type": "string"
+    },
+    "tokenRef": {
+     "$ref": "#/definitions/v1.SecretReference"
+    }
+   }
+  },
+  "v1alpha1.OrganizationStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "projectID": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "v1alpha1.ProjectClaim": {
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ObjectMeta"
+    },
+    "spec": {
+     "$ref": "#/definitions/v1alpha1.ProjectClaimSpec"
+    },
+    "status": {
+     "$ref": "#/definitions/v1alpha1.ProjectClaimStatus"
+    }
+   }
+  },
+  "v1alpha1.ProjectClaimList": {
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "apiVersion": {
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+     "type": "string"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1alpha1.ProjectClaim"
+     }
+    },
+    "kind": {
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+     "type": "string"
+    },
+    "metadata": {
+     "$ref": "#/definitions/v1.ListMeta"
+    }
+   }
+  },
+  "v1alpha1.ProjectClaimSpec": {
+   "required": [
+    "organization"
+   ],
+   "properties": {
+    "organization": {
+     "$ref": "#/definitions/v1.Ownership"
+    }
+   }
+  },
+  "v1alpha1.ProjectClaimStatus": {
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Component"
+     }
+    },
+    "credentialRef": {
+     "$ref": "#/definitions/v1.SecretReference"
+    },
+    "projectID": {
+     "type": "string"
+    },
+    "status": {
+     "type": "string"
+    }
+   }
+  },
+  "validation.Error": {
+   "required": [
+    "code",
+    "message",
+    "fieldErrors"
+   ],
+   "properties": {
+    "code": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "fieldErrors": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/validation.FieldError"
+     }
+    },
+    "message": {
+     "type": "string"
+    }
+   }
+  },
+  "validation.FieldError": {
+   "required": [
+    "field",
+    "errCode",
+    "message"
+   ],
+   "properties": {
+    "errCode": {
+     "type": "string"
+    },
+    "field": {
+     "type": "string"
+    },
+    "message": {
+     "type": "string"
+    }
+   }
+  }
+ },
+ "securityDefinitions": {
+  "OAuth2": {
+   "type": "oauth2",
+   "flow": "accessCode",
+   "authorizationUrl": "http://localhost:10080/auth",
+   "tokenUrl": "http://localhost:10080/token",
+   "scopes": {
+    "admin": "Admin scope",
+    "team": "Team scope"
+   }
+  }
+ },
+ "security": [
+  {
+   "OAuth2": [
+    "admin",
+    "team"
+   ]
+  }
+ ]
+}

--- a/ui/lib/components/ComponentStatusTree.js
+++ b/ui/lib/components/ComponentStatusTree.js
@@ -1,0 +1,107 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Typography, Collapse, Icon } from 'antd'
+const { Paragraph, Text } = Typography
+
+import KoreApi from '../kore-api'
+import ResourceStatusTag from './ResourceStatusTag'
+
+class ComponentStatusTree extends React.Component {
+  static propTypes = {
+    team: PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired,
+    component: PropTypes.object.isRequired,
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      component: props.component,
+      children: {},
+      loading: {},
+      openComponents: []
+    }
+  }
+  
+  componentDidUpdate(prevProps) {
+    // Refresh open children if the component updated/refreshed.
+    if (this.props.component !== prevProps.component) {
+      this.loadOpenChildren(this.state.openComponents)
+    }
+  }
+
+  componentChildren = (component) => {
+    let children = []
+    // Some things call their children components and some conditions, 
+    // join them both together for our purposes:
+    if (component.status.components) {
+      children.push(...component.status.components)
+    }
+    if (component.status.conditions) {
+      children.push(...component.status.conditions)
+    }
+    return children
+  }
+
+  api = null
+  loadChildComponentDetails = async (componentName) => {
+    if (!this.api) {
+      this.api = await KoreApi.client()
+    }
+    const res = await this.api.GetTeamResource(this.props.team.metadata.name, componentName)
+    this.setState({
+      children: {
+        ...this.state.children,
+        [componentName]: res
+      },
+      loading: {
+        ...this.state.loading,
+        [componentName]: false
+      }
+    })
+  }
+
+  loadOpenChildren = (openComponents) => {
+    this.setState({ openComponents: openComponents })
+    for (let x = 0; x < openComponents.length; x++) {
+      // No-op if not something we can load state for:
+      if (!openComponents[x].match(/^\w+\/[\w_-]+$/)) {
+        continue
+      }
+      this.setState({ loading: { ...this.state.loading, [openComponents[x]]: true } })
+      this.loadChildComponentDetails(openComponents[x]).then(() => {})
+    }
+  }
+
+  compMsg = (componentStatus) => {
+    if (componentStatus.detail) {
+      return `${componentStatus.message}: ${componentStatus.detail}`
+    }
+    return componentStatus.message
+  }
+
+  render() {
+    const { component } = this.props
+    const componentChildren = this.componentChildren(component)
+    const statusMsg = this.compMsg(component.status)
+    return (
+      <>
+        {statusMsg ? <Paragraph style={{ marginBottom: '20px', textAlign: 'center' }}>{this.compMsg(component.status)}</Paragraph> : null}
+        {componentChildren.length > 0 ? (
+          <Collapse onChange={(e) => this.loadOpenChildren(e)}>
+            {this.componentChildren(component).map((child => (
+              <Collapse.Panel header={child.name} key={child.name} extra={(<ResourceStatusTag resourceStatus={child} />)}>
+                <Text>{this.compMsg(child)}</Text>
+                {(this.state.children[child.name]) ? (
+                  <ComponentStatusTree team={this.props.team} user={this.props.user} component={this.state.children[child.name]} />
+                ) : (this.state.loading[child.name] ? <Icon type="loading" /> : null)}
+              </Collapse.Panel>
+            )))}
+          </Collapse>
+        ) : null}
+      </>
+    )
+  }
+}
+
+export default ComponentStatusTree

--- a/ui/lib/components/cluster-build/ClusterOptionsForm.js
+++ b/ui/lib/components/cluster-build/ClusterOptionsForm.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 
-import { Typography, Form, Select, Card, Radio, Modal, Input } from 'antd'
+import { Typography, Form, Select, Card, Radio, Modal, Input, Collapse } from 'antd'
 const { Text, Title } = Typography
 const { Option } = Select
 
@@ -115,12 +115,17 @@ class ClusterOptionsForm extends React.Component {
           </Form.Item>
         ) : null}
         {selectedPlan ? (
-          <PlanOptionsForm
-            team={this.props.team}
-            plan={selectedPlan}
-            validationErrors={this.props.validationErrors}
-            onPlanChange={this.onPlanOverridden}
-          />
+          <Collapse>
+            <Collapse.Panel header="Customize cluster parameters">
+              <PlanOptionsForm
+                team={this.props.team}
+                plan={selectedPlan}
+                validationErrors={this.props.validationErrors}
+                onPlanChange={this.onPlanOverridden}
+                mode="create"
+              />
+            </Collapse.Panel>
+          </Collapse>
         ) : null}
       </Card>
     )

--- a/ui/lib/components/plans/PlanOption.js
+++ b/ui/lib/components/plans/PlanOption.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import { Form, Input, Icon, Checkbox, InputNumber, Select, Button, Card, Alert } from 'antd'
+import { Form, Input, Checkbox, InputNumber, Select, Button, Card, Alert } from 'antd'
 import { startCase } from 'lodash'
 
 class PlanOption extends React.Component {
@@ -15,20 +15,23 @@ class PlanOption extends React.Component {
     validationErrors: PropTypes.array
   }
 
-  describe = property => {
-    let description = ''
+  describe = (property) => {
+    let descriptionPieces = []
     if (property.description) {
-      description += property.description
+      descriptionPieces.push(property.description)
     }
     if (property.format) {
-      description += ` Format: ${property.format}`
+      descriptionPieces.push(`Format: ${property.format}`)
     } else if (property.items && property.items.format) {
-      description += ` Format: ${property.items.format}`
+      descriptionPieces.push(`Format: ${property.items.format}`)
     }
-    if (description.length === 0) {
+    if (property.immutable) {
+      descriptionPieces.push('Cannot be edited after cluster is created.')
+    }
+    if (descriptionPieces.length === 0) {
       return null
     }
-    return description
+    return descriptionPieces.join(' | ')
   }
 
   addComplexItemToArray = (property, values) => {
@@ -67,7 +70,6 @@ class PlanOption extends React.Component {
     const onChange = this.props.onChange || (() => {})
 
     const displayName = this.props.displayName || name
-    const locked = !editable ? <Icon type="lock" /> : null
 
     // Special handling for object types - represent as a card with a plan option for each property:
     if (property.type === 'object') {
@@ -96,18 +98,18 @@ class PlanOption extends React.Component {
         {(() => {
           switch(property.type) {
           case 'string': {
-            return <Input value={value} readOnly={!editable} disabled={!editable} addonAfter={locked} onChange={(e) => onChange(name, e.target.value)} />
+            return <Input value={value} readOnly={!editable} onChange={(e) => onChange(name, e.target.value)} />
           }
           case 'boolean': {
-            return <Checkbox checked={value} readOnly={!editable} disabled={!editable} onChange={(e) => onChange(name, e.target.checked)} />
+            return <Checkbox checked={value} disabled={!editable} onChange={(e) => onChange(name, e.target.checked)} />
           }
           case 'number': {
-            return <InputNumber value={value} readOnly={!editable} disabled={!editable} onChange={(v) => onChange(name, v)} />
+            return <InputNumber value={value} readOnly={!editable} onChange={(v) => onChange(name, v)} />
           }
           case 'array': {
             const values = value ? value : []
             if (property.items.type !== 'array' && property.items.type !== 'object') {
-              return <Select mode="tags" tokenSeparators={[',']} value={values} readOnly={!editable} disabled={!editable} onChange={(v) => onChange(name, v)} />
+              return <Select mode="tags" tokenSeparators={[',']} value={values} disabled={!editable} onChange={(v) => onChange(name, v)} />
             } else {
               return (
                 <>

--- a/ui/lib/components/team/Cluster.js
+++ b/ui/lib/components/team/Cluster.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Icon, Typography, Modal, Popconfirm, message } from 'antd'
+import { List, Icon, Typography, Modal, Popconfirm, message, Tooltip } from 'antd'
 const { Text, Paragraph } = Typography
 
-import { clusterProviderIconSrcMap } from '../../utils/ui-helpers'
+import { clusterProviderIconSrcMap, inProgressStatusList } from '../../utils/ui-helpers'
 import ResourceStatusTag from '../ResourceStatusTag'
 import AutoRefreshComponent from './AutoRefreshComponent'
+import Link from 'next/link'
 
 class Cluster extends AutoRefreshComponent {
   static propTypes = {
@@ -54,7 +55,7 @@ class Cluster extends AutoRefreshComponent {
   }
 
   render() {
-    const { cluster } = this.props
+    const { cluster, team } = this.props
 
     if (cluster.deleted) {
       return null
@@ -67,7 +68,11 @@ class Cluster extends AutoRefreshComponent {
       const actions = []
       const status = cluster.status.status || 'Pending'
 
-      if (status === 'Success') {
+      actions.push((
+        <Link key="view" href={`/teams/${team}/clusters/${cluster.metadata.name}`}><a><Tooltip title="Cluster status details"><Icon type="info-circle" /></Tooltip></a></Link>
+      ))
+
+      if (!inProgressStatusList.includes(status)) {
         const deleteAction = (
           <Popconfirm
             key="delete"
@@ -76,7 +81,7 @@ class Cluster extends AutoRefreshComponent {
             okText="Yes"
             cancelText="No"
           >
-            <a><Icon type="delete" /></a>
+            <a><Tooltip title="Delete this cluster"><Icon type="delete" /></Tooltip></a>
           </Popconfirm>
         )
         actions.push(deleteAction)
@@ -90,7 +95,7 @@ class Cluster extends AutoRefreshComponent {
       <List.Item actions={actions()}>
         <List.Item.Meta
           avatar={<img src={clusterProviderIconSrcMap[cluster.spec.kind]} height="32px" />}
-          title={<Text>{cluster.spec.kind} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{cluster.metadata.name}</Text></Text>}
+          title={<Link href={`/teams/${team}/clusters/${cluster.metadata.name}`}><a><Text>{cluster.spec.kind} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{cluster.metadata.name}</Text></Text></a></Link>}
           description={
             <div>
               <Text type='secondary'>Created {created}</Text>

--- a/ui/lib/kore-api/index.js
+++ b/ui/lib/kore-api/index.js
@@ -23,9 +23,10 @@ class KoreApi {
       {
         spec: spec,
         requestInterceptor: (req) => {
-          if (process.browser) {
-            req.url = req.url.replace(KoreApi.basePath, '/apiproxy')
-          } else if (ctx && (ctx.id_token || ctx.req)) {
+          // If we're running on the server, we need to layer in the user's identity to 
+          // the request. When running in the browser, this is handled by the cookie-based
+          // session.
+          if (!process.browser && ctx && (ctx.id_token || ctx.req)) {
             req.headers['Authorization'] = `Bearer ${ctx.id_token || ctx.req.session.passport.user.id_token}`
           }
           return req
@@ -33,7 +34,7 @@ class KoreApi {
       }
     )
 
-    return new KoreApiClient(api)
+    return new KoreApiClient(api, KoreApi.basePath)
   }
 
   /**

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -1,11 +1,16 @@
 const redirect = require('../utils/redirect')
+const inflect = require('inflect')
 
 class KoreApiClient {
   spec = null
   apis = null
-  constructor(api) {
+  client = null
+  basePath = null
+  constructor(api, basePath) {
     this.apis = api.apis
     this.spec = api.spec
+    this.client = api
+    this.basePath = basePath
 
     // This decorates every operation returned from the swagger with a function which unwraps the
     // returned object, making the usage of the api much cleaner in the rest of the code.
@@ -41,6 +46,40 @@ class KoreApiClient {
     }
   )
 
+  _mapResourceToOperation = (team, resource) => {
+    const parts = resource.split('/')
+    const resType = parts[0]
+    const name = parts[1]
+    let pathName = null
+    let basePath = this.basePath
+    if (process.browser) {
+      basePath = '/apiproxy'
+    }
+
+    // EKS breaks the mould, everything else follows normal pluralization.
+    switch (parts[0]) {
+    case 'EKS': {
+      pathName = `${basePath}/teams/{team}/ekss/{name}`
+      break
+    }
+    default: {
+      const resTypePlural = inflect.pluralize(resType).toLowerCase()
+      pathName = `${basePath}/teams/{team}/${resTypePlural}/{name}`
+      break
+    } 
+    }
+    return {
+      pathName: pathName,
+      method: 'GET',
+      parameters: {
+        team: team,
+        name: name
+      }
+    }
+  }
+
+  GetTeamResource = (team, resource) => this._wrapFunc((t, r) => this.client.execute(this._mapResourceToOperation(t, r)), team, resource)
+
   // @TODO: Auto-generate these?
 
   // Users
@@ -52,6 +91,9 @@ class KoreApiClient {
   ListPlans = (kind) => this.apis.default.ListPlans({ kind })
   UpdatePlan = (name, plan) => this.apis.default.UpdatePlan({ name, body: JSON.stringify(plan) })
   GetPlanSchema = (name) => this.apis.default.GetPlanSchema({ name })
+
+  // Audit
+  ListAuditEvents = () => this.apis.default.ListAuditEvents()
 
   // Teams
   GetTeam = (team) => this.apis.default.GetTeam({ team })
@@ -74,9 +116,11 @@ class KoreApiClient {
   UpdateAllocation = (team, name, resource) => this.apis.default.UpdateAllocation({ team, name, body: JSON.stringify(resource) })
   ListClusters = (team) => this.apis.default.ListClusters({ team })
   UpdateCluster = (team, name, cluster) => this.apis.default.UpdateCluster({ team, name, body: JSON.stringify(cluster) })
+  GetCluster = (team, name) => this.apis.default.GetCluster({ team, name })
   ListNamespaces = (team) => this.apis.default.ListNamespaces({ team })
   GetTeamPlanDetails = (team, plan) => this.apis.default.GetTeamPlanDetails({ team, plan })
   UpdateTeamSecret = (team, name, secret) => this.apis.default.UpdateTeamSecret({ team, name, body: JSON.stringify(secret) })
+  ListTeamAudit = (team) => this.apis.default.ListTeamAudit({ team })
 }
 
 module.exports = KoreApiClient

--- a/ui/lib/kore-api/model/V1alpha1EKSNodeGroupSpec.js
+++ b/ui/lib/kore-api/model/V1alpha1EKSNodeGroupSpec.js
@@ -111,6 +111,9 @@ class V1alpha1EKSNodeGroupSpec {
             if (data.hasOwnProperty('tags')) {
                 obj['tags'] = ApiClient.convertToType(data['tags'], {'String': 'String'});
             }
+            if (data.hasOwnProperty('version')) {
+                obj['version'] = ApiClient.convertToType(data['version'], 'String');
+            }
         }
         return obj;
     }
@@ -310,6 +313,19 @@ class V1alpha1EKSNodeGroupSpec {
     setTags(tags) {
         this['tags'] = tags;
     }
+/**
+     * @return {String}
+     */
+    getVersion() {
+        return this.version;
+    }
+
+    /**
+     * @param {String} version
+     */
+    setVersion(version) {
+        this['version'] = version;
+    }
 
 }
 
@@ -387,6 +403,11 @@ V1alpha1EKSNodeGroupSpec.prototype['subnets'] = undefined;
  * @member {Object.<String, String>} tags
  */
 V1alpha1EKSNodeGroupSpec.prototype['tags'] = undefined;
+
+/**
+ * @member {String} version
+ */
+V1alpha1EKSNodeGroupSpec.prototype['version'] = undefined;
 
 
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7713,6 +7713,11 @@
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
+    "inflect": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/inflect/-/inflect-0.4.1.tgz",
+      "integrity": "sha512-l/tds1Xe6utGBWaCE6sPffj5tZLLl3lcHV4lCGjpdqT6BPu6naE7AOdXLU7D23FcTcd/mov3eV/VyO94+Joplg=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "express": "^4.17.1",
     "express-react-views": "^0.11.0",
     "express-session": "^1.17.0",
+    "inflect": "^0.4.1",
     "less": "^3.10.3",
     "less-vars-to-js": "^1.3.0",
     "lodash": "^4.17.15",

--- a/ui/pages/audit/index.js
+++ b/ui/pages/audit/index.js
@@ -1,10 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import apiRequest from '../../lib/utils/api-request'
-import apiPaths from '../../lib/utils/api-paths'
 import Breadcrumb from '../../lib/components/Breadcrumb'
 import AuditViewer from '../../lib/components/AuditViewer'
+import KoreApi from '../../lib/kore-api'
 
 class AuditPage extends React.Component {
   static propTypes = {
@@ -20,17 +19,14 @@ class AuditPage extends React.Component {
     adminOnly: true
   }
 
-  static async getPageData({ req, res }) {
-    const getAuditEvents = () => apiRequest({ req, res }, 'get', apiPaths.audit)
-
-    return getAuditEvents()
-      .then((eventList) => {
-        var events = eventList.items
-        return { events }
-      })
-      .catch(err => {
-        throw new Error(err.message)
-      })
+  static async getPageData(ctx) {
+    try {
+      const eventList = await (await KoreApi.client(ctx)).ListAuditEvents()
+      const events = eventList.items
+      return { events }
+    } catch (err) {
+      throw new Error(err.message)
+    }
   }
 
   static getInitialProps = async ctx => {

--- a/ui/pages/teams/[name]/audit.js
+++ b/ui/pages/teams/[name]/audit.js
@@ -2,10 +2,9 @@ import React from 'react'
 import axios from 'axios'
 import PropTypes from 'prop-types'
 
-import apiRequest from '../../../lib/utils/api-request'
-import apiPaths from '../../../lib/utils/api-paths'
 import Breadcrumb from '../../../lib/components/Breadcrumb'
 import AuditViewer from '../../../lib/components/AuditViewer'
+import KoreApi from '../../../lib/kore-api'
 
 class TeamAuditPage extends React.Component {
   static propTypes = {
@@ -22,12 +21,11 @@ class TeamAuditPage extends React.Component {
     adminOnly: false
   }
 
-  static async getPageData({ req, res, query }) {
-    const name = query.name
-    const getTeam = () => apiRequest({ req, res }, 'get', apiPaths.team(name).self)
-    const getAuditEvents = () => apiRequest({ req, res }, 'get', apiPaths.team(name).audit)
+  static async getPageData(ctx) {
+    const name = ctx.query.name
+    const api = await KoreApi.client(ctx)
 
-    return axios.all([getTeam(), getAuditEvents()])
+    return axios.all([api.GetTeam(name), api.ListTeamAudit(name)])
       .then(axios.spread(function (team, eventList) {
         return { team, events: eventList.items }
       }))

--- a/ui/pages/teams/[name]/clusters/[cluster].js
+++ b/ui/pages/teams/[name]/clusters/[cluster].js
@@ -1,0 +1,202 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import axios from 'axios'
+import moment from 'moment'
+import { Typography, Collapse, Row, Col, List, Button, Form } from 'antd'
+const { Text } = Typography
+
+import KoreApi from '../../../../lib/kore-api'
+import Breadcrumb from '../../../../lib/components/Breadcrumb'
+import PlanOptionsForm from '../../../../lib/components/plans/PlanOptionsForm'
+import ComponentStatusTree from '../../../../lib/components/ComponentStatusTree'
+import ResourceStatusTag from '../../../../lib/components/ResourceStatusTag'
+import { clusterProviderIconSrcMap } from '../../../../lib/utils/ui-helpers'
+import copy from '../../../../lib/utils/object-copy'
+import FormErrorMessage from '../../../../lib/components/forms/FormErrorMessage'
+import { inProgressStatusList } from '../../../../lib/utils/ui-helpers'
+
+class ClusterPage extends React.Component {
+  static propTypes = {
+    team: PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired,
+    cluster: PropTypes.object.isRequired
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      cluster: props.cluster,
+      components: {},
+      editMode: false,
+      clusterParams: props.cluster.spec.configuration,
+      formErrorMessage: null,
+      validationErrors: null
+    }
+  }
+
+  static getInitialProps = async ctx => {
+    const api = await KoreApi.client(ctx)
+    const { team, cluster } = await (axios.all([
+      api.GetTeam(ctx.query.name), 
+      api.GetCluster(ctx.query.name, ctx.query.cluster)
+    ]).then(axios.spread((team, cluster) => { 
+      return { team, cluster } 
+    })))
+
+    if ((!cluster || !team) && ctx.res) {
+      /* eslint-disable-next-line require-atomic-updates */
+      ctx.res.statusCode = 404
+    }
+    return { team, cluster }
+  }
+
+  interval = null
+  api = null
+  startRefreshing = async () => {
+    this.api = await KoreApi.client()
+    this.interval = setInterval(async () => {
+      await this.refreshCluster()
+    }, 5000)
+  }
+
+  refreshCluster = async () => {
+    const cluster = await this.api.GetCluster(this.props.team.metadata.name, this.state.cluster.metadata.name)
+    if (cluster) {
+      this.setState({ 
+        cluster: cluster,
+        // Keep the params up to date with the cluster, unless we're in edit mode.
+        clusterParams: this.state.editMode ? this.state.clusterParams : copy(cluster.spec.configuration)
+      })
+    } else {
+      this.setState({ cluster: { ...this.state.cluster, deleted: true } })
+    }
+  }
+
+  componentDidMount = () => {
+    this.startRefreshing()
+  }
+
+  componentWillUnmount = () => {
+    if (this.interval) {
+      clearInterval(this.interval)
+    }
+  }
+
+  onClusterConfigChanged = (updatedClusterParams) => {
+    this.setState({
+      clusterParams: updatedClusterParams
+    })
+  }
+
+  onEditClick = (e) => {
+    e.stopPropagation()
+    this.setState({ editMode: true })
+  }
+
+  onCancelClick = (e) => {
+    e.stopPropagation()
+    this.setState({ 
+      editMode: false,
+      clusterParams: copy(this.state.cluster.spec.configuration)
+    })
+  }
+
+  onSubmit = async (e) => {
+    e.preventDefault()
+    this.setState({ saving: true, validationErrors: null, formErrorMessage: null })
+    const clusterUpdated = copy(this.state.cluster)
+    clusterUpdated.spec.configuration = this.state.clusterParams
+    try {
+      await this.api.UpdateCluster(this.props.team.metadata.name, this.state.cluster.metadata.name, clusterUpdated)
+      this.setState({ 
+        cluster: { ...this.state.cluster, status: { ...this.state.cluster.status, status: 'Pending' } },
+        saving: false, 
+        validationErrors: null, 
+        formErrorMessage: null, 
+        editMode: false 
+      })
+      // await this.refreshCluster()
+    } catch (err) {
+      this.setState({
+        saving: false,
+        formErrorMessage: (err.fieldErrors && err.message) ? err.message : 'An error occurred saving the cluster, please try again',
+        validationErrors: err.fieldErrors // This will be undefined on non-validation errors, which is fine.
+      })
+    }
+  }
+
+  render = () => {
+    const { team, user } = this.props
+    const { cluster } = this.state
+    const created = moment(cluster.metadata.creationTimestamp).fromNow()
+    const deleted = cluster.metadata.deletionTimestamp ? moment(cluster.metadata.deletionTimestamp).fromNow() : false
+    const clusterNotEditable = !cluster || !cluster.status || inProgressStatusList.includes(cluster.status.status)
+    const editClusterFormConfig = {
+      layout: 'horizontal', labelAlign: 'left', hideRequiredMark: true,
+      labelCol: { xs: 24, xl: 10 }, wrapperCol: { xs: 24, xl: 14 }
+    }
+  
+    return (
+      <div>
+        <Breadcrumb
+          items={[
+            { text: team.spec.summary, href: '/teams/[name]', link: `/teams/${team.metadata.name}` },
+            { text: `Cluster: ${cluster.metadata.name}` }
+          ]}
+        />
+
+        <List.Item actions={[<ResourceStatusTag key="status" resourceStatus={cluster.status} />]}>
+          <List.Item.Meta
+            avatar={<img src={clusterProviderIconSrcMap[cluster.spec.kind]} height="32px" />}
+            title={<Text>{cluster.spec.kind} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{cluster.metadata.name}</Text></Text>}
+            description={
+              <div>
+                <Text type='secondary'>Created {created}</Text>
+                {deleted ? <Text type='secondary'><br/>Deleted {deleted}</Text> : null }
+              </div>
+            }
+          />
+        </List.Item>
+
+        <Row type="flex" gutter={[16,16]}>
+          <Col span={24} xl={12}>
+            <Collapse defaultActiveKey={['0']}>
+              <Collapse.Panel header="Detailed Cluster Status" extra={(<ResourceStatusTag resourceStatus={cluster.status} />)}>
+                <ComponentStatusTree team={team} user={user} component={cluster} />
+              </Collapse.Panel>
+            </Collapse>
+          </Col>
+          <Col span={24} xl={12}>
+            <Collapse>
+              <Collapse.Panel header="Cluster Parameters">
+                <Form {...editClusterFormConfig} onSubmit={(e) => this.onSubmit(e)}>
+                  <FormErrorMessage message={this.state.formErrorMessage} />
+                  <Form.Item label="" colon={false}>
+                    {!this.state.editMode ? (
+                      <Button icon="edit" htmlType="button" disabled={clusterNotEditable} onClick={(e) => this.onEditClick(e)}>Edit</Button>
+                    ) : (
+                      <>
+                        <Button type="primary" icon="save" htmlType="submit" loading={this.state.saving} disabled={this.state.saving || clusterNotEditable}>Save</Button>
+                        &nbsp;
+                        <Button icon="stop" htmlType="button" onClick={(e) => this.onCancelClick(e)}>Cancel</Button>
+                      </>
+                    )}
+                  </Form.Item>
+                  <PlanOptionsForm 
+                    team={team}
+                    plan={cluster.spec.plan}
+                    planValues={this.state.clusterParams}
+                    mode={this.state.editMode ? 'edit' : 'view'}
+                    validationErrors={this.state.validationErrors}
+                    onPlanChange={this.onClusterConfigChanged}
+                  />
+                </Form>
+              </Collapse.Panel>
+            </Collapse>
+          </Col>
+        </Row>
+      </div>
+    )
+  }
+}
+export default ClusterPage

--- a/ui/server/controllers/swagger.js
+++ b/ui/server/controllers/swagger.js
@@ -8,7 +8,13 @@ function swagger(koreApi) {
     const swaggerUrl = `${u.protocol}//${u.host}/swagger.json`
     try {
       const result = await axios['get'](swaggerUrl)
-      return res.json(result.data)
+      // Patch base path to our proxy URL:
+      const patched = result.data
+      for (const [key, value] of Object.entries(patched.paths)) {
+        patched.paths[key.replace(u.path, '/apiproxy')] = value
+        delete patched.paths[key]
+      }
+      return res.type('json').send(JSON.stringify(patched, null, 2))
     } catch (err) {
       const status = (err.response && err.response.status) || 500
       const message = (err.response && err.response.data && err.response.data.message) || err.message


### PR DESCRIPTION
Addresses #494 - Being able to drill-down into the detailed status of the cluster and it's sub-resources.
Addresses #493 - Being able to delete a cluster in a failed state.
Addresses #567 - Being able to edit an existing cluster's configuration after it is built through the UI.

Introduces the concept of 'immutable' plan parameters defined in the plan schema. These are parameters which cannot be edited after a cluster is created, such as region.

![image](https://user-images.githubusercontent.com/7505593/79853841-7cdc6700-83c0-11ea-96b9-b22e3964070a.png)

Drilling down into a sub-resource:

![image](https://user-images.githubusercontent.com/7505593/79853955-a0071680-83c0-11ea-873c-b8c7e2b3649e.png)

Editing cluster configuration:

![image](https://user-images.githubusercontent.com/7505593/79854055-c331c600-83c0-11ea-8e6f-7317c2e5de83.png)
