### PR TITLE
Patch Command

### DIFF
--- a/pkg/cmd/kore/alpha/alpha.go
+++ b/pkg/cmd/kore/alpha/alpha.go
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alpha
+
+import (
+	"github.com/appvia/kore/pkg/cmd/kore/patch"
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmdAlpha creates and returns the alpha command
+func NewCmdAlpha(factory cmdutil.Factory) *cobra.Command {
+	command := &cobra.Command{
+		Use:                   "alpha",
+		DisableFlagsInUseLine: true,
+		Short:                 "Experimental services and operations",
+		Run:                   cmdutil.RunHelp,
+	}
+
+	command.AddCommand(
+		//NewCmdCreateAlpha(factory),
+		patch.NewCmdPatch(factory),
+	)
+
+	return command
+}

--- a/pkg/cmd/kore/alpha/create.go
+++ b/pkg/cmd/kore/alpha/create.go
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alpha
+
+import (
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmdCreatAlpha creates and returns the alpha create command
+func NewCmdCreateAlpha(factory cmdutil.Factory) *cobra.Command {
+	command := &cobra.Command{
+		Use:                   "create",
+		DisableFlagsInUseLine: true,
+		Short:                 "Creates a collection of experimental resources in kore",
+		Run:                   cmdutil.RunHelp,
+	}
+
+	return command
+}

--- a/pkg/cmd/kore/apply/apply.go
+++ b/pkg/cmd/kore/apply/apply.go
@@ -18,7 +18,6 @@ package apply
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/appvia/kore/pkg/cmd/errors"
 	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
@@ -86,7 +85,6 @@ func (o *ApplyOptions) Run() error {
 
 			// @step: create a request to check the status
 			kind := x.Object.GetKind()
-			groupversion := x.Object.GetObjectKind().GroupVersionKind().GroupVersion()
 			resource, err := o.Resources().Lookup(kind)
 			if err != nil {
 				return err
@@ -134,9 +132,7 @@ func (o *ApplyOptions) Run() error {
 				state = "no changes"
 			}
 
-			endpoint := fmt.Sprintf("%s/%s", groupversion, x.Object.GetName())
-
-			o.Println("%s %s", endpoint, state)
+			o.Println("%s %s", utils.GetUnstructuredSelfLink(x.Object), state)
 		}
 	}
 

--- a/pkg/cmd/kore/kore.go
+++ b/pkg/cmd/kore/kore.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/appvia/kore/pkg/client"
 	"github.com/appvia/kore/pkg/client/config"
+	"github.com/appvia/kore/pkg/cmd/kore/alpha"
 	"github.com/appvia/kore/pkg/cmd/kore/apiresources"
 	"github.com/appvia/kore/pkg/cmd/kore/apply"
 	"github.com/appvia/kore/pkg/cmd/kore/create"
@@ -106,6 +107,7 @@ func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
 		NewCmdWhoami(factory),
 		apiresources.NewCmdAPIResources(factory),
 		NewCmdVersion(factory),
+		alpha.NewCmdAlpha(factory),
 		local.NewCmdCreateLocal(factory),
 	)
 

--- a/pkg/cmd/kore/patch/patch.go
+++ b/pkg/cmd/kore/patch/patch.go
@@ -158,6 +158,10 @@ func (o *PatchOptions) Run() error {
 
 		return sjson.Set(string(content), o.Key, ParseValue(o.Value))
 	}()
+	if err != nil {
+		return err
+	}
+
 	if err := json.NewDecoder(strings.NewReader(update)).Decode(u); err != nil {
 		return err
 	}

--- a/pkg/cmd/kore/patch/patch.go
+++ b/pkg/cmd/kore/patch/patch.go
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package patch
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"github.com/appvia/kore/pkg/client"
+	"github.com/appvia/kore/pkg/cmd/errors"
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	"github.com/appvia/kore/pkg/utils"
+	"github.com/tidwall/sjson"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	longDescription = `
+Patch allows you to apply patches to the resource managed in kore
+
+# Update the size in a cluster resource
+$ kore alpha patch clusters test spec.configuration.size 1
+
+# Update the allowed subnets
+$ kore alpha patch clusters test spec.configuration.authProxyAllowedIPs.-1 127.0.0.0/8
+`
+)
+
+// PatchOptions are the options for patch comment
+type PatchOptions struct {
+	cmdutil.Factory
+	// Name is an optional name for the resource
+	Name string
+	// Resource is the resource to retrieve
+	Resource string
+	// Team is the team name
+	Team string
+	// Key is the json path to patch
+	Key string
+	// Value is the value to set
+	Value string
+}
+
+// NewCmdPatch creates and returns the patch command
+func NewCmdPatch(factory cmdutil.Factory) *cobra.Command {
+	o := &PatchOptions{Factory: factory}
+
+	// @step: retrieve a list of known resources
+	possible, _ := factory.Resources().Names()
+
+	command := &cobra.Command{
+		Use:     "patch",
+		Short:   "Allows you to patch resource in kore",
+		Long:    longDescription,
+		Example: "kore alpha patch <resource> <name> <key> <value> [options]",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			o.Key = cmd.Flags().Arg(2)
+			o.Value = cmd.Flags().Arg(3)
+
+			cmdutil.DefaultRunFunc(o)(cmd, args)
+		},
+
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			switch len(args) {
+			case 0:
+				return possible, cobra.ShellCompDirectiveNoFileComp
+			case 1:
+				suggestions, err := o.Resources().LookupResourceNames(cmd.Flags().Arg(0), cmdutil.GetTeam(cmd))
+				if err != nil {
+					return nil, cobra.ShellCompDirectiveError
+				}
+
+				return suggestions, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+
+	return command
+}
+
+// Validate is used to validate the options
+func (o *PatchOptions) Validate() error {
+	if o.Resource == "" {
+		return errors.ErrMissingResource
+	}
+	if o.Name == "" {
+		return errors.ErrMissingResourceName
+	}
+	if o.Key == "" {
+		return errors.NewInvalidParamError("key", "missing")
+	}
+	if o.Value == "" {
+		return errors.NewInvalidParamError("value", "missing")
+	}
+	resource, err := o.Resources().Lookup(o.Resource)
+	if err != nil {
+		return err
+	}
+	if resource.IsTeamScoped() && o.Team == "" {
+		return errors.ErrTeamMissing
+	}
+
+	return nil
+}
+
+// Run implements the action
+func (o *PatchOptions) Run() error {
+	u := &unstructured.Unstructured{}
+
+	// @step: retrieve the resource from the API
+	resource, err := o.Resources().Lookup(o.Resource)
+	if err != nil {
+		return err
+	}
+	var request client.RestInterface
+	if resource.IsScoped(cmdutil.TeamScope) {
+		request = o.ClientWithTeamResource(o.Team, resource).Result(u).Name(o.Name).Get()
+	} else {
+		request = o.ClientWithResource(resource).Result(u).Name(o.Name).Get()
+	}
+	if err := request.Error(); err != nil {
+		return err
+	}
+	revision := u.GetResourceVersion()
+
+	content, err := ioutil.ReadAll(request.Body())
+	if err != nil {
+		return err
+	}
+
+	// @step: apply the patch to the json
+	update, err := sjson.Set(string(content), o.Key, ParseValue(o.Value))
+	if err != nil {
+		return err
+	}
+	if err := json.NewDecoder(strings.NewReader(update)).Decode(u); err != nil {
+		return err
+	}
+
+	err = request.
+		Name(o.Name).
+		Payload(u).
+		Result(u).
+		Update().
+		Error()
+	if err != nil {
+		return err
+	}
+
+	if revision != u.GetResourceVersion() {
+		o.Println("%s configured", utils.GetUnstructuredSelfLink(u))
+
+		return nil
+	}
+	o.Println("%s no changes", utils.GetUnstructuredSelfLink(u))
+
+	return nil
+}
+
+// ParseValue is used to parse the value
+func ParseValue(value string) interface{} {
+	num, err := strconv.ParseFloat(value, 64)
+	if err == nil {
+		return num
+	}
+
+	return value
+}

--- a/pkg/utils/unstructured.go
+++ b/pkg/utils/unstructured.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
@@ -31,6 +32,13 @@ func IsMissingKind(err error) bool {
 	}
 
 	return strings.Contains(err.Error(), "Object 'Kind' is missing in")
+}
+
+// GetUnstructuredSelfLink returns a self link to the resource
+func GetUnstructuredSelfLink(u *unstructured.Unstructured) string {
+	gvk := u.GetObjectKind().GroupVersionKind()
+
+	return fmt.Sprintf("%s/%s/%s/%s", gvk.Group, gvk.Version, strings.ToLower(gvk.Kind), u.GetName())
 }
 
 // GetOwnership returns an ownership from a object


### PR DESCRIPTION
Adding a patch command under the alpha category; this one is quite useful for quick changes

- also fixes the apply issue raise around better output 
```shell
[jest@starfury kore]$ kore apply -f hack/setup/instances/credentials.yml -t kore-admin 
gke.compute.kore.appvia.io/v1alpha1/gkecredentials/gke no changes
config.kore.appvia.io/v1/allocation/gke configured
```
