### PR TITLE
Adding delete team functionality

### DIFF
--- a/ui/__tests__/unit/pages/teams/[name].test.js
+++ b/ui/__tests__/unit/pages/teams/[name].test.js
@@ -16,7 +16,8 @@ const props = {
   members: { items: ['jbloggs', 'fflintstone'] },
   clusters: { items: [] },
   namespaceClaims: { items: [] },
-  available: { items: [] }
+  available: { items: [] },
+  teamRemoved: jest.fn()
 }
 
 describe('TeamPage', () => {

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -97,6 +97,7 @@ class KoreApiClient {
 
   // Teams
   GetTeam = (team) => this.apis.default.GetTeam({ team })
+  RemoveTeam = (team) => this.apis.default.RemoveTeam({ team })
   ListTeams = () => this.apis.default.ListTeams()
   UpdateTeam = (team, teamSpec) => this.apis.default.UpdateTeam({ team, body: JSON.stringify(teamSpec) })
   ListTeamMembers = (team) => this.apis.default.ListTeamMembers({ team })

--- a/ui/pages/_app.js
+++ b/ui/pages/_app.js
@@ -129,6 +129,13 @@ class MyApp extends App {
     this.setState(state)
   }
 
+  teamRemoved = (team) => {
+    this.setState({
+      userTeams: this.state.userTeams.filter(t => t.metadata.name !== team),
+      otherTeams: (this.state.otherTeams || []).filter(t => t.metadata.name !== team)
+    })
+  }
+
   render() {
     const { Component } = this.props
     const props = { ...this.props, ...this.props.pageProps }
@@ -183,7 +190,7 @@ class MyApp extends App {
           <Layout hasSider="true">
             <SiderMenu hide={hideSider} isAdmin={isAdmin} userTeams={this.state.userTeams} otherTeams={props.otherTeams}/>
             <Content style={{ background: '#fff', padding: 24, minHeight: 280 }}>
-              <Component {...this.props.pageProps} user={this.props.user} teamAdded={this.teamAdded} version={version} />
+              <Component {...this.props.pageProps} user={this.props.user} teamAdded={this.teamAdded} teamRemoved={this.teamRemoved} version={version} />
               <Paragraph style={{ textAlign: 'right', fontSize: '0.8em', padding: 0, margin: 0 }}>Appvia Kore {version}</Paragraph>
             </Content>
           </Layout>


### PR DESCRIPTION
* available from a new dropdown menu on the team page
* this menu also includes access to the team audit

**New dropdown on team page**

<img width="1246" alt="Screen Shot 2020-04-21 at 17 22 39" src="https://user-images.githubusercontent.com/1334068/79903163-84c0f900-840a-11ea-9eb1-4fa86a6681d4.png">

**Clusters warning**

<img width="486" alt="Screen Shot 2020-04-21 at 17 22 53" src="https://user-images.githubusercontent.com/1334068/79903175-88548000-840a-11ea-83c0-7db7d3e9b9c3.png">

**Delete confirm**

<img width="460" alt="Screen Shot 2020-04-21 at 20 03 29" src="https://user-images.githubusercontent.com/1334068/79903572-38c28400-840b-11ea-8ccb-b17efd6bcee1.png">


