### PR TITLE
Get Resources Names for Autocompletion

### DIFF
--- a/pkg/cmd/utils/resource.go
+++ b/pkg/cmd/utils/resource.go
@@ -119,7 +119,7 @@ func (r *resourceImpl) LookupResourceNames(kind, team string) ([]string, error) 
 	}
 
 	// @step: we then construct a request for the list of that type
-	req := r.client.Request().Resource(resource.Name)
+	req := r.client.Request().Resource(resource.GetAPIName())
 	if resource.IsTeamScoped() {
 		req.Team(team)
 	}


### PR DESCRIPTION
Changes was made were the name in lookup is not automatically pluralized .. we need to use get GetAPIName() .. This fixes and get the suggestions for resources working again

- fixing up the autocompletion on the LookupResourceNames()