### PR TITLE
Fix QA Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,9 @@ jobs:
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} quay.io
             VERSION=${CIRCLE_TAG:-latest} make images
             VERSION=${CIRCLE_TAG:-latest} make push-images
+            # These are used for QA
+            VERSION=${CIRCLE_SHA1} make images
+            VERSION=${CIRCLE_SHA1} make push-images
 
   release-cli:
     environment:
@@ -200,7 +203,9 @@ jobs:
           command: |
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} quay.io
             docker build -t ${KORE_UI_IMAGE}:${CIRCLE_TAG:-latest} --build-arg version=${CIRCLE_TAG:-latest} .
+            docker build -t ${KORE_UI_IMAGE}:${CIRCLE_SHA1} --build-arg version=${CIRCLE_SHA1} .
             docker push ${KORE_UI_IMAGE}:${CIRCLE_TAG:-latest}
+            docker push ${KORE_UI_IMAGE}:${CIRCLE_SHA1}
 
   release-qa:
     docker:
@@ -216,7 +221,8 @@ jobs:
       - run:
           name: Deploying to QA
           command: |
-            echo "Deploying to QA"
+            export VERSION="${CIRCLE_SHA1}"
+            echo "Deploying to QA, version: ${VERSION}"
             hack/deploy-qa.sh
 
   # This releases the local images for kore-apiserver and the auth-proxy; to

--- a/hack/deploy-qa.sh
+++ b/hack/deploy-qa.sh
@@ -24,7 +24,7 @@ set -o pipefail
 
 ENVIRONMENT="qa"
 export BUILD_ID=${CIRCLE_SHA1:-"unknown"}
-export VERSION=${CIRCLE_TAG:-"latest"}
+export VERSION=${VERSION:-"latest"}
 export KORE_API_PUBLIC_URL=${KORE_API_PUBLIC_URL_QA}
 export KORE_UI_PUBLIC_URL=${KORE_UI_PUBLIC_URL_QA}
 


### PR DESCRIPTION
The current implementation is using latest when deploying to QA; it would be better to use sha1 and be certain of the version