### PR TITLE
Team Deletion Bug

### DIFF
--- a/pkg/kore/teams.go
+++ b/pkg/kore/teams.go
@@ -82,7 +82,7 @@ func (t *teamsImpl) Delete(ctx context.Context, name string) error {
 	// else we can go ahead and remove the team
 
 	// @step: check if the team has any resources
-	resources, err := t.Team(name).Kubernetes().List(ctx)
+	resources, err := t.Team(name).Clusters().List(ctx)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"team": name,


### PR DESCRIPTION
The current implementation was only checking for Kubernetes which mean given we order it you could delete the team before all the resources (cloud provider) was removed