### PR TITLE
Fixing namespace name regex pattern

### DIFF
--- a/ui/__tests__/unit/lib/utils/validation.test.js
+++ b/ui/__tests__/unit/lib/utils/validation.test.js
@@ -1,0 +1,65 @@
+import { patterns } from '../../../../lib/utils/validation'
+
+describe('validation', () => {
+  describe('patterns', () => {
+    describe('uriCompatible40CharMax', () => {
+      const pattern = new RegExp(patterns.uriCompatible40CharMax.pattern)
+
+      test('matches correctly', () => {
+        expect('a1').toMatch(pattern)
+        expect('a'.repeat(40)).toMatch(pattern)
+        expect('sensible-test-string1').toMatch(pattern)
+      })
+
+      test('must be 40 chars or less', () => {
+        expect('a'.repeat(41)).not.toMatch(pattern)
+      })
+
+      test('must be lowercase', () => {
+        expect('string-with-UPPER-case').not.toMatch(pattern)
+      })
+
+      test('must start with letter', () => {
+        expect('1-test-string').not.toMatch(pattern)
+      })
+
+      test('must only contain alphanumeric and hyphen', () => {
+        expect('not_sensible_test_string1').not.toMatch(pattern)
+      })
+
+      test('must end with alphanumeric', () => {
+        expect('a1-').not.toMatch(pattern)
+      })
+    })
+
+    describe('uriCompatible63CharMax', () => {
+      const pattern = new RegExp(patterns.uriCompatible63CharMax.pattern)
+
+      test('matches correctly', () => {
+        expect('a1').toMatch(pattern)
+        expect('a'.repeat(63)).toMatch(pattern)
+        expect('sensible-test-string1').toMatch(pattern)
+      })
+
+      test('must be 63 chars or less', () => {
+        expect('a'.repeat(64)).not.toMatch(pattern)
+      })
+
+      test('must be lowercase', () => {
+        expect('string-with-UPPER-case').not.toMatch(pattern)
+      })
+
+      test('must start with letter', () => {
+        expect('1-test-string').not.toMatch(pattern)
+      })
+
+      test('must only contain alphanumeric and hyphen', () => {
+        expect('not_sensible_test_string1').not.toMatch(pattern)
+      })
+
+      test('must end with alphanumeric', () => {
+        expect('a1-').not.toMatch(pattern)
+      })
+    })
+  })
+})

--- a/ui/lib/components/cluster-build/ClusterOptionsForm.js
+++ b/ui/lib/components/cluster-build/ClusterOptionsForm.js
@@ -7,6 +7,7 @@ const { Option } = Select
 
 import PlanViewer from '../configure/PlanViewer'
 import PlanOptionsForm from '../plans/PlanOptionsForm'
+import { patterns } from '../../utils/validation'
 
 class ClusterOptionsForm extends React.Component {
   static propTypes = {
@@ -105,7 +106,7 @@ class ClusterOptionsForm extends React.Component {
             {getFieldDecorator('clusterName', {
               rules: [
                 { required: true, message: 'Please enter cluster name!' },
-                { pattern: '^[a-z][a-z0-9-]{0,38}[a-z0-9]$', message: 'Name must consist of lower case alphanumeric characters or "-", it must start with a letter and end with an alphanumeric and must be no longer than 40 characters' },
+                { ...patterns.uriCompatible40CharMax },
                 { validator: checkForDuplicateName }
               ],
               initialValue: this.generateClusterName(selectedPlan)

--- a/ui/lib/components/forms/NamespaceClaimForm.js
+++ b/ui/lib/components/forms/NamespaceClaimForm.js
@@ -4,6 +4,7 @@ import copy from '../../utils/object-copy'
 import Generic from '../../crd/Generic'
 import apiRequest from '../../utils/api-request'
 import apiPaths from '../../utils/api-paths'
+import { patterns } from '../../utils/validation'
 import { Button, Form, Input, Alert, Select } from 'antd'
 
 class NamespaceClaimForm extends React.Component {
@@ -150,7 +151,7 @@ class NamespaceClaimForm extends React.Component {
           {getFieldDecorator('name', {
             rules: [
               { required: true, message: 'Please enter the namespace name!' },
-              { pattern: '^[a-z0-9-_]+$', message: 'Name must only contain lowercase letters, numbers, hyphen and underscore' }
+              { ...patterns.uriCompatible63CharMax }
             ]
           })(
             <Input placeholder="Name" />,

--- a/ui/lib/utils/validation.js
+++ b/ui/lib/utils/validation.js
@@ -1,0 +1,10 @@
+export const patterns = {
+  uriCompatible40CharMax: {
+    pattern: '^[a-z][a-z0-9-]{0,38}[a-z0-9]$',
+    message: 'Must consist of lower case alphanumeric characters or "-", it must start with a letter and end with an alphanumeric and must be no longer than 40 characters'
+  },
+  uriCompatible63CharMax: {
+    pattern: '^[a-z][a-z0-9-]{0,61}[a-z0-9]$',
+    message: 'Must consist of lower case alphanumeric characters or "-", it must start with a letter and end with an alphanumeric and must be no longer than 63 characters'
+  }
+}


### PR DESCRIPTION
* it should only allow alphanumerics and hyphen
* also moving the patterns and messages out to a validation file
* refactoring pattern validations to use this

This could be taken a lot further to include all field validations but it's a starting point.

Fixes #663 