### PR TITLE
Adding prototypes for team settings and setup wizard

### DIFF
--- a/ui/config.js
+++ b/ui/config.js
@@ -45,5 +45,6 @@ module.exports = {
     url: process.env.KORE_API_URL || 'http://localhost:10080/api/v1alpha1',
     publicUrl: process.env.KORE_API_PUBLIC_URL || 'http://localhost:10080',
     token: process.env.KORE_API_TOKEN || 'password'
-  }
+  },
+  showPrototypes: process.env.NODE_ENV === 'development' || process.env.KORE_UI_SHOW_PROTOTYPES === 'true'
 }

--- a/ui/pages/_app.js
+++ b/ui/pages/_app.js
@@ -4,7 +4,7 @@ import Head from 'next/head'
 import Router from 'next/router'
 import Link from 'next/link'
 import axios from 'axios'
-import { Layout } from 'antd'
+import { Layout, Tag } from 'antd'
 const { Header, Content } = Layout
 
 import User from '../lib/components/User'
@@ -12,7 +12,7 @@ import SiderMenu from '../lib/components/SiderMenu'
 import redirect from '../lib/utils/redirect'
 import KoreApi from '../lib/kore-api'
 import copy from '../lib/utils/object-copy'
-import { kore, server } from '../config'
+import { kore, server, showPrototypes } from '../config'
 import OrgService from '../server/services/org'
 import userExpired from '../server/lib/user-expired'
 import gtag from '../lib/utils/gtag'
@@ -110,13 +110,22 @@ class MyApp extends App {
 
   componentDidMount() {
     this.setSessionTimeout()
+    if (showPrototypes) {
+      this.setState({ prototypePath: window.location.pathname.indexOf('/prototype') === 0 })
+    }
     axios.get(`${window.location.origin}/version`).then((v) => {
       this.setState({ version: v.data.version })
     })
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
     this.setSessionTimeout()
+    if (showPrototypes) {
+      const prototypePath = window.location.pathname.indexOf('/prototype') === 0
+      if (prevState.prototypePath !== prototypePath) {
+        this.setState({ prototypePath })
+      }
+    }
   }
 
   componentWillUnmount() {
@@ -142,7 +151,7 @@ class MyApp extends App {
     const isAdmin = Boolean(props.user && props.user.isAdmin)
     const hideSider = Boolean(props.hideSider || props.unrestrictedPage)
     const hidePage = Boolean(!props.unrestrictedPage && !props.user)
-    const { version } = this.state
+    const { version, prototypePath } = this.state
 
     if (hidePage) {
       return null
@@ -184,6 +193,7 @@ class MyApp extends App {
                   <a style={{ color: '#FFFFFF' }}>Appvia Kore</a>
                 </Link>
               </div>
+              {showPrototypes && prototypePath ? <Link href="/prototype"><Tag style={{ marginLeft: '20px' }}>PROTOTYPE</Tag></Link> : null}
             </div>
             <User user={props.user}/>
           </Header>

--- a/ui/pages/prototype/configure/settings.js
+++ b/ui/pages/prototype/configure/settings.js
@@ -1,0 +1,147 @@
+import React from 'react'
+import { Alert, Tabs, Card, Typography, Tooltip, Icon, Tag, Row, Col, Button, Checkbox } from 'antd'
+const { Title, Text } = Typography
+import Breadcrumb from '../../../lib/components/Breadcrumb'
+
+class SettingsPage extends React.Component {
+
+  render() {
+    const targets = [
+      {
+        id: 'notprod',
+        title: 'Not production',
+        description: 'Target covering all but the production environment',
+        plans: {
+          GKE: [{
+            spec: {
+              description: 'GKE Development Cluster',
+              summary: 'Provides a development cluster within GKE',
+            }
+          }, {
+            spec: {
+              description: 'GKE Development Cluster High-CPU',
+              summary: 'Provides a development cluster within GKE, with high-CPU nodes for intensive operations',
+            }
+          }],
+          EKS: [{
+            spec: {
+              description: 'EKS Development Cluster',
+              summary: 'Provides a development cluster within EKS',
+            }
+          }],
+          AKS: []
+        }
+      },
+      {
+        id: 'prod',
+        title: 'Production',
+        description: 'Target covering the production environment',
+        plans: {
+          GKE: [{
+            spec: {
+              description: 'GKE Production Cluster',
+              summary: 'Provides a production cluster within GKE',
+            }
+          }],
+          EKS: [{
+            spec: {
+              description: 'EKS Production Cluster',
+              summary: 'Provides a production cluster within EKS',
+            }
+          }],
+          AKS: []
+        }
+      }
+    ]
+
+    const IconTooltip = ({ icon, text }) => (
+      <Tooltip title={text}>
+        <Icon type={icon} theme="twoTone" />
+      </Tooltip>
+    )
+
+    const IconTooltipButton = ({ icon, text, onClick }) => (
+      <Tooltip title={text}>
+        <a style={{ marginLeft: '5px' }} onClick={onClick}><Icon type={icon} theme="twoTone" /></a>
+      </Tooltip>
+    )
+
+    const CloudPlans = ({ imageFilename, cloudName, plans }) => (
+      <Col span={8}>
+        <Card
+          title={
+            <span>
+              <img src={`/static/images/${imageFilename}`} height="20px" style={{ marginRight: '10px' }}/>
+              {cloudName}
+            </span>
+          }
+          size="small"
+          bordered={false}
+        >
+          {plans.length === 0 ? <div style={{ padding: '5px 0' }}>No plans</div> : null}
+          {plans.map((plan, i) => (
+            <div key={i} style={{ padding: '5px 0' }}>
+              <Text style={{ marginRight: '10px' }}>{plan.spec.description}</Text>
+              <IconTooltip icon="info-circle" text={plan.spec.summary} />
+              <IconTooltipButton icon="eye" text="View plan" onClick={() => {}} />
+            </div>
+          ))}
+          <div style={{ padding: '5px 0' }}>
+            <a>+ Associate plan</a>
+          </div>
+        </Card>
+      </Col>
+    )
+
+    return (
+      <>
+        <Breadcrumb items={[{ text: 'Configure' }, { text: 'Settings' }]} />
+        <Alert
+          message="View and configure the settings for Kore"
+          type="info"
+          style={{ marginBottom: '20px' }}
+        />
+
+        <Tabs defaultActiveKey={'teams'} tabPosition="left">
+          <Tabs.TabPane tab="Teams" key="teams">
+            <Card
+              title="Targets"
+              extra={<Button type="primary">+ New</Button>}
+            >
+              <Alert
+                message="This setting controls which targets teams are able to create. When a team sets up a target it will create a project within the chosen cloud provider."
+                type="info"
+                style={{ marginBottom: '20px' }}
+              />
+
+              <Checkbox checked={true} disabled={true}>
+                <Text strong style={{ marginRight: '10px' }}>Allow teams to use project level credentials</Text>
+                <IconTooltip icon="info-circle" text="Upon creation of a target, this will enable the team to choose a project that is already created within the cloud provider, rather than creating a new one. Note, it must be configured by an admin and allocated to teams to be available." />
+              </Checkbox>
+
+              {targets.map(target => (
+                <Card style={{ marginTop: '20px' }} key={target.id}>
+                  <Title level={4} style={{ display: 'inline', marginRight: '10px' }}>{target.title}</Title>
+                  <IconTooltip icon="info-circle" text={target.description} />
+                  <Tag style={{ marginLeft: '15px' }}>{target.id}</Tag>
+                  <Text strong style={{ fontSize: '16px', display: 'block', marginBottom: '5px', marginTop: '10px' }}>Cluster plans</Text>
+                  <Row gutter={16}>
+                    <CloudPlans imageFilename="GCP.png" cloudName="Google Cloud Platform" plans={target.plans.GKE} />
+                    <CloudPlans imageFilename="AWS.png" cloudName="Amazon Web Services" plans={target.plans.EKS} />
+                    <CloudPlans imageFilename="Azure.svg" cloudName="Microsoft Azure" plans={target.plans.AKS} />
+                  </Row>
+                </Card>
+              ))}
+
+            </Card>
+          </Tabs.TabPane>
+          <Tabs.TabPane tab="Setting 2" key="2" />
+          <Tabs.TabPane tab="Setting 3" key="3" />
+        </Tabs>
+      </>
+    )
+  }
+
+}
+
+export default SettingsPage

--- a/ui/pages/prototype/index.js
+++ b/ui/pages/prototype/index.js
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import { Typography, List, Button } from 'antd'
+const { Title, Text } = Typography
+
+const prototypeList = [{
+  title: 'Team settings',
+  description: 'Configure teams settings, such as targets available for teams',
+  path: '/prototype/configure/settings'
+}, {
+  title: 'Setup wizard',
+  description: 'Setup Kore cloud access and team project settings for GCP',
+  path: '/prototype/setup/kore'
+}]
+
+const PrototypeIndex = () => (
+  <>
+    <Title>Prototypes</Title>
+    <List
+      dataSource={prototypeList}
+      renderItem={item => (
+        <List.Item actions={[<Link key="view" href={item.path}><Button type="primary">View</Button></Link>]}>
+          <List.Item.Meta
+            title={<Text style={{ fontSize: '20px', fontWeight: '600' }}>{item.title}</Text>}
+            description={item.description}
+          />
+        </List.Item>
+      )}
+    />
+  </>
+)
+
+PrototypeIndex.staticProps = {
+  title: 'Kore prototypes',
+  hideSider: true
+}
+
+export default PrototypeIndex

--- a/ui/pages/prototype/setup/kore/cloud-access.js
+++ b/ui/pages/prototype/setup/kore/cloud-access.js
@@ -1,0 +1,619 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import { Typography, Card, Alert, Divider, Radio, List, Icon, Tooltip, Steps, Button, Row, Col, Modal , Drawer, Form, Input, Popover, Result } from 'antd'
+const { Title, Text, Paragraph } = Typography
+const { Step } = Steps
+
+import copy from '../../../../lib/utils/object-copy'
+import canonical from '../../../../lib/utils/canonical'
+import KoreApi from '../../../../lib/kore-api'
+import GCPOrganizationsList from '../../../../lib/components/configure/GCPOrganizationsList'
+import GKECredentialsList from '../../../../lib/components/configure/GKECredentialsList'
+import PlanList from '../../../../lib/components/configure/PlanList'
+import PlanViewer from '../../../../lib/components/configure/PlanViewer'
+import CloudSelector from '../../../../lib/components/cluster-build/CloudSelector'
+import FormErrorMessage from '../../../../lib/components/forms/FormErrorMessage'
+
+class ProjectForm extends React.Component {
+  static propTypes = {
+    form: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    handleCancel: PropTypes.func.isRequired,
+  }
+
+  state = {
+    submitting: false,
+    formErrorMessage: false
+  }
+
+  handleSubmit = (e) => {
+    e.preventDefault()
+    this.setState({ submitting: true })
+    this.props.form.validateFields((err, values) => {
+      if (err) {
+        this.setState({ submitting: false, formErrorMessage: 'Validation failed' })
+        return
+      }
+      this.props.handleSubmit(values)
+    })
+  }
+
+  fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
+
+  render() {
+    const { getFieldDecorator } = this.props.form
+    const formConfig = {
+      layout: 'horizontal',
+      labelAlign: 'left',
+      hideRequiredMark: true,
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    }
+    return (
+      <>
+        <FormErrorMessage message={this.state.formErrorMessage} />
+        <Form { ...formConfig } onSubmit={this.handleSubmit}>
+          <Form.Item label="Title" help={this.fieldError('title') || ''}>
+            {getFieldDecorator('title', { rules: [{ required: true, message: 'Please enter the title!' }] })(
+              <Input placeholder="Title" />
+            )}
+          </Form.Item>
+          <Form.Item label="Description" help={this.fieldError('description') || ''}>
+            {getFieldDecorator('description', { rules: [{ required: true, message: 'Please enter the description!' }] })(
+              <Input placeholder="Description" />
+            )}
+          </Form.Item>
+          <Form.Item label="Prefix" help={this.fieldError('prefix') || 'The project ID prefix'}>
+            {getFieldDecorator('prefix', { initialValue: 'kore' })(
+              <Input placeholder="Prefix" />
+            )}
+          </Form.Item>
+          <Form.Item label="Suffix" help={this.fieldError('suffix') || 'The project ID suffix'}>
+            {getFieldDecorator('suffix', { rules: [{ required: true, message: 'Please enter the suffix!' }] })(
+              <Input placeholder="Suffix" />
+            )}
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={this.state.submitting}>Save</Button>
+            <Button type="link" onClick={this.props.handleCancel}>Cancel</Button>
+          </Form.Item>
+        </Form>
+      </>
+    )
+  }
+}
+const WrappedProjectForm = Form.create({ name: 'project_form' })(ProjectForm)
+
+class CloudAccessPage extends React.Component {
+
+  static staticProps = {
+    title: 'Setup cloud access',
+    hideSider: true,
+    adminOnly: true
+  }
+
+  static initialProjectList = [{
+    code: 'not-production',
+    title: 'Not production',
+    description: 'To be used for all environments except production',
+    prefix: 'kore',
+    suffix: 'not-prod',
+    plans: ['gke-development']
+  }, {
+    code: 'production',
+    title: 'Production',
+    description: 'Project just for the production environment',
+    prefix: 'kore',
+    suffix: 'prod',
+    plans: ['gke-production']
+  }]
+
+  stepsKoreManaged = [
+    { id: 'CREDS', title: 'Credentials' },
+    { id: 'PLANS', title: 'Review plans' },
+    { id: 'PROJECTS', title: 'Project automation' }
+  ]
+
+  stepsExisting = [
+    { id: 'CREDS', title: 'Credentials' },
+    { id: 'PLANS', title: 'Review plans' },
+    { id: 'ACCESS', title: 'Project access' }
+  ]
+
+  state = {
+    selectedCloud: '',
+    gcpManagementType: '',
+    gcpProjectAutomationType: '',
+    gcpProjectList: CloudAccessPage.initialProjectList,
+    currentStepKoreManaged: 0,
+    currentStepExisting: 0,
+    stepsKoreManagedComplete: false,
+    stepsExistingComplete: false,
+    addProject: false,
+    associatePlanVisible: false
+  }
+
+  nextStepKoreManaged() {
+    const currentStepKoreManaged = this.state.currentStepKoreManaged + 1
+    this.setState({ currentStepKoreManaged })
+  }
+
+  prevStepKoreManaged() {
+    const currentStepKoreManaged = this.state.currentStepKoreManaged - 1
+    this.setState({ currentStepKoreManaged })
+  }
+
+  nextStepExisting() {
+    const currentStepExisting = this.state.currentStepExisting + 1
+    this.setState({ currentStepExisting })
+  }
+
+  prevStepExisting() {
+    const currentStepExisting = this.state.currentStepExisting - 1
+    this.setState({ currentStepExisting })
+  }
+
+  stepsKoreManagedComplete = () => this.setState({ stepsKoreManagedComplete: true })
+  stepsExistingComplete = () => this.setState({ stepsExistingComplete: true })
+
+  async fetchComponentData() {
+    const api = await KoreApi.client()
+    const planList = await api.ListPlans()
+    return planList.items
+  }
+
+  componentDidMount() {
+    this.fetchComponentData().then(plans => {
+      this.setState({ plans })
+    })
+  }
+
+  handleSelectCloud = cloud => {
+    if (this.state.selectedCloud !== cloud) {
+      const state = copy(this.state)
+      state.selectedCloud = cloud
+      this.setState(state)
+    }
+  }
+
+  selectGcpManagementType = e => this.setState({ gcpManagementType: e.target.value })
+  selectGcpProjectAutomationType = e => this.setState({ gcpProjectAutomationType: e.target.value })
+
+  deleteGcpProject = (code) => {
+    return () => this.setState({
+      gcpProjectList: this.state.gcpProjectList.filter(p => p.code !== code)
+    })
+  }
+
+  onChange = (code, property) => {
+    return (value) => {
+      const gcpProjectList = copy(this.state.gcpProjectList)
+      gcpProjectList.find(p => p.code === code)[property] = value
+      this.setState({
+        gcpProjectList
+      })
+    }
+  }
+
+  showPlanDetails = (plan) => {
+    return () => {
+      Modal.info({
+        title: (<><Title level={4}>{plan.spec.description}</Title><Text>{plan.spec.summary}</Text></>),
+        content: <PlanViewer plan={plan} />,
+        width: 700,
+        onOk() {}
+      })
+    }
+  }
+
+  handleAssociatePlanVisibleChange = (projectCode) => () => this.setState({ associatePlanVisible: projectCode })
+
+  associatePlan = (projectCode, plan) => {
+    return () => {
+      const gcpProjectList = copy(this.state.gcpProjectList)
+      gcpProjectList.find(p => p.code === projectCode).plans.push(plan)
+      this.setState({ gcpProjectList })
+    }
+  }
+
+  closeAssociatePlans = () => this.setState({ associatePlanVisible: false })
+
+  associatePlanContent = (projectCode) => {
+    const project = this.state.gcpProjectList.find(p => p.code === projectCode)
+    const cloudPlans = this.state.plans.filter(p => p.spec.kind === this.state.selectedCloud)
+    const unassociatedPlans = cloudPlans.filter(p => !project.plans.includes(p.metadata.name))
+    if (unassociatedPlans.length === 0) {
+      return (
+        <>
+          <Alert style={{ marginBottom: '20px' }} message="All existing plans are already associated with this project type." />
+          <Button type="primary" onClick={this.closeAssociatePlans}>Close</Button>
+        </>
+      )
+    }
+    return (
+      <>
+        <Alert style={{ marginBottom: '20px' }} message="Plans available to be associated with this project type." />
+        <List
+          dataSource={unassociatedPlans}
+          renderItem={plan => <Paragraph>{plan.spec.description} <a style={{ textDecoration: 'underline' }} onClick={this.associatePlan(project.code, plan.metadata.name)}>Associate</a></Paragraph>}
+        />
+        <Button style={{ marginTop: '10px' }} type="primary" onClick={this.closeAssociatePlans}>Close</Button>
+      </>
+    )
+  }
+
+  unassociatePlan = (projectCode, plan) => {
+    return () => {
+      const gcpProjectList = copy(this.state.gcpProjectList)
+      const project = gcpProjectList.find(p => p.code === projectCode)
+      project.plans = project.plans.filter(p => p !== plan)
+      this.setState({ gcpProjectList })
+    }
+  }
+
+  addProject = (enabled) => () => this.setState({ addProject: enabled })
+
+  handleProjectAdded = (project) => {
+    const code = canonical(project.title)
+    this.setState({
+      gcpProjectList: this.state.gcpProjectList.concat([{ code, plans: [], ...project }]),
+      addProject: false
+    })
+  }
+
+  IconTooltip = ({ icon, text }) => (
+    <Tooltip title={text}>
+      <Icon type={icon} theme="twoTone" />
+    </Tooltip>
+  )
+
+  IconTooltipButton = ({ icon, text, onClick }) => (
+    <Tooltip title={text}>
+      <a style={{ marginLeft: '5px' }} onClick={onClick}><Icon type={icon} theme="twoTone" /></a>
+    </Tooltip>
+  )
+
+  render() {
+    const {
+      selectedCloud,
+      gcpManagementType,
+      gcpProjectAutomationType,
+      gcpProjectList,
+      plans,
+      currentStepKoreManaged,
+      currentStepExisting,
+      stepsKoreManagedComplete,
+      stepsExistingComplete,
+      addProject,
+      associatePlanVisible
+    } = this.state
+
+    return (
+      <div>
+        <Title>Setup cloud access</Title>
+        <Alert
+          message="Setup cloud access"
+          description="Choose a cloud provider below to configure how Kore uses your cloud accounts."
+          type="info"
+          showIcon
+          style={{ marginBottom: '20px' }}
+        />
+        <div style={{ marginTop: '20px', marginBottom: '20px' }}>
+          <CloudSelector selectedCloud={selectedCloud} handleSelectCloud={this.handleSelectCloud} />
+        </div>
+        { selectedCloud === 'GKE' ? (
+          <Card>
+
+            <div style={{ marginBottom: '15px' }}>
+              <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>How do you want Kore to integrate with GCP projects?</Paragraph>
+              <Radio.Group onChange={this.selectGcpManagementType} value={gcpManagementType} disabled={stepsKoreManagedComplete || stepsExistingComplete}>
+                <Radio value={'KORE'} style={{ marginRight: '20px' }}>
+                  <Text style={{ fontSize: '16px', fontWeight: '600' }}>Kore managed <Text type="secondary">(recommended)</Text></Text>
+                  <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will manage the lifecycle of GCP projects along with Kore teams</Paragraph>
+                </Radio>
+                <Radio value={'EXTERNAL'}>
+                  <Text style={{ fontSize: '16px', fontWeight: '600' }}>Use existing</Text>
+                  <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will use existing GCP projects that it&apos;s given access to</Paragraph>
+                </Radio>
+              </Radio.Group>
+            </div>
+
+            {gcpManagementType === 'KORE' && stepsKoreManagedComplete ? (
+              <Card>
+                <Result
+                  status="success"
+                  title="Kore managed setup complete!"
+                  subTitle="Kore will manage the lifecycle of GCP projects along with Kore teams"
+                  extra={<Link href="/prototype/setup/kore/complete"><Button type="primary" key="continue">Continue</Button></Link>}
+                >
+                  <Paragraph><Icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" /> GCP organization credentials</Paragraph>
+                  <Paragraph><Icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" /> Review cluster plans</Paragraph>
+                  <Paragraph><Icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" /> Project automation</Paragraph>
+                </Result>
+              </Card>
+            ) : null}
+
+            {gcpManagementType === 'KORE' && !stepsKoreManagedComplete ? (
+              <>
+                <Card>
+                  <Steps current={currentStepKoreManaged}>
+                    {this.stepsKoreManaged.map(item => (
+                      <Step key={item.title} title={item.title} />
+                    ))}
+                  </Steps>
+                  <Divider />
+                  <div className="steps-content" style={{ marginTop: '20px', marginBottom: '20px' }}>
+                    {this.stepsKoreManaged[currentStepKoreManaged].id === 'CREDS' ? (
+                      <>
+                        <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Add one or more GCP organization credentials</Paragraph>
+                        <GCPOrganizationsList />
+                      </>
+                    ) : null}
+                    {this.stepsKoreManaged[currentStepKoreManaged].id === 'PLANS' ? (
+                      <>
+                        <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Review the cluster plans available for GKE</Paragraph>
+                        <PlanList kind={selectedCloud} />
+                      </>
+                    ) : null}
+                    {this.stepsKoreManaged[currentStepKoreManaged].id === 'PROJECTS' ? (
+                      <>
+                        <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Configure GCP project automation</Paragraph>
+                        <Alert
+                          message="This defines how Kore will automate GCP projects for teams"
+                          description="When a team is created in Kore and a cluster is requested, Kore will ensure the GCP project is also created and the cluster placed inside it. You must also specify the plans available for each type of project, this is to ensure the correct cluster specification is being used."
+                          type="info"
+                          showIcon
+                          style={{ marginBottom: '20px' }}
+                        />
+
+                        <div style={{ marginBottom: '15px' }}>
+                          <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>How do you want Kore to automate GCP projects for teams?</Paragraph>
+                          <Radio.Group onChange={this.selectGcpProjectAutomationType} value={gcpProjectAutomationType}>
+                            <Radio value={'CLUSTER'} style={{ marginRight: '20px' }}>
+                              <Text style={{ fontSize: '16px', fontWeight: '600' }}>One per cluster</Text>
+                              <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will create a GCP project for each cluster a team provisions</Paragraph>
+                            </Radio>
+                            <Radio value={'CUSTOM'}>
+                              <Text style={{ fontSize: '16px', fontWeight: '600' }}>Custom</Text>
+                              <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Configure how Kore will create GCP projects for teams</Paragraph>
+                            </Radio>
+                          </Radio.Group>
+                        </div>
+
+                        {gcpProjectAutomationType === 'CLUSTER' ? (
+                          <Alert
+                            message="For every cluster a team creates Kore will also create a GCP project and provision the cluster inside it. The GCP project will share the name given to the cluster."
+                            type="info"
+                            showIcon
+                            style={{ marginBottom: '20px' }}
+                          />
+                        ) : null}
+
+                        {gcpProjectAutomationType === 'CUSTOM' ? (
+
+                          <>
+                            <Alert
+                              message="When a team is created in Kore and a cluster is requested, Kore will ensure the associated GCP project is also created and the cluster placed inside it. You must also specify the plans available for each type of project, this is to ensure the correct cluster specification is being used."
+                              type="info"
+                              showIcon
+                              style={{ marginBottom: '20px' }}
+                            />
+                            <Button type="primary" onClick={this.addProject(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
+                            <List
+                              itemLayout="vertical"
+                              bordered={true}
+                              dataSource={gcpProjectList}
+                              renderItem={project => (
+                                <List.Item actions={[<a key="delete" onClick={this.deleteGcpProject(project.code)}><Icon type="delete" /> Remove</a>]}>
+                                  <List.Item.Meta
+                                    title={<Text editable={{ onChange: this.onChange(project.code, 'title') }} style={{ fontSize: '16px' }}>{project.title}</Text>}
+                                    description={<Text editable={{ onChange: this.onChange(project.code, 'description') }}>{project.description}</Text>}
+                                  />
+
+                                  <Row gutter={16}>
+                                    <Col span={8}>
+                                      <Card
+                                        title="Naming"
+                                        size="small"
+                                        bordered={false}
+                                      >
+                                        <Paragraph>The project will be named using the team name, with the prefix and suffix below</Paragraph>
+                                        <Row style={{ padding: '5px 0' }}>
+                                          <Col span={8}>
+                                          Prefix
+                                          </Col>
+                                          <Col span={16}>
+                                            <Text editable={{ onChange: this.onChange(project.code, 'prefix') }}>{project.prefix}</Text>
+                                          </Col>
+                                        </Row>
+                                        <Row style={{ padding: '5px 0' }}>
+                                          <Col span={8}>
+                                          Suffix
+                                          </Col>
+                                          <Col span={16}>
+                                            <Text editable={{ onChange: this.onChange(project.code, 'suffix') }}>{project.suffix}</Text>
+                                          </Col>
+                                        </Row>
+                                        <Row style={{ paddingTop: '15px' }}>
+                                          <Col span={8}>
+                                          Example
+                                          </Col>
+                                          <Col span={16}>
+                                            <Text>{project.prefix}-<span style={{ fontStyle: 'italic' }}>team-name</span>-{project.suffix}</Text>
+                                          </Col>
+                                        </Row>
+                                      </Card>
+                                    </Col>
+                                    <Col span={8}>
+                                      <Card
+                                        title="Cluster plans"
+                                        size="small"
+                                        bordered={false}
+                                      >
+                                        <Paragraph>The cluster plans associated with this project.</Paragraph>
+                                        {project.plans.length === 0 ? <div style={{ padding: '5px 0' }}>No plans</div> : null}
+                                        {(plans || []).filter(p => project.plans.includes(p.metadata.name)).map((plan, i) => (
+                                          <div key={i} style={{ padding: '5px 0' }}>
+                                            <Text style={{ marginRight: '10px' }}>{plan.spec.description}</Text>
+                                            <this.IconTooltip icon="info-circle" text={plan.spec.summary} />
+                                            <this.IconTooltipButton icon="eye" text="View plan" onClick={this.showPlanDetails(plan)} />
+                                            <this.IconTooltipButton icon="delete" text="Unassociate plan" onClick={this.unassociatePlan(project.code, plan.metadata.name)} />
+                                          </div>
+                                        ))}
+                                        <div style={{ padding: '5px 0' }}>
+
+                                          <Popover
+                                            content={this.associatePlanContent(project.code)}
+                                            title={`${project.title}: associate plans`}
+                                            trigger="click"
+                                            visible={associatePlanVisible === project.code}
+                                            onVisibleChange={this.handleAssociatePlanVisibleChange(project.code)}
+                                          >
+                                            <a>+ Associate plan</a>
+                                          </Popover>
+                                        </div>
+                                      </Card>
+                                    </Col>
+                                  </Row>
+
+                                </List.Item>
+                              )}
+                            />
+                            {addProject ? (
+                              <Drawer
+                                title={<Title level={4}>New project</Title>}
+                                visible={addProject}
+                                onClose={this.addProject(false)}
+                                width={700}
+                              >
+                                <WrappedProjectForm handleSubmit={this.handleProjectAdded} handleCancel={this.addProject(false)} />
+                              </Drawer>
+                            ) : null}
+                          </>
+
+                        ) : null}
+
+                      </>
+                    ) : null}
+                  </div>
+                  <Divider />
+                  <div className="steps-action">
+                    {currentStepKoreManaged < this.stepsKoreManaged.length - 1 && (
+                      <Button type="primary" onClick={() => this.nextStepKoreManaged()}>
+                        Next
+                      </Button>
+                    )}
+                    {currentStepKoreManaged === this.stepsKoreManaged.length - 1 && (
+                      <Button type="primary" onClick={this.stepsKoreManagedComplete}>
+                        Done
+                      </Button>
+                    )}
+                    {currentStepKoreManaged > 0 && (
+                      <Button style={{ marginLeft: 8 }} onClick={() => this.prevStepKoreManaged()}>
+                        Previous
+                      </Button>
+                    )}
+                  </div>
+                </Card>
+
+              </>
+            ) : null}
+
+            {gcpManagementType === 'EXTERNAL' && stepsExistingComplete ? (
+              <Card>
+                <Result
+                  status="success"
+                  title="Use existing setup complete!"
+                  subTitle="Kore will use existing GCP projects that it's given access to"
+                  extra={<Link href="/prototype/setup/kore/complete"><Button type="primary" key="continue">Continue</Button></Link>}
+                >
+                  <Paragraph><Icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" /> GCP project credentials</Paragraph>
+                  <Paragraph><Icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" /> Review cluster plans</Paragraph>
+                  <Paragraph><Icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" /> Project access guidance</Paragraph>
+                </Result>
+              </Card>
+            ) : null}
+
+            {gcpManagementType === 'EXTERNAL' && !stepsExistingComplete ? (
+              <>
+                <Card>
+
+                  <Steps current={currentStepExisting}>
+                    {this.stepsExisting.map(item => (
+                      <Step key={item.title} title={item.title} />
+                    ))}
+                  </Steps>
+                  <Divider />
+
+                  {this.stepsExisting[currentStepExisting].id === 'CREDS' ? (
+                    <>
+                      <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Add one or more GCP project credentials</Paragraph>
+                      <GKECredentialsList />
+                    </>
+                  ) : null}
+                  {this.stepsExisting[currentStepExisting].id === 'PLANS' ? (
+                    <>
+                      <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Review the cluster plans available for GKE</Paragraph>
+                      <PlanList kind={selectedCloud} />
+                    </>
+                  ) : null}
+                  {this.stepsExisting[currentStepExisting].id === 'ACCESS' ? (
+                    <>
+                      <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Project credential access for teams</Paragraph>
+                      <Alert
+                        message="Team access"
+                        description="When using Kore with existing GCP projects, you must allocate the project credentials to teams in order for them to provision clusters within those projects. When a new team is created they may not have access to any project credentials, here you can provide an email address which will be displayed to a team in this situation, in order to request access to a GCP project through Kore."
+                        type="info"
+                        showIcon
+                        style={{ marginBottom: '20px' }}
+                      />
+                      <Form.Item labelAlign="left" labelCol={{ span: 2 }} wrapperCol={{ span: 6 }} label="Email" help="Email for teams who need access to project credentails">
+                        <Input placeholder="Title" />
+                      </Form.Item>
+                    </>
+                  ) : null}
+
+                  <Divider />
+                  <div className="steps-action">
+                    {currentStepExisting < this.stepsExisting.length - 1 && (
+                      <Button type="primary" onClick={() => this.nextStepExisting()}>
+                        Next
+                      </Button>
+                    )}
+                    {currentStepExisting === this.stepsExisting.length - 1 && (
+                      <Button type="primary" onClick={this.stepsExistingComplete}>
+                        Done
+                      </Button>
+                    )}
+                    {currentStepExisting > 0 && (
+                      <Button style={{ marginLeft: 8 }} onClick={() => this.prevStepExisting()}>
+                        Previous
+                      </Button>
+                    )}
+                  </div>
+                  
+                </Card>
+              </>
+            ) : null}
+
+          </Card>
+        ) : null }
+
+        { selectedCloud === 'EKS' ? (
+          <Card>
+            <Alert
+              message="Amazon Web Services"
+              description="TODO"
+              type="info"
+              showIcon
+              style={{ marginBottom: '20px' }}
+            />
+          </Card>
+        ) : null}
+      </div>
+    )
+  }
+}
+
+export default CloudAccessPage

--- a/ui/pages/prototype/setup/kore/complete.js
+++ b/ui/pages/prototype/setup/kore/complete.js
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+import { Result, Button } from 'antd'
+
+const SetupKoreCompletePage = () => (
+  <div>
+    <Result
+      status="success"
+      title="Kore setup complete"
+      subTitle="You have configured the minimum settings in order to work with Kore"
+      extra={[
+        <Button type="primary" key="buttonContinue">
+          <Link href="/prototype">
+            <a>Continue</a>
+          </Link>
+        </Button>
+      ]}
+    />
+  </div>
+)
+
+SetupKoreCompletePage.staticProps = {
+  title: 'Kore setup complete',
+  hideSider: true,
+  adminOnly: true
+}
+
+export default SetupKoreCompletePage

--- a/ui/pages/prototype/setup/kore/index.js
+++ b/ui/pages/prototype/setup/kore/index.js
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import PropTypes from 'prop-types'
+import { Result, Icon, Button } from 'antd'
+
+const SetupKoreIndexPage = ({ user }) => (
+  <div>
+    <Result
+      icon={<Icon type="smile" theme="twoTone" />}
+      title={`Welcome to Kore, ${user.displayName || user.name || user.id}!`}
+      subTitle="As the first user you are now an administrator and are responsible for the initial setup"
+      extra={[
+        <Button key="buttonBegin" type="primary">
+          <Link href="/prototype/setup/kore/cloud-access">
+            <a>Begin setup</a>
+          </Link>
+        </Button>,
+        <Button key="buttonSkip">
+          <Link href="/">
+            <a>Skip</a>
+          </Link>
+        </Button>
+      ]}
+    />
+  </div>
+)
+
+SetupKoreIndexPage.staticProps = {
+  title: 'Welcome. Initial Kore setup',
+  hideSider: true,
+  adminOnly: true
+}
+
+SetupKoreIndexPage.propTypes = {
+  user: PropTypes.object.isRequired
+}
+
+export default SetupKoreIndexPage

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -13,6 +13,8 @@ const port = config.server.port
 const RedisStore = require('connect-redis')(session)
 const redisClient = redis.createClient({ url: config.server.session.url })
 
+const nextjsPath = config.showPrototypes ? '*' : /^((?!\/prototype).)*$/
+
 app.prepare().then(() => {
   const server = express()
 
@@ -35,7 +37,7 @@ app.prepare().then(() => {
 
   server.use(routes)
 
-  server.all('*', (req, res) => {
+  server.all(nextjsPath, (req, res) => {
     const handle = app.getRequestHandler()
     return handle(req, res)
   })


### PR DESCRIPTION
Including adding a feature flag for showing prototypes

* prototypes can be added under `pages/prototype`
* this directory will only be served by next.js if `NODE_ENV` is `development` or specifically enabled by setting `KORE_UI_SHOW_PROTOTYPES` env var to true
* adding a tag/link to the header to show if the page being viewed is a prototype
* adding an index page to the prototype directory which can list and link to the prototypes as required

<img width="1239" alt="Screen Shot 2020-04-24 at 14 31 00" src="https://user-images.githubusercontent.com/1334068/80217839-44df5900-8638-11ea-8cb6-6a5f1a3d3912.png">
