### PR TITLE
Replace prompt in kore local configure to use manifoldco/promptui

### DIFF
--- a/pkg/cmd/utils/prompts.go
+++ b/pkg/cmd/utils/prompts.go
@@ -29,12 +29,16 @@ type Prompt struct {
 	ErrMsg      string
 	Value       *string
 	AllowEdit   bool
+	Validate    func(in string) error
 }
 
 func (p *Prompt) Do() error {
 	var value string
 	if p.Value != nil {
 		value = *p.Value
+	}
+	if p.ErrMsg == "" {
+		p.ErrMsg = "%s cannot be blank"
 	}
 	runner := promptui.Prompt{
 		Label:     p.Id + " " + p.LabelSuffix,
@@ -43,6 +47,11 @@ func (p *Prompt) Do() error {
 		Validate: func(in string) error {
 			if len(in) == 0 {
 				return fmt.Errorf(p.ErrMsg, p.Id)
+			}
+			if p.Validate != nil {
+				if err := p.Validate(in); err != nil {
+					return err
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
## What

Replace prompt in kore local configure to use manifoldco/promptui

Backspace didn't work when trying to edit the Kore API URL input:

```
Please enter the Kore API URL (e.g https://api.domain.com): asdfasdf^?^?^?^?
```