### PR TITLE
UI Plan Policies - Create, Edit, View and Delete

### DIFF
--- a/pkg/kore/assets/plan_policies.go
+++ b/pkg/kore/assets/plan_policies.go
@@ -27,7 +27,6 @@ import (
 func GetDefaultPlanPolicies() []*configv1.PlanPolicy {
 	return []*configv1.PlanPolicy{
 		{
-
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "default-gke",
 				Labels: map[string]string{
@@ -36,8 +35,8 @@ func GetDefaultPlanPolicies() []*configv1.PlanPolicy {
 			},
 			Spec: configv1.PlanPolicySpec{
 				Kind:        "GKE",
-				Summary:     "Default policy for GKE Cluster plans",
-				Description: "This policy defines which plan properties can be edited by default",
+				Summary:     "Default GKE",
+				Description: "This policy defines which plan properties can be edited by default for GKE clusters",
 				Properties: []configv1.PlanPolicyProperty{
 					{Name: "authProxyAllowedIPs", AllowUpdate: true},
 					{Name: "clusterUsers", AllowUpdate: true},
@@ -60,8 +59,8 @@ func GetDefaultPlanPolicies() []*configv1.PlanPolicy {
 			},
 			Spec: configv1.PlanPolicySpec{
 				Kind:        "EKS",
-				Summary:     "Default policy for EKS Cluster plans",
-				Description: "This policy defines which plan properties can be edited by default",
+				Summary:     "Default EKS",
+				Description: "This policy defines which plan properties can be edited by default for EKS clusters",
 				Properties: []configv1.PlanPolicyProperty{
 					{Name: "authProxyAllowedIPs", AllowUpdate: true},
 					{Name: "clusterUsers", AllowUpdate: true},

--- a/ui/__tests__/api-test-helpers.js
+++ b/ui/__tests__/api-test-helpers.js
@@ -14,6 +14,7 @@ class ApiTestHelpers {
   
     return nock(`${u.protocol}//${u.host}`)
       .get('/swagger.json')
+      .times(10000)
       .optionally()
       .reply(200, spec, { 'Content-type': 'application/json' })
   }

--- a/ui/__tests__/unit/lib/components/forms/EKSCredentialsForm.test.js
+++ b/ui/__tests__/unit/lib/components/forms/EKSCredentialsForm.test.js
@@ -29,7 +29,7 @@ describe('EKSCredentialsForm', () => {
         getFieldValue: () => {},
         validateFields: jest.fn()
       },
-      team: 'abc',
+      team: 'kore-admin',
       allTeams: { items: [] },
       handleSubmit: jest.fn()
     }
@@ -51,8 +51,8 @@ describe('EKSCredentialsForm', () => {
   describe('#getResource', () => {
     beforeEach(() => {
       apiScope
-        .get(`${ApiTestHelpers.basePath}/teams/abc/ekscredentials/eks`).reply(200, eksCredential)
-        .get(`${ApiTestHelpers.basePath}/teams/abc/allocations/eks`).reply(200, allocation)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/ekscredentials/eks`).reply(200, eksCredential)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/eks`).reply(200, allocation)
     })
 
     it('returns EKS credential and allocation from API', async () => {
@@ -66,8 +66,8 @@ describe('EKSCredentialsForm', () => {
   describe('#putResource', () => {
     beforeEach(() => {
       apiScope
-        .put(`${ApiTestHelpers.basePath}/teams/abc/ekscredentials/eks`).reply(200, eksCredential)
-        .put(`${ApiTestHelpers.basePath}/teams/abc/allocations/eks`).reply(200, allocation)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/ekscredentials/eks`).reply(200, eksCredential)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/eks`).reply(200, allocation)
     })
 
     it('creates/updates and returns EKS credential and allocation from API', async () => {

--- a/ui/__tests__/unit/lib/components/forms/GCPOrganizationsForm.test.js
+++ b/ui/__tests__/unit/lib/components/forms/GCPOrganizationsForm.test.js
@@ -33,7 +33,7 @@ describe('GCPOrganizationForm', () => {
         getFieldValue: () => {},
         validateFields: jest.fn()
       },
-      team: 'abc',
+      team: 'kore-admin',
       allTeams: { items: [] },
       handleSubmit: jest.fn()
     }
@@ -62,8 +62,8 @@ describe('GCPOrganizationForm', () => {
   describe('#getResource', () => {
     beforeEach(() => {
       apiScope
-        .get(`${ApiTestHelpers.basePath}/teams/abc/organizations/gcp`).reply(200, gcpOrganization)
-        .get(`${ApiTestHelpers.basePath}/teams/abc/allocations/gcp`).reply(200, allocation)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/organizations/gcp`).reply(200, gcpOrganization)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gcp`).reply(200, allocation)
     })
 
     it('returns Organization and allocation from API', async () => {
@@ -77,9 +77,9 @@ describe('GCPOrganizationForm', () => {
   describe('#putResource', () => {
     beforeEach(() => {
       apiScope
-        .put(`${ApiTestHelpers.basePath}/teams/abc/secrets/gcp`).reply(200, secret)
-        .put(`${ApiTestHelpers.basePath}/teams/abc/organizations/gcp`).reply(200, gcpOrganization)
-        .put(`${ApiTestHelpers.basePath}/teams/abc/allocations/gcp`).reply(200, allocation)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/secrets/gcp`).reply(200, secret)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/organizations/gcp`).reply(200, gcpOrganization)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gcp`).reply(200, allocation)
     })
 
     it('creates/updates and returns Organization and allocation from API', async () => {

--- a/ui/__tests__/unit/lib/components/forms/GKECredentialsForm.test.js
+++ b/ui/__tests__/unit/lib/components/forms/GKECredentialsForm.test.js
@@ -29,7 +29,7 @@ describe('GKECredentialsForm', () => {
         getFieldValue: () => {},
         validateFields: jest.fn()
       },
-      team: 'abc',
+      team: 'kore-admin',
       allTeams: { items: [] },
       handleSubmit: jest.fn()
     }
@@ -51,8 +51,8 @@ describe('GKECredentialsForm', () => {
   describe('#getResource', () => {
     beforeEach(() => {
       apiScope
-        .get(`${ApiTestHelpers.basePath}/teams/abc/gkecredentials/gke`).reply(200, gkeCredential)
-        .get(`${ApiTestHelpers.basePath}/teams/abc/allocations/gke`).reply(200, allocation)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/gkecredentials/gke`).reply(200, gkeCredential)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gke`).reply(200, allocation)
     })
 
     it('returns GKE credential and allocation from API', async () => {
@@ -66,8 +66,8 @@ describe('GKECredentialsForm', () => {
   describe('#putResource', () => {
     beforeEach(() => {
       apiScope
-        .put(`${ApiTestHelpers.basePath}/teams/abc/gkecredentials/gke`).reply(200, gkeCredential)
-        .put(`${ApiTestHelpers.basePath}/teams/abc/allocations/gke`).reply(200, allocation)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/gkecredentials/gke`).reply(200, gkeCredential)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gke`).reply(200, allocation)
     })
 
     it('creates/updates and returns GKE credential and allocation from API', async () => {

--- a/ui/__tests__/unit/lib/components/forms/VerifiedAllocatedResourceForm.test.js
+++ b/ui/__tests__/unit/lib/components/forms/VerifiedAllocatedResourceForm.test.js
@@ -82,16 +82,6 @@ describe('VerifiedAllocatedResourceForm', () => {
     })
   })
 
-  describe('#generateAllocationResource', () => {
-    it('returns a configured Allocation object when given valid values', () => {
-      const allocation = form.generateAllocationResource(
-        { group: 'aws.compute.kore.appvia.io', version: 'v1alpha1', kind: 'EKSCredentials' },
-        { name: 'Allocation name', summary: 'Summary of allocation' }
-      )
-      expect(allocation).toBeDefined()
-    })
-  })
-
   describe('#handleSubmit', () => {
     let event
     beforeEach(() => {

--- a/ui/__tests__/unit/lib/components/policies/PolicyForm.test.js
+++ b/ui/__tests__/unit/lib/components/policies/PolicyForm.test.js
@@ -1,0 +1,133 @@
+import { mount } from 'enzyme'
+
+import PolicyForm from '../../../../../lib/components/policies/PolicyForm'
+import ApiTestHelpers from '../../../../api-test-helpers'
+
+describe('PolicyForm', () => {
+  let props
+  let form
+  let apiScope
+
+  const schema = {
+    properties: {
+      bool1: { type: 'boolean' },
+      bool2: { type: 'boolean' }
+    }
+  }
+
+  beforeEach(async () => {
+    // In case any tests leak to the API, mock out the API at this stage:
+    apiScope = (ApiTestHelpers.getScope())
+      .get(`${ApiTestHelpers.basePath}/planschemas/GKE`).reply(200, schema)
+      .get(`${ApiTestHelpers.basePath}/teams`).reply(200, { items: [] })
+      .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/allow-gke-node-type-changes`).reply(404)
+
+    props = {
+      form: {
+        isFieldTouched: () => {},
+        getFieldDecorator: jest.fn(() => c => c),
+        getFieldsError: () => () => {},
+        getFieldError: () => {},
+        getFieldValue: () => {},
+        validateFields: jest.fn()
+      },
+      policy: {
+        'kind':'PlanPolicy',
+        'apiVersion':'config.kore.appvia.io/v1',
+        'metadata':{
+          'name': 'allow-gke-node-type-changes',
+          'namespace':'kore-admin',
+        },
+        'spec':{
+          'kind':'GKE',
+          'summary':'Allow GKE node type changes',
+          'description':'Teams with this policy applied may set the cluster node type',
+          'properties':[
+            { 'name':'machineType', 'allowUpdate':true, 'disallowUpdate':false }
+          ]
+        }
+      },
+      allocatedTeams: [],
+      kind: 'GKE',
+      handleSubmit: jest.fn()
+    }
+    mount(<PolicyForm wrappedComponentRef={component => form = component} {...props} />)
+    await form.componentDidMountComplete
+  })
+
+  afterEach(() => {
+    // This will check that no calls were made against the API, unless the test registered them:
+    apiScope.done()
+  })
+
+  describe('#generatePolicyResource', () => {
+    test('returns a configured Policy object when given valid values', () => {
+      const plan = form.generatePolicyResource({ description: 'Policy description', summary: 'Policy name', properties: [{}] })
+      expect(plan).toBeDefined()
+    })
+  })
+
+  describe('#handleSubmit', () => {
+    let event
+    beforeEach(() => {
+      event = { preventDefault: jest.fn() }
+      form.setFormSubmitting = jest.fn()
+      props.form.validateFields.mockClear()
+      form.handleSubmit(event)
+    })
+
+    test('prevents default', () => {
+      expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    })
+
+    test('sets form submitting in state', () => {
+      expect(form.setFormSubmitting).toHaveBeenCalledTimes(1)
+      expect(form.setFormSubmitting.mock.calls[0]).toEqual([])
+    })
+
+    test('validates fields', () => {
+      expect(props.form.validateFields).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('#_process', () => {
+    const policyResource = {
+      'kind':'PlanPolicy',
+      'apiVersion':'config.kore.appvia.io/v1',
+      'metadata':{
+        'name': 'allow-gke-node-type-changes',
+        'namespace':'kore-admin',
+      },
+      'spec':{
+        'kind':'GKE',
+        'summary':'Allow GKE node type changes',
+        'description':'Teams with this policy applied may set the cluster node type',
+        'properties':[
+          { 'name':'machineType', 'allowUpdate':true, 'disallowUpdate':false }
+        ]
+      }
+    }
+
+    beforeEach(() => {
+      form.setFormSubmitting = jest.fn()
+      props.handleSubmit.mockClear()
+      form.state.policy = policyResource
+      form.state.allocatedTeams = ['*']
+    })
+
+    test('handles form validation errors', async () => {
+      await form._process('error', null)
+      expect(form.setFormSubmitting).toHaveBeenCalledTimes(1)
+      expect(form.setFormSubmitting.mock.calls[0]).toEqual([false, 'Validation failed'])
+    })
+
+    test('creates the resource and calls the wrapper component handleSubmit function', async () => {
+      apiScope.put(`${ApiTestHelpers.basePath}/planpolicies/allow-gke-node-type-changes`).reply(200, policyResource)
+      apiScope.put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/allow-gke-node-type-changes`).reply(200)
+      await form._process(null, { summary: 'Allow GKE node type changes', description: 'Description of policy' })
+      expect(props.handleSubmit).toHaveBeenCalledTimes(1)
+      expect(props.handleSubmit.mock.calls[0]).toEqual([policyResource])
+      apiScope.done()
+    })
+  })
+})

--- a/ui/__tests__/unit/lib/utils/allocation-helpers.test.js
+++ b/ui/__tests__/unit/lib/utils/allocation-helpers.test.js
@@ -1,0 +1,48 @@
+import AllocationHelpers from '../../../../lib/utils/allocation-helpers'
+import config from '../../../../config'
+
+describe('AllocationHelpers', () => {
+  describe('#generateAllocation', () => {
+    const resource = {
+      apiVersion: 'testgroup.appvia.io/v1alpha1',
+      kind: 'TestKind',
+      metadata: {
+        name: 'test-resource',
+        namespace: 'test-team'
+      },
+    }
+
+    it('should return an allocation when called with a resource', () => {
+      const allocation = AllocationHelpers.generateAllocation({ resourceToAllocate: resource, teams: [] })
+      expect(allocation).toBeDefined()
+      expect(allocation.metadata.name).toEqual(resource.metadata.name)
+      expect(allocation.metadata.namespace).toEqual(config.kore.koreAdminTeamName)
+      expect(allocation.spec.resource.group).toEqual('testgroup.appvia.io')
+      expect(allocation.spec.resource.version).toEqual('v1alpha1')
+      expect(allocation.spec.resource.kind).toEqual(resource.kind)
+      expect(allocation.spec.resource.namespace).toEqual(resource.metadata.namespace)
+    })
+
+    it('should set the teams to all if no teams provided', () => {
+      const allocation = AllocationHelpers.generateAllocation({ resourceToAllocate: resource, teams: [] })
+      expect(allocation.spec.teams).toEqual(['*'])
+    })
+
+    it('should set the teams to specific value if teams provided', () => {
+      const allocation = AllocationHelpers.generateAllocation({ resourceToAllocate: resource, teams: ['team1','team2'] })
+      expect(allocation.spec.teams).toEqual(['team1','team2'])
+    })
+
+    it('should set the spec name and summary if provided', () => {
+      const allocation = AllocationHelpers.generateAllocation({ resourceToAllocate: resource, teams: ['team1','team2'], name: 'horse', summary: 'cheese' })
+      expect(allocation.spec.name).toEqual('horse')
+      expect(allocation.spec.summary).toEqual('cheese')
+    })
+
+    it('should set defaults for the spec name and description if not provided', () => {
+      const allocation = AllocationHelpers.generateAllocation({ resourceToAllocate: resource, teams: ['team1','team2'] })
+      expect(allocation.spec.name).toEqual('test-resource')
+      expect(allocation.spec.summary).toEqual('Allocation of test-resource')
+    })
+  })
+})

--- a/ui/lib/components/configure/ResourceList.js
+++ b/ui/lib/components/configure/ResourceList.js
@@ -24,11 +24,19 @@ class ResourceList extends React.Component {
     return this.fetchComponentData()
       .then(data => {
         this.setState({
-          ...this.state,
           ...data,
           dataLoading: false
         })
       })
+  }
+
+  refresh = async () => {
+    this.setState({ dataLoading: true })
+    const data = await this.fetchComponentData()
+    this.setState({
+      ...data,
+      dataLoading: false
+    })
   }
 
   handleStatusUpdated = (updatedResource, done) => {

--- a/ui/lib/components/forms/AllocationsFormItem.js
+++ b/ui/lib/components/forms/AllocationsFormItem.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Form, Select, Radio, Alert } from 'antd'
+
+import KoreApi from '../../kore-api'
+import { kore } from '../../../config'
+
+export default class AllocationsFormItem extends React.Component {
+  static propTypes = {
+    allTeams: PropTypes.array,
+    allocatedTeams: PropTypes.array.isRequired,
+    onAllocationChange: PropTypes.func.isRequired
+  }
+
+  state = {
+    allTeams: [],
+  }
+
+  componentDidMountComplete = null
+  componentDidMount() {
+    this.componentDidMountComplete = Promise.resolve().then(async () => {
+      // If we've not been handed teams, load them ourselves.
+      let teams = this.props.allTeams
+      if (!teams) {
+        teams = await (await KoreApi.client()).ListTeams()
+      }
+      this.setState({
+        allTeams: teams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+      })
+    })
+  }
+
+  getAllocateMode = () => {
+    return this.props.allocatedTeams.find((t) => t === '*') ? 'all' : 'specified'
+  }
+
+  onAllocateModeChange = (v) => {
+    this.props.onAllocationChange(v === 'all' ? ['*'] : [])
+  }
+
+  onTeamsChange = (v) => {
+    this.props.onAllocationChange([...v])
+  }
+
+  getHelp = () => {
+    const mode = this.getAllocateMode()
+    if (mode === 'all') {
+      return <>This will be allocated to <span style={{ fontWeight: 'bold' }}>all teams</span></>
+    } 
+    const hasTeams = this.props.allocatedTeams.length > 0
+    if (hasTeams) {
+      return <>This will be allocated to the <span style={{ fontWeight: 'bold' }}>specified teams</span> only</>
+    }
+    return <Alert type='error' message={<>You must specify <span style={{ fontWeight: 'bold' }}>one or more teams</span> this will be allocated to</>} />
+  }
+
+  render() {
+    if (this.props.allocatedTeams === null) {
+      // @TODO: Loading...
+      return null
+    }
+    const { allTeams } = this.state
+    const mode = this.getAllocateMode()
+    return (
+      <Form.Item label="Allocate to teams" help={this.getHelp()} required={true}>
+        <Radio.Group onChange={(e) => this.onAllocateModeChange(e.target.value)} value={mode}>
+          <Radio value="all">All</Radio>
+          <Radio value="specified">Specified teams</Radio>
+        </Radio.Group>
+        {mode !== 'all' ? (
+          <Select
+            mode="multiple"
+            style={{ width: '100%' }}
+            value={this.props.allocatedTeams.filter((t) => t !== '*')}
+            onChange={(v) => this.onTeamsChange(v)}
+          >
+            {allTeams.map(t => (
+              <Select.Option key={t.metadata.name} value={t.metadata.name}>{t.spec.summary}</Select.Option>
+            ))}
+          </Select>
+        ) : null}
+      </Form.Item>
+    )
+  }
+}

--- a/ui/lib/components/forms/EKSCredentialsForm.js
+++ b/ui/lib/components/forms/EKSCredentialsForm.js
@@ -4,6 +4,7 @@ import V1ObjectMeta from '../../kore-api/model/V1ObjectMeta'
 import VerifiedAllocatedResourceForm from '../../components/forms/VerifiedAllocatedResourceForm'
 import KoreApi from '../../kore-api'
 import { Form, Input, Alert, Card } from 'antd'
+import AllocationHelpers from '../../utils/allocation-helpers'
 
 class EKSCredentialsForm extends VerifiedAllocatedResourceForm {
 
@@ -30,16 +31,16 @@ class EKSCredentialsForm extends VerifiedAllocatedResourceForm {
   getResource = async metadataName => {
     const api = await KoreApi.client()
     const eksCredentialsResult = await api.GetEKSCredentials(this.props.team, metadataName)
-    eksCredentialsResult.allocation = await api.GetAllocation(this.props.team, metadataName)
+    eksCredentialsResult.allocation = await AllocationHelpers.getAllocationForResource(eksCredentialsResult)
     return eksCredentialsResult
   }
 
   putResource = async values => {
     const api = await KoreApi.client()
     const metadataName = this.getMetadataName(values)
-    const eksResult = await api.UpdateEKSCredentials(this.props.team, metadataName, this.generateEKSCredentialsResource(values))
-    const allocationResource = this.generateAllocationResource({ group: 'aws.compute.kore.appvia.io', version: 'v1alpha1', kind: 'EKSCredentials' }, values)
-    eksResult.allocation = await api.UpdateAllocation(this.props.team, metadataName, allocationResource)
+    const eksCredResource = this.generateEKSCredentialsResource(values)
+    const eksResult = await api.UpdateEKSCredentials(this.props.team, metadataName, eksCredResource)
+    eksResult.allocation = await this.storeAllocation(eksCredResource, values)
     return eksResult
   }
 

--- a/ui/lib/components/forms/GCPOrganizationForm.js
+++ b/ui/lib/components/forms/GCPOrganizationForm.js
@@ -8,6 +8,7 @@ import V1SecretReference from '../../kore-api/model/V1SecretReference'
 import V1alpha1OrganizationSpec from '../../kore-api/model/V1alpha1OrganizationSpec'
 import KoreApi from '../../kore-api'
 import { Form, Input, Alert, Card } from 'antd'
+import AllocationHelpers from '../../utils/allocation-helpers'
 
 class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
 
@@ -60,7 +61,7 @@ class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
   getResource = async metadataName => {
     const api = await KoreApi.client()
     const gcpOrgResult = await api.GetGCPOrganization(this.props.team, metadataName)
-    gcpOrgResult.allocation = await api.GetAllocation(this.props.team, metadataName)
+    gcpOrgResult.allocation = await AllocationHelpers.getAllocationForResource(gcpOrgResult)
     return gcpOrgResult
   }
 
@@ -68,9 +69,9 @@ class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
     const api = await KoreApi.client()
     const metadataName = this.getMetadataName(values)
     await api.UpdateTeamSecret(this.props.team, metadataName, this.generateSecretResource(values))
-    const gcpOrgResult = await api.UpdateGCPOrganization(this.props.team, metadataName, this.generateGCPOrganizationResource(values))
-    const allocationResource = this.generateAllocationResource({ group: 'gcp.compute.kore.appvia.io', version: 'v1alpha1', kind: 'Organization' }, values)
-    gcpOrgResult.allocation = await api.UpdateAllocation(this.props.team, metadataName, allocationResource)
+    const gcpOrg = this.generateGCPOrganizationResource(values)
+    const gcpOrgResult = await api.UpdateGCPOrganization(this.props.team, metadataName, gcpOrg)
+    gcpOrgResult.allocation = await this.storeAllocation(gcpOrg, values)
     return gcpOrgResult
   }
 

--- a/ui/lib/components/forms/GKECredentialsForm.js
+++ b/ui/lib/components/forms/GKECredentialsForm.js
@@ -4,6 +4,7 @@ import V1ObjectMeta from '../../kore-api/model/V1ObjectMeta'
 import VerifiedAllocatedResourceForm from '../../components/forms/VerifiedAllocatedResourceForm'
 import KoreApi from '../../kore-api'
 import { Form, Input, Alert, Card } from 'antd'
+import AllocationHelpers from '../../utils/allocation-helpers'
 
 class GKECredentialsForm extends VerifiedAllocatedResourceForm {
 
@@ -29,16 +30,16 @@ class GKECredentialsForm extends VerifiedAllocatedResourceForm {
   getResource = async metadataName => {
     const api = await KoreApi.client()
     const gkeCredentialsResult = await api.GetGKECredential(this.props.team, metadataName)
-    gkeCredentialsResult.allocation = await api.GetAllocation(this.props.team, metadataName)
+    gkeCredentialsResult.allocation = await AllocationHelpers.getAllocationForResource(gkeCredentialsResult)
     return gkeCredentialsResult
   }
 
   putResource = async values => {
     const api = await KoreApi.client()
     const metadataName = this.getMetadataName(values)
-    const gkeResult = await api.UpdateGKECredential(this.props.team, metadataName, this.generateGKECredentialsResource(values))
-    const allocationResource = this.generateAllocationResource({ group: 'gke.compute.kore.appvia.io', version: 'v1alpha1', kind: 'GKECredentials' }, values)
-    gkeResult.allocation = await api.UpdateAllocation(this.props.team, metadataName, allocationResource)
+    const gkeCredRes = this.generateGKECredentialsResource(values)
+    const gkeResult = await api.UpdateGKECredential(this.props.team, metadataName, gkeCredRes)
+    gkeResult.allocation = await this.storeAllocation(gkeCredRes, values)
     return gkeResult
   }
 

--- a/ui/lib/components/forms/VerifiedAllocatedResourceForm.js
+++ b/ui/lib/components/forms/VerifiedAllocatedResourceForm.js
@@ -1,14 +1,12 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import canonical from '../../utils/canonical'
-import V1Allocation from '../../kore-api/model/V1Allocation'
-import V1AllocationSpec from '../../kore-api/model/V1AllocationSpec'
-import V1ObjectMeta from '../../kore-api/model/V1ObjectMeta'
-import V1Ownership from '../../kore-api/model/V1Ownership'
-import ResourceVerificationStatus from '../../components/ResourceVerificationStatus'
-import FormErrorMessage from '../../components/forms/FormErrorMessage'
 import { message, Typography, Form, Card, Alert, Button, Input, Select } from 'antd'
 const { Paragraph, Text } = Typography
+
+import canonical from '../../utils/canonical'
+import ResourceVerificationStatus from '../../components/ResourceVerificationStatus'
+import FormErrorMessage from '../../components/forms/FormErrorMessage'
+import AllocationHelpers from '../../utils/allocation-helpers'
 
 class VerifiedAllocatedResourceForm extends React.Component {
   static propTypes = {
@@ -112,33 +110,8 @@ class VerifiedAllocatedResourceForm extends React.Component {
     return (data && data.metadata && data.metadata.name) || canonical(values.name)
   }
 
-  generateAllocationResource = (ownership, values) => {
-    const metadataName = this.getMetadataName(values)
-
-    const resource = new V1Allocation()
-    resource.setApiVersion('config.kore.appvia.io/v1')
-    resource.setKind('Allocation')
-
-    const meta = new V1ObjectMeta()
-    meta.setName(metadataName)
-    meta.setNamespace(this.props.team)
-    resource.setMetadata(meta)
-
-    const spec = new V1AllocationSpec()
-    spec.setName(values.name)
-    spec.setSummary(values.summary)
-    spec.setTeams(this.state.allocations.length > 0 ? this.state.allocations : ['*'])
-    const owner = new V1Ownership()
-    owner.setGroup(ownership.group)
-    owner.setVersion(ownership.version)
-    owner.setKind(ownership.kind)
-    owner.setName(metadataName)
-    owner.setNamespace(this.props.team)
-    spec.setResource(owner)
-
-    resource.setSpec(spec)
-
-    return resource
+  storeAllocation = async (resource, values) => {
+    return await AllocationHelpers.storeAllocation({ resourceToAllocate: resource, teams: this.state.allocations, name: values.name, summary: values.summary })
   }
 
   _process = async (err, values) => {

--- a/ui/lib/components/policies/Policy.js
+++ b/ui/lib/components/policies/Policy.js
@@ -1,0 +1,155 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import KoreApi from '../../kore-api'
+import { Table, Icon, Typography, Tooltip } from 'antd'
+const { Text } = Typography
+import { startCase } from 'lodash'
+
+export default class Policy extends React.Component {
+  static propTypes = {
+    policy: PropTypes.object.isRequired,
+    mode: PropTypes.oneOf(['view','edit']),
+    onPolicyUpdate: PropTypes.func
+  }
+
+  state = {
+    dataLoading: true,
+    schema: null
+  }
+
+  componentDidMountComplete = null
+  componentDidMount() {
+    this.componentDidMountComplete = this.fetchComponentData()
+  }
+
+  async fetchComponentData() {
+    const schema = await (await KoreApi.client()).GetPlanSchema(this.props.policy.spec.kind)
+    this.setState({
+      schema,
+      dataLoading: false
+    })
+  }
+
+  componentDidUpdate(prevProps) {
+    // If we've changed kind, reload the plan schema.
+    if (this.props.policy.spec.kind !== prevProps.policy.spec.kind) {
+      this.fetchComponentData()
+    }
+  }
+
+  handleClick = (name, rule, newValue) => {
+    if (!this.props.onPolicyUpdate || this.props.mode === 'view') {
+      return
+    }
+    let newProperties = [...this.props.policy.spec.properties]
+    const ind = newProperties.findIndex((p) => p.name === name)
+    if (ind === -1) {
+      newProperties.push({
+        name: name,
+        [rule]: newValue
+      })
+    } else {
+      newProperties[ind] = {
+        ...newProperties[ind],
+        [rule]: newValue
+      }
+      // Remove rule if no longer used.
+      if (!newProperties[ind].disallowUpdate && !newProperties[ind].allowUpdate) {
+        newProperties.splice(ind, 1)
+      }
+    }
+    this.props.onPolicyUpdate({
+      ...this.props.policy,
+      spec: {
+        ...this.props.policy.spec,
+        properties: newProperties
+      }
+    })
+  }
+
+  propertyDisplayName = (name, description) => (
+    <>
+      <Text strong>{startCase(name)}</Text> {description ? <><br/><Text type="secondary">{description}</Text></> : null}
+    </>
+  )
+
+  propertyAllowUpdate = (name) => {
+    const policyProperty = this.props.policy.spec.properties.find((p) => p.name === name)
+    if (policyProperty && policyProperty.allowUpdate) {
+      return <Icon style={{ fontSize: '1.5em' }} type="check-circle" theme="twoTone" twoToneColor="#52c41a" onClick={() => this.handleClick(name, 'allowUpdate', false)}/>
+    } else {
+      return <Icon style={{ fontSize: '1.5em' }} type="question-circle" theme="twoTone" twoToneColor="lightgray" onClick={() => this.handleClick(name, 'allowUpdate', true)} />      
+    }
+  }
+
+  propertyDisallowUpdate = (name) => {
+    const policyProperty = this.props.policy.spec.properties.find((p) => p.name === name)
+    if (policyProperty && policyProperty.disallowUpdate) {
+      return <Icon style={{ fontSize: '1.5em' }} type="close-circle" theme="twoTone" twoToneColor="red" onClick={() => this.handleClick(name, 'disallowUpdate', false)} />
+    } else {
+      return <Icon style={{ fontSize: '1.5em' }} type="question-circle" theme="twoTone" twoToneColor="lightgray" onClick={() => this.handleClick(name, 'disallowUpdate', true)}/>      
+    }
+  }
+
+  propertyResult = (name) => {
+    const policyProperty = this.props.policy.spec.properties.find((p) => p.name === name)
+    const defaultAllow = false
+    if (policyProperty) {
+      if (policyProperty.disallowUpdate) {
+        return <Tooltip placement="left" title="Changes explicitly denied by this policy, this cannot be changed by another policy"><Icon style={{ fontSize: '1.5em' }} type="close-circle" theme="twoTone" twoToneColor="red" /></Tooltip>
+      }
+      if (policyProperty.allowUpdate) {
+        return <Tooltip placement="left" title="Changes explicitly allowed by this policy, but another policy could still disallow edits"><Icon style={{ fontSize: '1.5em' }} type="check-circle" theme="twoTone" twoToneColor="#52c41a" /></Tooltip>
+      }
+    }
+    if (defaultAllow) {
+      return <Tooltip placement="left" title="Changes will be allowed by default, but another policy could disallow edits"><Icon style={{ fontSize: '1.5em' }} type="check-circle" theme="twoTone" twoToneColor="silver" /></Tooltip>
+    }
+    return <Tooltip placement="left" title="Changes will be denied by default, but another policy could allow edits"><Icon style={{ fontSize: '1.5em' }} type="close-circle" theme="twoTone" twoToneColor="silver" /></Tooltip>
+  }
+
+  render() {
+    const { schema, dataLoading } = this.state
+
+    if (dataLoading) {
+      return null
+    }
+
+    const columns = [{
+      title: 'Property',
+      dataIndex: 'property',
+      key: 'property',
+    }, {
+      title: 'Allow Update',
+      dataIndex: 'allowUpdate',
+      key: 'allowUpdate',
+    }, {
+      title: 'Disallow Update',
+      dataIndex: 'disallowUpdate',
+      key: 'disallowUpdate',
+    }, {
+      title: 'Result',
+      dataIndex: 'result',
+      key: 'result',
+    }]
+
+    const planValues = Object.keys(schema.properties).map(name => {
+      return {
+        key: name,
+        property: this.propertyDisplayName(name, schema.properties[name].description),
+        allowUpdate: this.propertyAllowUpdate(name),
+        disallowUpdate: this.propertyDisallowUpdate(name),
+        result: this.propertyResult(name)
+      }
+    })
+
+    return (
+      <Table
+        size="small"
+        pagination={false}
+        columns={columns}
+        dataSource={planValues}
+      />
+    )
+  }
+}

--- a/ui/lib/components/policies/PolicyForm.js
+++ b/ui/lib/components/policies/PolicyForm.js
@@ -1,0 +1,199 @@
+import * as React from 'react'
+import { Card, Alert, Form, Input, Button } from 'antd'
+import PropTypes from 'prop-types'
+
+import KoreApi from '../../kore-api'
+import V1PlanPolicy from '../../kore-api/model/V1PlanPolicy'
+import V1PlanPolicySpec from '../../kore-api/model/V1PlanPolicySpec'
+import V1ObjectMeta from '../../kore-api/model/V1ObjectMeta'
+import FormErrorMessage from '../forms/FormErrorMessage'
+import canonical from '../../utils/canonical'
+import Policy from './Policy'
+import AllocationsFormItem from '../forms/AllocationsFormItem'
+import AllocationHelpers  from '../../utils/allocation-helpers'
+import config from '../../../config'
+
+class PolicyForm extends React.Component {
+  static propTypes = {
+    form: PropTypes.any.isRequired,
+    policy: PropTypes.object,
+    allocatedTeams: PropTypes.array,
+    kind: PropTypes.string.isRequired,
+    handleSubmit: PropTypes.func.isRequired
+  }
+
+  state = {
+    submitting: false,
+    policy: this.props.policy || {},
+    allocation: null,
+    allocatedTeams: this.props.allocatedTeams || ['*'],
+    formErrorMessage: false
+  }
+
+  componentDidMountComplete = null
+  componentDidMount() {
+    // To disabled submit button at the beginning.
+    this.props.form.validateFields()
+    this.componentDidMountComplete = Promise.resolve().then(async () => {
+      const existingAllocation = await AllocationHelpers.getAllocationForResource(this.props.policy)
+      this.setState({
+        allocatedTeams: existingAllocation ? existingAllocation.spec.teams : ['*']
+      })
+    })
+  }
+
+  onPolicyChange = (updatedPolicy) => {
+    this.setState({
+      policy: updatedPolicy
+    })
+  }
+
+  onAllocationChange = (updatedAllocation) => {
+    this.setState({
+      allocatedTeams: updatedAllocation
+    })
+  }
+
+  disableButton = fieldsError => {
+    if (this.state.submitting) {
+      return true
+    }
+    return Object.keys(fieldsError).some(field => fieldsError[field])
+  }
+
+  setFormSubmitting = (submitting = true, formErrorMessage = false) => {
+    this.setState({
+      submitting,
+      formErrorMessage
+    })
+  }
+
+  getMetadataName = values => {
+    const policy = this.props.policy
+    return (policy && policy.metadata && policy.metadata.name) || canonical(values.summary)
+  }
+
+  generatePolicyResource = (values) => {
+    const metadataName = this.getMetadataName(values)
+
+    const resource = new V1PlanPolicy()
+    resource.setApiVersion('config.kore.appvia.io/v1')
+    resource.setKind('PlanPolicy')
+
+    const meta = new V1ObjectMeta()
+    meta.setName(metadataName)
+    meta.setNamespace(config.kore.koreAdminTeamName)
+    resource.setMetadata(meta)
+
+    const spec = new V1PlanPolicySpec()
+    spec.setKind(this.props.kind)
+    spec.setDescription(values.description)
+    spec.setSummary(values.summary)
+    spec.setProperties(values.properties)
+    resource.setSpec(spec)
+
+    return resource
+  }
+
+  _process = async (err, values) => {
+    if (err) {
+      this.setFormSubmitting(false, 'Validation failed')
+      return
+    }
+    if (!this.state.allocatedTeams || this.state.allocatedTeams.length === 0) {
+      this.setFormSubmitting(false, 'You must allocate this policy to all teams or to one or more specific teams.')
+      return
+    }
+    try {
+      const api = await KoreApi.client()
+      const policy = this.generatePolicyResource({ ...values, properties: this.state.policy.spec.properties })
+      const result = await api.UpdatePlanPolicy(policy.getMetadata().getName(), policy)
+      result.allocation = await AllocationHelpers.storeAllocation({ resourceToAllocate: policy, teams: this.state.allocatedTeams })
+      return await this.props.handleSubmit(result)
+    } catch (err) {
+      console.log(err)
+      const message = (err.fieldErrors && err.message) ? err.message : 'An error occurred saving the plan, please try again'
+      this.setFormSubmitting(false, message)
+    }
+  }
+
+  handleSubmit = e => {
+    e.preventDefault()
+    this.setFormSubmitting()
+    this.props.form.validateFields(this._process)
+  }
+
+  // Only show error after a field is touched.
+  fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
+
+  render() {
+    const { form } = this.props
+    const { submitting, policy, formErrorMessage } = this.state
+    const { getFieldDecorator, getFieldsError } = form
+
+    const formConfig = {
+      layout: 'horizontal',
+      labelAlign: 'left',
+      labelCol: {
+        sm: { span: 24 },
+        md: { span: 8 }
+      },
+      wrapperCol: {
+        sm: { span: 24 },
+        md: { span: 16 }
+      },
+      hideRequiredMark: true
+    }
+
+    return (
+      <Form {...formConfig} onSubmit={this.handleSubmit}>
+
+        <FormErrorMessage message={formErrorMessage} />
+
+        <Card style={{ marginBottom: '20px' }}>
+          <Alert
+            message="Help Kore administrators understand this policy"
+            description="Give this policy a name and description to help admins understand it"
+            type="info"
+            style={{ marginBottom: '20px' }}
+          />
+          <Form.Item label="Name" validateStatus={this.fieldError('summary') ? 'error' : ''} help={this.fieldError('summary') || 'Name of the policy'}>
+            {getFieldDecorator('summary', {
+              rules: [{ required: true, message: 'Please enter the name!' }],
+              initialValue: policy && policy.spec.summary
+            })(
+              <Input placeholder="Name" />,
+            )}
+          </Form.Item>
+          <Form.Item label="Description" validateStatus={this.fieldError('description') ? 'error' : ''} help={this.fieldError('description') || 'Description of this policy to explain it to admins of Kore'}>
+            {getFieldDecorator('description', {
+              rules: [{ required: true, message: 'Please enter the description!' }],
+              initialValue: policy && policy.spec.description
+            })(
+              <Input placeholder="Description" />,
+            )}
+          </Form.Item>
+          <AllocationsFormItem allocatedTeams={this.state.allocatedTeams} onAllocationChange={this.onAllocationChange} />
+        </Card>
+
+        <Card style={{ marginBottom: '20px' }}>
+          <Alert
+            message="Set policy rules"
+            description="By default, all plan values are read-only for teams. By selecting Allow Update, teams that have this policy applied will be able to make changes to that property when creating or editing clusters. By selecting Disallow Update, teams that have this policy applied will NEVER be able to edit that property, even if another policy would allow it to be edited."
+            type="info"
+            style={{ marginBottom: '20px' }}
+          />
+          <Policy policy={policy} mode="edit" onPolicyUpdate={this.onPolicyChange} />
+        </Card>
+
+        <Form.Item>
+          <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
+        </Form.Item>
+      </Form>
+    )
+  }
+}
+
+const WrappedPolicyForm = Form.create({ name: 'policy' })(PolicyForm)
+
+export default WrappedPolicyForm

--- a/ui/lib/components/policies/PolicyList.js
+++ b/ui/lib/components/policies/PolicyList.js
@@ -1,0 +1,156 @@
+import PropTypes from 'prop-types'
+import moment from 'moment'
+import { message, Avatar, List, Alert, Icon, Drawer, Typography, Button, Tooltip, Modal } from 'antd'
+const { Title, Text, Paragraph } = Typography
+
+import ResourceList from '../configure/ResourceList'
+import KoreApi from '../../kore-api'
+import Policy from './Policy'
+import PolicyForm from './PolicyForm'
+import AllocationHelpers from '../../utils/allocation-helpers'
+import config from '../../../config'
+
+class PolicyList extends ResourceList {
+  static propTypes = {
+    kind: PropTypes.string,
+    style: PropTypes.object
+  }
+
+  async fetchComponentData() {
+    const api = await KoreApi.client()
+    const [ policyList, allAllocations ] = await Promise.all([
+      api.ListPlanPolicies(this.props.kind),
+      api.ListAllocations(config.kore.koreAdminTeamName)
+    ])
+    policyList.items.forEach((p) => {
+      p.allocation = AllocationHelpers.findAllocationForResource(allAllocations, p)
+    })
+    return { resources: policyList }
+  }
+
+  delete = (policy) => () => {
+    Modal.confirm({
+      title: `Are you sure you want to delete the policy ${policy.spec.description}?`,
+      content: 'This cannot be undone',
+      okText: 'Yes',
+      okType: 'danger',
+      cancelText: 'No',
+      onOk: async () => {
+        await AllocationHelpers.removeAllocation(policy)
+        await (await KoreApi.client()).RemovePlanPolicy(policy.metadata.name)
+        message.success(`Policy ${policy.spec.description} deleted`)
+        await this.refresh()
+      }
+    })
+  }
+
+  updatedMessage = 'Policy saved successfully'
+  createdMessage = 'Policy created successfully'
+
+  describeAllocation = (allocation) => {
+    if (!allocation) {
+      return <><span style={{ fontWeight: 'bold' }}>No teams allocated</span> <Tooltip title="This policy is not allocated to any teams, edit the policy to fix this."><Icon type="warning" theme="twoTone" twoToneColor="orange" /></Tooltip></>
+    }
+    if (AllocationHelpers.isAllTeams(allocation)) {
+      return <>This policy applies to <span style={{ fontWeight: 'bold' }}>all teams</span></>
+    }
+    return <>This policy applies to: <span style={{ fontWeight: 'bold' }}>{allocation.spec.teams.join(', ')}</span></>
+  }
+
+  policyItem = (policy) => {
+    const created = moment(policy.metadata.creationTimestamp).fromNow()
+    const readonly = policy.metadata.labels && policy.metadata.labels['kore.appvia.io/readonly']
+    return (
+      <List.Item key={policy.metadata.name} actions={[
+        <Text key="view_policy"><a onClick={this.view(policy)}><Icon type="eye" theme="filled"/> View</a></Text>,
+        <Text key="edit_policy">
+          <Tooltip title={readonly ? 'Read-only' : 'Edit this policy'}>
+            <a onClick={readonly ? () => {} : this.edit(policy)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
+          </Tooltip>
+        </Text>,
+        <Text key="delete_policy">
+          <Tooltip title={readonly ? 'Read-only' : 'Delete this policy'}>
+            <a onClick={readonly ? () => {} : this.delete(policy)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
+          </Tooltip>
+        </Text>
+      ]}>
+        <List.Item.Meta
+          avatar={<Avatar icon="lock" />}
+          title={policy.spec.summary}
+          description={(<Text>{policy.spec.description}. {this.describeAllocation(policy.allocation)}</Text>)}
+        />
+        <Text type='secondary'>Created {created}</Text>
+      </List.Item>
+    )
+  }
+
+  render() {
+    const { resources, view, edit, add } = this.state
+
+    return (
+      <>
+        <Alert
+          message="Manage plan policies"
+          description="These policies define what aspects of a plan can be edited by teams when they are creating or updating clusters. This allows you to control what aspects of clusters teams can manage for themselves."
+          type="info"
+          showIcon
+          style={{ marginBottom: '20px' }}
+        />
+        <Button type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
+        {!resources ? <Icon type="loading" /> : (
+          <>
+            <List
+              dataSource={resources.items}
+              renderItem={policy => this.policyItem(policy)}
+            >
+            </List>
+
+            {view ? (
+              <Drawer
+                title={<><Title level={4}>{view.spec.summary}</Title><Text>{view.spec.description}</Text></>}
+                visible={Boolean(view)}
+                onClose={this.view(false)}
+                width={900}
+              >
+                <Paragraph style={{ textAlign: 'center' }}>{this.describeAllocation(view.allocation)}</Paragraph>
+                <Policy policy={view} mode="view" />
+              </Drawer>
+            ) : null}
+
+            {edit ? (
+              <Drawer
+                title={<><Title level={4}>{edit.spec.summary}</Title><Text>{edit.spec.description}</Text></>}
+                visible={Boolean(edit)}
+                onClose={this.edit(false)}
+                width={900}
+              >
+                <PolicyForm
+                  kind={this.props.kind}
+                  policy={edit}
+                  handleSubmit={this.handleEditSave}
+                />
+              </Drawer>
+            ) : null}
+
+            {add ? (
+              <Drawer
+                title={<Title level={4}>New {this.props.kind} policy</Title>}
+                visible={add}
+                onClose={this.add(false)}
+                width={900}
+              >
+                <PolicyForm
+                  kind={this.props.kind}
+                  policy={{ spec: { kind: this.props.kind, properties: [] } }}
+                  handleSubmit={this.handleAddSave}
+                />
+              </Drawer>
+            ) : null}            
+          </>
+        )}
+      </>
+    )
+  }
+}
+
+export default PolicyList

--- a/ui/lib/components/team/GKECredentials.js
+++ b/ui/lib/components/team/GKECredentials.js
@@ -54,10 +54,16 @@ class GKECredentials extends AutoRefreshComponent {
           title={
             <>
               <Text style={{ display: 'inline', marginRight: '15px', fontSize: '20px', fontWeight: '600' }}>{gkeCredentials.spec.project}</Text>
-              <Text style={{ marginRight: '5px' }}>{gkeCredentials.allocation.spec.name}</Text>
-              <Tooltip title={gkeCredentials.allocation.spec.summary}>
-                <Icon type="info-circle" theme="twoTone" />
-              </Tooltip>
+              {gkeCredentials.allocation ? (
+                <>
+                  <Text style={{ marginRight: '5px' }}>{gkeCredentials.allocation.spec.name}</Text>
+                  <Tooltip title={gkeCredentials.allocation.spec.summary}>
+                    <Icon type="info-circle" theme="twoTone" />
+                  </Tooltip>
+                </>
+              ) : (
+                <Text style={{ marginRight: '5px' }}>Not allocated</Text>
+              )}
             </>
           }
           description={

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -83,6 +83,12 @@ class KoreApiClient {
 
   // Audit
   ListAuditEvents = () => this.apis.default.ListAuditEvents()
+  
+  // Policies 
+  ListPlanPolicies = (kind) => this.apis.default.ListPlanPolicies({ kind })
+  GetPlanPolicy = (name) => this.apis.default.GetPlanPolicy({ name })
+  UpdatePlanPolicy = (name, plan) => this.apis.default.UpdatePlanPolicy({ name, body: JSON.stringify(plan) })
+  RemovePlanPolicy = (name) => this.apis.default.RemovePlanPolicy({ name })
 
   // Teams
   GetTeam = (team) => this.apis.default.GetTeam({ team })
@@ -104,6 +110,7 @@ class KoreApiClient {
   ListAllocations = (team, assigned = undefined) => this.apis.default.ListAllocations({ team, assigned })
   GetAllocation = (team, name) => this.apis.default.GetAllocation({ team, name })
   UpdateAllocation = (team, name, resource) => this.apis.default.UpdateAllocation({ team, name, body: JSON.stringify(resource) })
+  RemoveAllocation = (team, name) => this.apis.default.RemoveAllocation({ team, name })
   ListClusters = (team) => this.apis.default.ListClusters({ team })
   UpdateCluster = (team, name, cluster) => this.apis.default.UpdateCluster({ team, name, body: JSON.stringify(cluster) })
   GetCluster = (team, name) => this.apis.default.GetCluster({ team, name })

--- a/ui/lib/utils/allocation-helpers.js
+++ b/ui/lib/utils/allocation-helpers.js
@@ -1,0 +1,81 @@
+import KoreApi from '../kore-api'
+import V1Allocation from '../kore-api/model/V1Allocation'
+import V1AllocationSpec from '../kore-api/model/V1AllocationSpec'
+import V1ObjectMeta from '../kore-api/model/V1ObjectMeta'
+import V1Ownership from '../kore-api/model/V1Ownership'
+import config from '../../config' 
+
+export default class AllocationHelpers {
+  static getAllocationNameForResource = (resource) => {
+    // @TODO: Include kind in allocation name so they're predictabley-named but don't clash
+    return resource.metadata.name
+  }
+
+  static generateAllocation = ({ resourceToAllocate, teams, name, summary }) => {
+    if (!resourceToAllocate) {
+      throw 'Must specify resourceToAllocate'
+    }
+    const resource = new V1Allocation()
+    resource.setApiVersion('config.kore.appvia.io/v1')
+    resource.setKind('Allocation')
+
+    const meta = new V1ObjectMeta()
+    meta.setName(AllocationHelpers.getAllocationNameForResource(resourceToAllocate))
+    meta.setNamespace(config.kore.koreAdminTeamName)
+    resource.setMetadata(meta)
+
+    const spec = new V1AllocationSpec()
+    spec.setName(name ? name : resourceToAllocate.metadata.name)
+    spec.setSummary(summary ? summary : `Allocation of ${resourceToAllocate.metadata.name}`)
+    spec.setTeams(teams && teams.length > 0 ? teams : ['*'])
+
+    const resGroupVersion = resourceToAllocate.apiVersion.split('/')
+    const owner = new V1Ownership()
+    owner.setGroup(resGroupVersion[0])
+    owner.setVersion(resGroupVersion[1])
+    owner.setKind(resourceToAllocate.kind)
+    owner.setName(resourceToAllocate.metadata.name)
+    owner.setNamespace(resourceToAllocate.metadata.namespace)
+    spec.setResource(owner)
+
+    resource.setSpec(spec)
+    return resource
+  }
+
+  static getAllocationForResource = async (resource) => {
+    if (!resource || !resource.metadata || !resource.metadata.name) {
+      return null
+    }
+    return await (await KoreApi.client()).GetAllocation(config.kore.koreAdminTeamName, AllocationHelpers.getAllocationNameForResource(resource))
+  }
+
+  /**
+   * From a list of allocations (typically returned from api.ListAllocations), this will return the first allocation 
+   * which has a resource kind, group, version, name and namespace matching those of the passed-in resource.
+   */
+  static findAllocationForResource = (allocationList, resource) => {
+    if (!resource) {
+      return null
+    }
+    const resGroupVersion = resource.apiVersion.split('/')
+    return allocationList.items.find((a) => 
+      a.spec.resource.kind === resource.kind && 
+      a.spec.resource.group === resGroupVersion[0] && 
+      a.spec.resource.version === resGroupVersion[1] && 
+      a.spec.resource.name === resource.metadata.name && 
+      a.spec.resource.namespace === resource.metadata.namespace)
+  }
+
+  static isAllTeams = (allocation) => {
+    return allocation && allocation.spec && allocation.spec.teams && allocation.spec.teams.find((t) => t === '*')
+  }
+
+  static storeAllocation = async ({ resourceToAllocate, teams, name, summary }) => {
+    const allocation = AllocationHelpers.generateAllocation({ resourceToAllocate, teams, name, summary })
+    return await (await KoreApi.client()).UpdateAllocation(config.kore.koreAdminTeamName, allocation.metadata.name, allocation)
+  }
+
+  static removeAllocation = async (resourceToDeallocate) => {
+    return await (await KoreApi.client()).RemoveAllocation(config.kore.koreAdminTeamName, AllocationHelpers.getAllocationNameForResource(resourceToDeallocate))
+  }
+}

--- a/ui/pages/_app.js
+++ b/ui/pages/_app.js
@@ -201,7 +201,7 @@ class MyApp extends App {
             <SiderMenu hide={hideSider} isAdmin={isAdmin} userTeams={this.state.userTeams} otherTeams={props.otherTeams}/>
             <Content style={{ background: '#fff', padding: 24, minHeight: 280 }}>
               <Component {...this.props.pageProps} user={this.props.user} teamAdded={this.teamAdded} teamRemoved={this.teamRemoved} version={version} />
-              <Paragraph style={{ textAlign: 'right', fontSize: '0.8em', padding: 0, margin: 0 }}>Appvia Kore {version}</Paragraph>
+              <Paragraph style={{ textAlign: 'center', fontSize: '0.8em', padding: '5px 0 0 0', margin: '15px 0 0 0', borderTop: '1px solid #efefef', color: 'darkgray' }}>Appvia Kore {version}</Paragraph>
             </Content>
           </Layout>
         </Layout>

--- a/ui/pages/configure/cloud.js
+++ b/ui/pages/configure/cloud.js
@@ -7,6 +7,7 @@ import GKECredentialsList from '../../lib/components/configure/GKECredentialsLis
 import GCPOrganizationsList from '../../lib/components/configure/GCPOrganizationsList'
 import EKSCredentialsList from '../../lib/components/configure/EKSCredentialsList'
 import PlanList from '../../lib/components/configure/PlanList'
+import PolicyList from '../../lib/components/policies/PolicyList'
 import CloudTabs from '../../lib/components/configure/CloudTabs'
 
 class ConfigureCloudPage extends React.Component {
@@ -45,6 +46,9 @@ class ConfigureCloudPage extends React.Component {
             <Tabs.TabPane tab="Plans" key="plans">
               <PlanList kind="GKE" />
             </Tabs.TabPane>
+            <Tabs.TabPane tab="Policies" key="policies">
+              <PolicyList kind="GKE" />
+            </Tabs.TabPane>
           </Tabs>
         ) : null}
         {selectedCloud === 'AWS' ? (
@@ -54,6 +58,9 @@ class ConfigureCloudPage extends React.Component {
             </Tabs.TabPane>
             <Tabs.TabPane tab="Plans" key="plans">
               <PlanList kind="EKS" />
+            </Tabs.TabPane>
+            <Tabs.TabPane tab="Policies" key="policies">
+              <PolicyList kind="EKS" />
             </Tabs.TabPane>
           </Tabs>
         ) : null}


### PR DESCRIPTION
This PR introduces to the UI the ability to view, create, edit and delete plan policies through the UI, including allocating them to teams.

It is part of the work required for #536.

Additional changes in this PR:
- Allocations have been rationalised into a new, unit tested helper class to avoid repeating this logic in multiple places. This simplifies the allocation logic in a number of other parts of the UI (the various credentials forms) and will help when we include allocating plans, currently not possible through the UI.
- Minor tweak to the version number display (addresses #686).

### Policy list:
![image](https://user-images.githubusercontent.com/7505593/80252635-893a1b80-866f-11ea-87f6-6f1f9c50da78.png)

### Policy adding/editing interface:
![image](https://user-images.githubusercontent.com/7505593/80252709-b8e92380-866f-11ea-970f-1af46dee9974.png)
