### PR TITLE
Add feature gates to the Kore API server and the CLI

### DIFF
--- a/cmd/kore-apiserver/options/options.go
+++ b/cmd/kore-apiserver/options/options.go
@@ -123,6 +123,11 @@ func Options() []cli.Flag {
 			EnvVars: []string{"KORE_IDP_USER_CLAIMS"},
 			Value:   cli.NewStringSlice("preferred_username", "email", "name", "username"),
 		},
+		&cli.StringFlag{
+			Name:    "feature-gates",
+			Usage:   "List of feature gates to disable/enable, as key-value pairs, e.g. 'services=true' `GATES`",
+			EnvVars: []string{"KORE_FEATURE_GATES"},
+		},
 
 		//
 		// @related to the user management service

--- a/pkg/client/config/types.go
+++ b/pkg/client/config/types.go
@@ -35,6 +35,8 @@ type Config struct {
 	Servers map[string]*Server `json:"servers,omitempty" yaml:"servers"`
 	// Version is the version of the configuration
 	Version string `json:"version,omitempty" yaml:"version"`
+	// FeatureGates shows all feature gates
+	FeatureGates map[string]bool `json:"feature-gates,omitempty" yaml:"feature-gates"`
 }
 
 // AuthInfo defines a credential to the api endpoint

--- a/pkg/cmd/errors/errors.go
+++ b/pkg/cmd/errors/errors.go
@@ -24,7 +24,7 @@ import (
 var (
 	// ErrAuthentication indicates we need to authenticate
 	ErrAuthentication = kerrors.New("authorization require, ensure you have $ kore login")
-	// ErrMissingResource indicates the resource name is missing
+	// ErrMissingResource indicates the resource is missing
 	ErrMissingResource = kerrors.New("resource is missing")
 	// ErrMissingResourceName indicates the resource name is missing
 	ErrMissingResourceName = kerrors.New("name is missing")

--- a/pkg/cmd/kore/alpha/alpha.go
+++ b/pkg/cmd/kore/alpha/alpha.go
@@ -17,6 +17,7 @@
 package alpha
 
 import (
+	"github.com/appvia/kore/pkg/cmd/kore/featuregates"
 	"github.com/appvia/kore/pkg/cmd/kore/patch"
 	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
 
@@ -33,8 +34,8 @@ func NewCmdAlpha(factory cmdutil.Factory) *cobra.Command {
 	}
 
 	command.AddCommand(
-		//NewCmdCreateAlpha(factory),
 		patch.NewCmdPatch(factory),
+		featuregates.NewCmdFeatureGates(factory),
 	)
 
 	return command

--- a/pkg/cmd/kore/delete/delete.go
+++ b/pkg/cmd/kore/delete/delete.go
@@ -108,7 +108,7 @@ func (o *DeleteOptions) Validate() error {
 		return nil
 	}
 	if o.Resource == "" {
-		return errors.ErrMissingResourceName
+		return errors.ErrMissingResource
 	}
 	if o.Name == "" {
 		return errors.ErrMissingResourceName

--- a/pkg/cmd/kore/featuregates/disable_feature_gate.go
+++ b/pkg/cmd/kore/featuregates/disable_feature_gate.go
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featuregates
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/appvia/kore/pkg/kore"
+
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+
+	"github.com/spf13/cobra"
+)
+
+type DisableFeatureGateOption struct {
+	cmdutil.Factory
+	Name string
+}
+
+// NewCmdDisableFeatureGate disables the given feature gate
+func NewCmdDisableFeatureGate(factory cmdutil.Factory) *cobra.Command {
+	o := &DisableFeatureGateOption{Factory: factory}
+
+	return &cobra.Command{
+		Use:     "disable",
+		Short:   "Disables the given feature gate",
+		Run:     cmdutil.DefaultRunFunc(o),
+		Example: "kore alpha feature-gates disable <FEATURE>",
+	}
+}
+
+// Validate is called to validate the options
+func (o *DisableFeatureGateOption) Validate() error {
+	name := strings.ToLower(o.Name)
+
+	if name == "" {
+		return errors.New("feature gate name is required")
+	}
+	defaultFeatureGates := kore.DefaultFeatureGates()
+	if _, exists := defaultFeatureGates[name]; !exists {
+		return fmt.Errorf("feature gate %q is invalid", name)
+	}
+	return nil
+}
+
+// Run implements the action
+func (o *DisableFeatureGateOption) Run() error {
+	name := strings.ToLower(o.Name)
+
+	if o.Config().FeatureGates == nil {
+		o.Config().FeatureGates = map[string]bool{}
+	}
+	o.Config().FeatureGates[name] = false
+
+	if err := o.UpdateConfig(); err != nil {
+		return err
+	}
+
+	o.Println("%q feature gate was disabled", name)
+	return nil
+}

--- a/pkg/cmd/kore/featuregates/enable_feature_gate.go
+++ b/pkg/cmd/kore/featuregates/enable_feature_gate.go
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featuregates
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/appvia/kore/pkg/kore"
+
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+
+	"github.com/spf13/cobra"
+)
+
+type EnableFeatureGateOption struct {
+	cmdutil.Factory
+	Name string
+}
+
+// NewCmdEnabledFeatureGate enables the given feature gate
+func NewCmdEnabledFeatureGate(factory cmdutil.Factory) *cobra.Command {
+	o := &EnableFeatureGateOption{Factory: factory}
+
+	return &cobra.Command{
+		Use:     "enable",
+		Short:   "Enables the given feature gate",
+		Run:     cmdutil.DefaultRunFunc(o),
+		Example: "kore alpha feature-gate enables <FEATURE>",
+	}
+}
+
+// Validate is called to validate the options
+func (o *EnableFeatureGateOption) Validate() error {
+	name := strings.ToLower(o.Name)
+
+	if name == "" {
+		return errors.New("feature gate name is required")
+	}
+	defaultFeatureGates := kore.DefaultFeatureGates()
+	if _, exists := defaultFeatureGates[name]; !exists {
+		return fmt.Errorf("feature gate %q is invalid", name)
+	}
+	return nil
+}
+
+// Run implements the action
+func (o *EnableFeatureGateOption) Run() error {
+	name := strings.ToLower(o.Name)
+
+	if o.Config().FeatureGates == nil {
+		o.Config().FeatureGates = map[string]bool{}
+	}
+	o.Config().FeatureGates[name] = true
+
+	if err := o.UpdateConfig(); err != nil {
+		return err
+	}
+
+	o.Println("%q feature gate was enabled", name)
+	return nil
+}

--- a/pkg/cmd/kore/featuregates/feature_gates.go
+++ b/pkg/cmd/kore/featuregates/feature_gates.go
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featuregates
+
+import (
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	"github.com/appvia/kore/pkg/utils/render"
+	"github.com/spf13/cobra"
+)
+
+type FeatureGatesOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+	// Headers indicates no headers on the table output
+	Headers bool
+	// Output is the output format
+	Output string
+}
+
+// NewCmdFeatureGates creates and returns the profile list command
+func NewCmdFeatureGates(factory cmdutil.Factory) *cobra.Command {
+	o := &FeatureGatesOptions{Factory: factory}
+
+	command := &cobra.Command{
+		Use:     "feature-gates",
+		Short:   "List all feature gates",
+		Run:     cmdutil.DefaultRunFunc(o),
+		Example: "kore alpha feature-gates",
+	}
+
+	command.AddCommand(
+		NewCmdEnabledFeatureGate(factory),
+		NewCmdDisableFeatureGate(factory),
+	)
+
+	return command
+}
+
+// Run implements the action
+func (o *FeatureGatesOptions) Run() error {
+	type featureGate struct {
+		Name    string `json:"name"`
+		Enabled bool   `json:"enabled"`
+	}
+	var list []featureGate
+
+	for k, v := range o.Config().FeatureGates {
+		list = append(list, featureGate{
+			Name:    k,
+			Enabled: v,
+		})
+	}
+
+	return render.Render().
+		Writer(o.Writer()).
+		Format(o.Output).
+		ShowHeaders(o.Headers).
+		Resource(render.FromStruct(&list)).
+		Printer(
+			render.Column("Feature gate", "name"),
+			render.Column("Enabled", "enabled"),
+		).Do()
+}

--- a/pkg/cmd/utils/factory.go
+++ b/pkg/cmd/utils/factory.go
@@ -39,7 +39,7 @@ type factory struct {
 
 // NewFactory returns a default factory
 func NewFactory(client client.Interface, streams Streams, config *config.Config) (Factory, error) {
-	resources, err := newResourceManager(client)
+	resources, err := newResourceManager(client, config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/utils/handler.go
+++ b/pkg/cmd/utils/handler.go
@@ -56,8 +56,9 @@ func DefaultRunFunc(o RunHandler) func(*cobra.Command, []string) {
 
 		// @step: we can help with resource and name as well
 		if utils.HasReflectField("Resource", o) && utils.HasReflectField("Name", o) {
-			resource, err := o.Resources().Lookup(cmd.Flags().Arg(0))
-			if err == nil {
+			if cmd.Flags().Arg(0) != "" {
+				resource, err := o.Resources().Lookup(cmd.Flags().Arg(0))
+				o.CheckError(err)
 				utils.SetReflectedField("Resource", resource.Name, o)
 			}
 			utils.SetReflectedField("Name", cmd.Flags().Arg(1), o)

--- a/pkg/cmd/utils/helper.go
+++ b/pkg/cmd/utils/helper.go
@@ -17,9 +17,12 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"regexp"
+
+	"github.com/appvia/kore/pkg/utils"
 
 	"github.com/appvia/kore/pkg/cmd/errors"
 	"github.com/appvia/kore/pkg/utils/render"
@@ -151,10 +154,12 @@ func ParseDocument(f Factory, src io.Reader) ([]*ResourceDocument, error) {
 			return nil, errors.ErrMissingResourceVersion
 		}
 
+		displayName := utils.GetUnstructuredSelfLink(u)
+
 		// @step: lookup the resource from the cache
 		resource, err := f.Resources().Lookup(u.GetKind())
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s: %w", displayName, err)
 		}
 
 		list = append(list, &ResourceDocument{Object: u, Resource: resource})

--- a/pkg/cmd/utils/resource_types.go
+++ b/pkg/cmd/utils/resource_types.go
@@ -24,28 +24,7 @@ import (
 	orgv1 "github.com/appvia/kore/pkg/apis/org/v1"
 )
 
-func init() {
-	ResourceNames = make([]string, len(ResourceList))
-	for i := 0; i < len(ResourceList); i++ {
-		ResourceNames[i] = ResourceList[i].Name
-	}
-}
-
 var (
-	// ResourceNames is a list of resource names
-	ResourceNames []string
-
-	// DefaultResource the printer to use for unknown resources
-	DefaultResource = Resource{
-		Name:  "default",
-		Scope: TeamScope,
-		Printer: []Column{
-			{"Name", "metadata.name", ""},
-			{"Status", "status.status", ""},
-			{"Age", "metadata.creationTimestamp", "age"},
-		},
-	}
-
 	// ResourceList is a list of supported resources
 	ResourceList = []Resource{
 		{

--- a/pkg/cmd/utils/types.go
+++ b/pkg/cmd/utils/types.go
@@ -133,6 +133,8 @@ type Resource struct {
 	Scope ResourceScope `json:"scope,omitempty"`
 	// Printer is printer columns for the resource
 	Printer []Column `json:"printer,omitempty"`
+	// FeatureFlag binds the resource to a feature gate
+	FeatureGate string `json:"featureFlag,omitempty"`
 }
 
 // IsTeamScoped checks if a team resource

--- a/pkg/kore/config.go
+++ b/pkg/kore/config.go
@@ -61,3 +61,11 @@ func (c Config) HasCertificateAuthority() bool {
 func (c Config) HasHMAC() bool {
 	return c.HMAC != ""
 }
+
+func (c Config) IsFeatureGateEnabled(gate string) bool {
+	if c.FeatureGates == nil {
+		return false
+	}
+
+	return c.FeatureGates[gate]
+}

--- a/pkg/kore/feature_gates.go
+++ b/pkg/kore/feature_gates.go
@@ -14,22 +14,16 @@
  * limitations under the License.
  */
 
-package alpha
+package kore
 
-import (
-	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
-
-	"github.com/spf13/cobra"
+const (
+	// FeatureGateServices enables the managed services
+	FeatureGateServices = "services"
 )
 
-// NewCmdCreatAlpha creates and returns the alpha create command
-func NewCmdCreateAlpha(factory cmdutil.Factory) *cobra.Command {
-	command := &cobra.Command{
-		Use:                   "create",
-		DisableFlagsInUseLine: true,
-		Short:                 "Creates a collection of experimental resources in kore",
-		Run:                   cmdutil.RunHelp,
+// DefaultFeatureGates returns the existing feature gates with the default statuses
+func DefaultFeatureGates() map[string]bool {
+	return map[string]bool{
+		FeatureGateServices: false,
 	}
-
-	return command
 }

--- a/pkg/kore/types.go
+++ b/pkg/kore/types.go
@@ -115,6 +115,8 @@ type Config struct {
 	// EnableClusterProviderCheck indicate the k8s controller should check the status of the
 	// cloud provider as well
 	EnableClusterProviderCheck bool `json:"enable-cluster-provider-check,omitempty"`
+	// FeatureGates defines which feature gates should be enabled/disabled
+	FeatureGates map[string]bool `json:"feature-gates,omitempty"`
 	// HMAC is the token used to sign things
 	HMAC string `json:"hmac"`
 	// IDPClientID is the client id for the openid authenticator


### PR DESCRIPTION
## What

This is a prerequisite of https://github.com/appvia/kore/pull/652. You can decide whether you want to review the two stories separately or together.

This adds feature gates to the API server and the CLI. For now we have to set these separately, but in the future we should create an endpoint in the API, so the CLI and UI can query the enabled features.

The feature gates are stores in the Kore CLI's config as:
```
feature-gates:
  services: false
```

The feature gates can be set on the API using the `--feature-gates="services=true"`, or using an env var: `export KORE_FEATURE_GATES="services=true"` 

By default services is disabled.

## New commands

```
$ kore alpha feature-gates
FEATURE GATE    ENABLED
services        false

$ kore alpha feature-gates enable services
"services" feature gate was enabled

$ kore alpha feature-gates disable services
"services" feature gate was disabled
```

## Additional changes

 * I've dropped the DefaultResource in the CLI, so we are going to throw better errors if a resource does not exist
 * I've fixed the `kore get` doesn't match the `audit` type accidentally.