### PR TITLE
Always check on the team API endpoints whether a team exists

### DIFF
--- a/pkg/apiserver/helpers.go
+++ b/pkg/apiserver/helpers.go
@@ -20,7 +20,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"strings"
+
+	"github.com/jinzhu/gorm"
 
 	"github.com/appvia/kore/pkg/kore"
 	"github.com/appvia/kore/pkg/utils/validation"
@@ -82,7 +83,7 @@ func handleError(req *restful.Request, resp *restful.Response, err error) {
 		code = http.StatusBadRequest
 	}
 
-	if strings.Contains(err.Error(), "record not found") {
+	if err == gorm.ErrRecordNotFound {
 		code = http.StatusNotFound
 		err = errors.New("resource not found")
 	}

--- a/pkg/store/client.go
+++ b/pkg/store/client.go
@@ -323,24 +323,26 @@ func (r *rclient) Update(ctx context.Context, options ...UpdateOptionFunc) error
 
 		return r.client.Patch(ctx, r.value, client.MergeFrom(original))
 	}()
-	if err == nil {
-		// @step: attempt to inject the resource direct
-		err = func() error {
-			object, err := r.updateQueryFromObject(r.value)
-			if err != nil {
-				return err
-			}
-			if err := r.index.Set(object.GetName(), object); err != nil {
-				return err
-			}
+	if err != nil {
+		return err
+	}
 
-			return nil
-		}()
+	// @step: attempt to inject the resource direct
+	err = func() error {
+		object, err := r.updateQueryFromObject(r.value)
 		if err != nil {
-			log.WithFields(log.Fields{
-				"error": err.Error(),
-			}).Error("failed to update internal cache on create")
+			return err
 		}
+		if err := r.index.Set(object.GetName(), object); err != nil {
+			return err
+		}
+
+		return nil
+	}()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("failed to update internal cache on create")
 	}
 
 	// @step: if possible we try and inject the gvk from the schema


### PR DESCRIPTION
## What

There is a bug in the API server, that if you try to create certain resources for a non-existing team with a superadmin, it will return a 200 OK without any errors. This happens because:
 - for superadmins we don't do team membership checks
 - we don't check the team's existence in many of the team API endpoints
 - we swallow an internal error when we update an object in Kubernetes

This change adds a filter to the Team API endpoints to always check the team's existence (except the team resource endpoints) + we don't swallow the internal error anymore. 