### PR TITLE
[PROTOTYPE] Setup wizard and team settings changes

### DIFF
--- a/ui/lib/prototype/components/configure/AutomatedProjectForm.js
+++ b/ui/lib/prototype/components/configure/AutomatedProjectForm.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Form, Input } from 'antd'
+
+import FormErrorMessage from '../../../../lib/components/forms/FormErrorMessage'
+
+class AutomatedProjectForm extends React.Component {
+  static propTypes = {
+    form: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    handleCancel: PropTypes.func.isRequired,
+  }
+
+  state = {
+    submitting: false,
+    formErrorMessage: false
+  }
+
+  handleSubmit = (e) => {
+    e.preventDefault()
+    this.setState({ submitting: true })
+    this.props.form.validateFields((err, values) => {
+      if (err) {
+        this.setState({ submitting: false, formErrorMessage: 'Validation failed' })
+        return
+      }
+      this.props.handleSubmit(values)
+    })
+  }
+
+  fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
+
+  render() {
+    const { getFieldDecorator } = this.props.form
+    const formConfig = {
+      layout: 'horizontal',
+      labelAlign: 'left',
+      hideRequiredMark: true,
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    }
+    return (
+      <>
+        <FormErrorMessage message={this.state.formErrorMessage} />
+        <Form { ...formConfig } onSubmit={this.handleSubmit}>
+          <Form.Item label="Title" help={this.fieldError('title') || ''}>
+            {getFieldDecorator('title', { rules: [{ required: true, message: 'Please enter the title!' }] })(
+              <Input placeholder="Title" />
+            )}
+          </Form.Item>
+          <Form.Item label="Description" help={this.fieldError('description') || ''}>
+            {getFieldDecorator('description', { rules: [{ required: true, message: 'Please enter the description!' }] })(
+              <Input placeholder="Description" />
+            )}
+          </Form.Item>
+          <Form.Item label="Prefix" help={this.fieldError('prefix') || 'The project ID prefix'}>
+            {getFieldDecorator('prefix', { initialValue: 'kore' })(
+              <Input placeholder="Prefix" />
+            )}
+          </Form.Item>
+          <Form.Item label="Suffix" help={this.fieldError('suffix') || 'The project ID suffix'}>
+            {getFieldDecorator('suffix', { rules: [{ required: true, message: 'Please enter the suffix!' }] })(
+              <Input placeholder="Suffix" />
+            )}
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={this.state.submitting}>Save</Button>
+            <Button type="link" onClick={this.props.handleCancel}>Cancel</Button>
+          </Form.Item>
+        </Form>
+      </>
+    )
+  }
+}
+
+const WrappedAutomatedProjectForm = Form.create({ name: 'project_form' })(AutomatedProjectForm)
+
+export default WrappedAutomatedProjectForm

--- a/ui/lib/prototype/components/credentials/GCPOrganization.js
+++ b/ui/lib/prototype/components/credentials/GCPOrganization.js
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types'
+import moment from 'moment'
+import { List, Avatar, Icon, Typography, message, Tooltip } from 'antd'
+const { Text } = Typography
+
+import ResourceVerificationStatus from '../../../components/ResourceVerificationStatus'
+import AutoRefreshComponent from '../../../components/team/AutoRefreshComponent'
+
+class GCPOrganization extends AutoRefreshComponent {
+  static propTypes = {
+    organization: PropTypes.object.isRequired,
+    allTeams: PropTypes.array.isRequired,
+    editOrganization: PropTypes.func.isRequired
+  }
+
+  componentDidUpdate(prevProps) {
+    const prevStatus = prevProps.organization.status && prevProps.organization.status.status
+    const newStatus = this.props.organization.status && this.props.organization.status.status
+    if (prevStatus !== newStatus) {
+      this.startRefreshing()
+    }
+  }
+
+  finalStateReached() {
+    const { organization } = this.props
+    const { allocation, status } = organization
+    if (status.status === 'Success') {
+      return message.success(`GCP organization "${allocation.spec.name}" created successfully`)
+    }
+    if (status.status === 'Failure') {
+      return message.error(`GCP organization "${allocation.spec.name}" failed to be created`)
+    }
+  }
+
+  render() {
+    const { organization, editOrganization } = this.props
+    const created = moment(organization.metadata.creationTimestamp).fromNow()
+
+    return (
+      <List.Item key={organization.metadata.name} actions={[
+        <ResourceVerificationStatus key="verification_status" resourceStatus={organization.status} />,
+        <Text key="edit"><a onClick={editOrganization(organization)}><Icon type="edit" theme="filled"/> Edit</a></Text>
+      ]}>
+        <List.Item.Meta
+          avatar={<Avatar icon="cloud" />}
+          title={<Text style={{ display: 'inline', marginRight: '15px', fontSize: '20px', fontWeight: '600' }}>{organization.spec.parentID}</Text>}
+          description={
+            <>
+              <Text style={{ marginRight: '5px' }}>{organization.allocation.spec.name}</Text>
+              <Tooltip title={organization.allocation.spec.summary}>
+                <Icon type="info-circle" theme="twoTone" />
+              </Tooltip>
+            </>
+          }
+        />
+        <Text type='secondary'>Created {created}</Text>
+      </List.Item>
+    )
+  }
+
+}
+
+export default GCPOrganization

--- a/ui/lib/prototype/components/credentials/GCPOrganizationForm.js
+++ b/ui/lib/prototype/components/credentials/GCPOrganizationForm.js
@@ -1,0 +1,146 @@
+import * as React from 'react'
+import VerifiedAllocatedResourceForm from '../forms/VerifiedAllocatedResourceForm'
+import V1alpha1Organization from '../../../kore-api/model/V1alpha1Organization'
+import V1ObjectMeta from '../../../kore-api/model/V1ObjectMeta'
+import V1Secret from '../../../kore-api/model/V1Secret'
+import V1SecretSpec from '../../../kore-api/model/V1SecretSpec'
+import V1SecretReference from '../../../kore-api/model/V1SecretReference'
+import V1alpha1OrganizationSpec from '../../../kore-api/model/V1alpha1OrganizationSpec'
+import KoreApi from '../../../kore-api'
+import { Form, Input, Alert, Card } from 'antd'
+import AllocationHelpers from '../../../utils/allocation-helpers'
+
+class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
+
+  generateSecretResource = values => {
+    const resource = new V1Secret()
+    resource.setApiVersion('config.kore.appvia.io')
+    resource.setKind('Secret')
+
+    const meta = new V1ObjectMeta()
+    meta.setName(this.getMetadataName(values))
+    meta.setNamespace(this.props.team)
+    resource.setMetadata(meta)
+
+    const spec = new V1SecretSpec()
+    spec.setType('gcp-org')
+    spec.setDescription(`GCP admin project Service Account for ${values.parentID}`)
+    spec.setData({ key: values.account })
+    resource.setSpec(spec)
+
+    return resource
+  }
+
+  generateGCPOrganizationResource = values => {
+    const name = this.getMetadataName(values)
+    const resource = new V1alpha1Organization()
+    resource.setApiVersion('gcp.compute.kore.appvia.io/v1alpha1')
+    resource.setKind('Organization')
+
+    const meta = new V1ObjectMeta()
+    meta.setName(name)
+    meta.setNamespace(this.props.team)
+    resource.setMetadata(meta)
+
+    const spec = new V1alpha1OrganizationSpec()
+    spec.setParentType('organization')
+    spec.setParentID(values.parentID)
+    spec.setBillingAccount(values.billingAccount)
+    spec.setServiceAccount('kore')
+
+    const secret = new V1SecretReference()
+    secret.setName(name)
+    secret.setNamespace(this.props.team)
+    spec.setCredentialsRef(secret)
+
+    resource.setSpec(spec)
+
+    return resource
+  }
+
+  getResource = async metadataName => {
+    const api = await KoreApi.client()
+    const gcpOrgResult = await api.GetGCPOrganization(this.props.team, metadataName)
+    gcpOrgResult.allocation = await AllocationHelpers.getAllocationForResource(gcpOrgResult)
+    return gcpOrgResult
+  }
+
+  putResource = async values => {
+    const api = await KoreApi.client()
+    const metadataName = this.getMetadataName(values)
+    await api.UpdateTeamSecret(this.props.team, metadataName, this.generateSecretResource(values))
+    const gcpOrg = this.generateGCPOrganizationResource(values)
+    const gcpOrgResult = await api.UpdateGCPOrganization(this.props.team, metadataName, gcpOrg)
+    gcpOrgResult.allocation = await this.storeAllocation(gcpOrg, values)
+    return gcpOrgResult
+  }
+
+  allocationFormFieldsInfo = {
+    allocationMissing: {
+      infoMessage: 'This organization credential is not allocated to any teams',
+      infoDescription: 'Give the organization credential a Name and Description below and enter Allocated team(s) as appropriate. Once complete, click Save to allocate it.'
+    },
+    nameSection: {
+      infoMessage: 'Help Kore teams understand this organization credential',
+      infoDescription: 'Give this organization credential a name and description to help teams choose the correct one.',
+      nameHelp: 'The name for the organization credential eg. MyOrg',
+      descriptionHelp: 'A description of the organization credential to help when choosing between them'
+    },
+    allocationSection: {
+      infoMessage: 'Make this organization credential available to teams in Kore',
+      infoDescription: 'This will give teams the ability to create GCP projects inside the organization. Within these scoped projects the team will have the ability to create clusters.',
+      allTeamsWarningMessage: 'This organization credential will be available to all teams',
+      allTeamsWarningDescription: 'No teams exist in Kore yet, therefore currently this organization credential will be available to all teams created in the future. If you wish to restrict this please return here and allocate to teams once they have been created.',
+      allocateExtra: 'If nothing selected then this organization credential will be available to ALL teams'
+    }
+  }
+
+  resourceFormFields = () => {
+    const { form, data } = this.props
+    return (
+      <Card style={{ marginBottom: '20px' }}>
+        <Alert
+          message="GCP Organization details"
+          description="Retrieve these values from your GCP organization. Providing these gives Kore the ability to create projects for teams within the GCP organization. Teams will then be able to provision clusters within their projects."
+          type="info"
+          style={{ marginBottom: '20px' }}
+        />
+        <Form.Item label="Organization ID" validateStatus={this.fieldError('parentID') ? 'error' : ''} help={this.fieldError('parentID') || 'The GCP organization ID'}>
+          {form.getFieldDecorator('parentID', {
+            rules: [{ required: true, message: 'Please enter the organization ID!' }],
+            initialValue: data && data.spec.parentID
+          })(
+            <Input placeholder="Organization ID" />,
+          )}
+        </Form.Item>
+        <Form.Item label="Billing account" validateStatus={this.fieldError('billingAccount') ? 'error' : ''} help={this.fieldError('billingAccount') || 'The billing account'}>
+          {form.getFieldDecorator('billingAccount', {
+            rules: [{ required: true, message: 'Please enter your billing account!' }],
+            initialValue: data && data.spec.billingAccount
+          })(
+            <Input placeholder="Billing account" />,
+          )}
+        </Form.Item>
+        <Form.Item label="Service Account JSON" labelCol={{ span: 24 }} wrapperCol={{ span: 24 }} validateStatus={this.fieldError('account') ? 'error' : ''} help={this.fieldError('account') || Boolean(data) || 'The Service Account key in JSON format, with project creation permissions.'}>
+          {!data ? (
+            form.getFieldDecorator('account', {
+              rules: [{ required: true, message: 'Please enter your Service Account!' }]
+            })(
+              <Input.TextArea autoSize={{ minRows: 4, maxRows: 10  }} placeholder="Service Account JSON" />,
+            )
+          ) : (
+            <Alert
+              message="For security reasons, the Service Account key is not shown after creation of the organization"
+              type="warning"
+              style={{ marginBottom: '-20px', marginTop: '10px' }}
+            />
+          )}
+        </Form.Item>
+      </Card>
+    )
+  }
+}
+
+const WrappedGCPOrganizationForm = Form.create({ name: 'gcp_organization' })(GCPOrganizationForm)
+
+export default WrappedGCPOrganizationForm

--- a/ui/lib/prototype/components/credentials/GCPOrganizationsList.js
+++ b/ui/lib/prototype/components/credentials/GCPOrganizationsList.js
@@ -1,0 +1,100 @@
+import PropTypes from 'prop-types'
+import { Typography, List, Button, Drawer, Icon, Alert } from 'antd'
+const { Title } = Typography
+
+import { kore } from '../../../../config'
+import GCPOrganization from './GCPOrganization'
+import ResourceList from '../../../components/configure/ResourceList'
+import GCPOrganizationForm from './GCPOrganizationForm'
+import KoreApi from '../../../kore-api'
+
+class GCPOrganizationsList extends ResourceList {
+
+  static propTypes = {
+    style: PropTypes.object
+  }
+
+  createdMessage = 'GCP organization created successfully'
+  updatedMessage = 'GCP organization updated successfully'
+
+  async fetchComponentData() {
+    const api = await KoreApi.client()
+    const [ allTeams, gcpOrganizations, allAllocations ] = await Promise.all([
+      api.ListTeams(),
+      api.ListGCPOrganizations(kore.koreAdminTeamName),
+      api.ListAllocations(kore.koreAdminTeamName)
+    ])
+    allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    gcpOrganizations.items.forEach(org => {
+      org.allocation = (allAllocations.items || []).find(alloc => alloc.metadata.name === org.metadata.name)
+    })
+    return { resources: gcpOrganizations, allTeams }
+  }
+
+  render() {
+    const { resources, allTeams, edit, add } = this.state
+
+    return (
+      <>
+        <Alert
+          message="Give Kore access to your Google Cloud Platform organization"
+          description="This will allow Kore to manage the organization for you. This includes managing the creation of projects and Service Accounts giving Kore teams the ability to create clusters with ease."
+          type="info"
+          showIcon
+          style={{ marginBottom: '20px' }}
+        />
+        <Button type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
+        {!resources ? <Icon type="loading" /> : (
+          <>
+            <List
+              dataSource={resources.items}
+              renderItem={org =>
+                <GCPOrganization
+                  organization={org}
+                  allTeams={allTeams.items}
+                  editOrganization={this.edit}
+                  handleUpdate={this.handleStatusUpdated}
+                  refreshMs={2000}
+                  propsResourceDataKey="organization"
+                  resourceApiPath={`/teams/${kore.koreAdminTeamName}/organizations/${org.metadata.name}`}
+                />
+              }
+            >
+            </List>
+            {edit ? (
+              <Drawer
+                title={<Title level={4}>GCP Organization: {edit.spec.parentID}</Title>}
+                visible={Boolean(edit)}
+                onClose={this.edit(false)}
+                width={700}
+              >
+                <GCPOrganizationForm
+                  team={kore.koreAdminTeamName}
+                  allTeams={allTeams}
+                  data={edit}
+                  handleSubmit={this.handleEditSave}
+                />
+              </Drawer>
+            ) : null}
+            {add ? (
+              <Drawer
+                title={<Title level={4}>New GCP organization</Title>}
+                visible={add}
+                onClose={this.add(false)}
+                width={700}
+              >
+                <GCPOrganizationForm
+                  team={kore.koreAdminTeamName}
+                  allTeams={allTeams}
+                  handleSubmit={this.handleAddSave}
+                />
+              </Drawer>
+            ) : null}
+          </>
+        )}
+      </>
+    )
+  }
+}
+
+export default GCPOrganizationsList

--- a/ui/lib/prototype/components/forms/VerifiedAllocatedResourceForm.js
+++ b/ui/lib/prototype/components/forms/VerifiedAllocatedResourceForm.js
@@ -1,0 +1,237 @@
+import * as React from 'react'
+import PropTypes from 'prop-types'
+import { message, Typography, Form, Card, Alert, Button, Input } from 'antd'
+const { Paragraph, Text } = Typography
+
+import canonical from '../../../utils/canonical'
+import ResourceVerificationStatus from '../../../components/ResourceVerificationStatus'
+import FormErrorMessage from '../../../components/forms/FormErrorMessage'
+import AllocationHelpers from '../../../utils/allocation-helpers'
+
+class VerifiedAllocatedResourceForm extends React.Component {
+  static propTypes = {
+    form: PropTypes.any.isRequired,
+    team: PropTypes.string.isRequired,
+    allTeams: PropTypes.object,
+    data: PropTypes.object,
+    handleSubmit: PropTypes.func.isRequired,
+    saveButtonText: PropTypes.string,
+    inlineVerification: PropTypes.bool
+  }
+
+  constructor(props) {
+    super(props)
+    let allocations = []
+    if (props.data && props.data.allocation) {
+      allocations = props.data.allocation.spec.teams.filter(a => a !== '*')
+    }
+    this.state = {
+      submitting: false,
+      formErrorMessage: false,
+      allocations,
+      inlineVerificationFailed: false
+    }
+  }
+
+  componentDidMount() {
+    // To disabled submit button at the beginning.
+    this.props.form.validateFields()
+  }
+
+  disableButton = fieldsError => {
+    if (this.state.submitting) {
+      return true
+    }
+    return Object.keys(fieldsError).some(field => fieldsError[field])
+  }
+
+  onAllocationsChange = value => {
+    this.setState({
+      ...this.state,
+      allocations: value
+    })
+  }
+
+  getResource = () => {
+    throw new Error('getResource must be implemented')
+  }
+
+  putResource = () => {
+    throw new Error('putResource must be implemented')
+  }
+
+  async verify(resource, tryCount) {
+    const messageKey = 'verify'
+    tryCount = tryCount || 0
+    if (tryCount === 0) {
+      message.loading({ content: 'Verifying credentials', key: messageKey, duration: 0 })
+    }
+    if (tryCount === 3) {
+      message.error({ content: 'Credentials verification failed', key: messageKey })
+      this.setState({
+        ...this.state,
+        inlineVerificationFailed: true,
+        submitting: false,
+        formErrorMessage: (
+          <>
+            <Paragraph>The credentials have been saved but could not be verified, see the error below. Please try again or click &quot;Continue without verification&quot;.</Paragraph>
+            {(resource.status.conditions || []).map((c, idx) =>
+              <Paragraph key={idx} style={{ marginBottom: '0' }}>
+                <Text strong>{c.message}</Text>
+                <br/>
+                <Text>{c.detail}</Text>
+              </Paragraph>
+            )}
+          </>
+        )
+      })
+    } else {
+      setTimeout(async () => {
+        const resourceResult = await this.getResource(resource.metadata.name)
+        if (resourceResult.status.status === 'Success') {
+          message.success({ content: 'Credentials verification successful', key: messageKey })
+          return await this.props.handleSubmit(resourceResult)
+        }
+        return await this.verify(resourceResult, tryCount + 1)
+      }, 2000)
+    }
+  }
+
+  setFormSubmitting = (submitting = true, formErrorMessage = false) => {
+    this.setState({
+      ...this.state,
+      submitting,
+      formErrorMessage
+    })
+  }
+
+  getMetadataName = values => {
+    const data = this.props.data
+    return (data && data.metadata && data.metadata.name) || canonical(values.name)
+  }
+
+  storeAllocation = async (resource, values) => {
+    return await AllocationHelpers.storeAllocation({ resourceToAllocate: resource, teams: this.state.allocations, name: values.name, summary: values.summary })
+  }
+
+  _process = async (err, values) => {
+    if (err) {
+      this.setFormSubmitting(false, 'Validation failed')
+      return
+    }
+    try {
+      const resourceResult = await this.putResource(values)
+      if (this.props.inlineVerification) {
+        return await this.verify(resourceResult)
+      }
+      return await this.props.handleSubmit(resourceResult)
+    } catch (err) {
+      console.error('Error submitting form', err)
+      this.setFormSubmitting(false, 'An error occurred saving the form, please try again')
+    }
+  }
+
+  handleSubmit = e => {
+    e.preventDefault()
+    this.setFormSubmitting()
+    this.props.form.validateFields(this._process)
+  }
+
+  continueWithoutVerification = async () => {
+    try {
+      const metadataName = this.getMetadataName(this.props.form.getFieldsValue())
+      const resourceResult = await this.getResource(metadataName)
+      await this.props.handleSubmit(resourceResult)
+    } catch (err) {
+      console.error('Error getting data', err)
+      this.setFormSubmitting(false, 'An error occurred saving the form, please try again')
+    }
+  }
+
+  // Only show error after a field is touched.
+  fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
+
+  resourceFormFields = () => {
+    throw new Error('resourceFormFields must be implemented')
+  }
+
+  render() {
+    const { form, data, saveButtonText } = this.props
+    const { getFieldDecorator, getFieldsError } = form
+    const { formErrorMessage, submitting, inlineVerificationFailed } = this.state
+    const formConfig = {
+      layout: 'horizontal',
+      labelAlign: 'left',
+      hideRequiredMark: true,
+      labelCol: {
+        sm: { span: 24 },
+        md: { span: 8 },
+        lg: { span: 6 }
+      },
+      wrapperCol: {
+        sm: { span: 24 },
+        md: { span: 16 },
+        lg: { span: 18 }
+      }
+    }
+
+    const noAllocation = Boolean(data && !data.allocation)
+    const { allocationMissing, nameSection } = this.allocationFormFieldsInfo
+
+    return (
+      <>
+        <ResourceVerificationStatus resourceStatus={data && data.status} style={{ marginBottom: '15px' }}/>
+
+        {noAllocation ? (
+          <Alert
+            message={allocationMissing.infoMessage}
+            description={allocationMissing.infoDescription}
+            type="warning"
+            showIcon
+            style={{ marginBottom: '20px', marginTop: '5px' }}
+          />
+        ) : null}
+
+        <Form {...formConfig} onSubmit={this.handleSubmit}>
+          <FormErrorMessage message={formErrorMessage} />
+
+          <this.resourceFormFields />
+
+          <Card style={{ marginBottom: '20px' }}>
+            <Alert
+              message={nameSection.infoMessage}
+              description={nameSection.infoDescription}
+              type="info"
+              style={{ marginBottom: '20px' }}
+            />
+            <Form.Item label="Name" validateStatus={this.fieldError('name') ? 'error' : ''} help={this.fieldError('name') || nameSection.nameHelp}>
+              {getFieldDecorator('name', {
+                rules: [{ required: true, message: 'Please enter the name!' }],
+                initialValue: data && data.allocation && data.allocation.spec.name
+              })(
+                <Input placeholder="Name" />,
+              )}
+            </Form.Item>
+            <Form.Item label="Description" validateStatus={this.fieldError('summary') ? 'error' : ''} help={this.fieldError('summary') || nameSection.descriptionHelp}>
+              {getFieldDecorator('summary', {
+                rules: [{ required: true, message: 'Please enter the description!' }],
+                initialValue: data && data.allocation && data.allocation.spec.summary
+              })(
+                <Input placeholder="Description" />,
+              )}
+            </Form.Item>
+          </Card>
+
+          <Form.Item style={{ marginBottom: '0' }}>
+            <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>{saveButtonText || 'Save'}</Button>
+            {inlineVerificationFailed ? (
+              <Button id="continue-without-verification" onClick={this.continueWithoutVerification} disabled={this.disableButton(getFieldsError())} style={{ marginLeft: '10px' }}>Continue without verification</Button>
+            ) : null}
+          </Form.Item>
+        </Form>
+      </>
+    )
+  }
+}
+
+export default VerifiedAllocatedResourceForm

--- a/ui/pages/prototype/configure/settings.js
+++ b/ui/pages/prototype/configure/settings.js
@@ -1,139 +1,348 @@
 import React from 'react'
-import { Alert, Tabs, Card, Typography, Tooltip, Icon, Tag, Row, Col, Button, Checkbox } from 'antd'
-const { Title, Text } = Typography
+import { Alert, Tabs, Card, Typography, Tooltip, Icon, Row, Col, Button, Form, Input, Radio, List, Drawer, Popover, Modal } from 'antd'
+const { Title, Text, Paragraph } = Typography
 import Breadcrumb from '../../../lib/components/Breadcrumb'
+
+import KoreApi from '../../../lib/kore-api'
+import copy from '../../../lib/utils/object-copy'
+import canonical from '../../../lib/utils/canonical'
+import PlanViewer from '../../../lib/components/configure/PlanViewer'
+
+// prototype components
+import AutomatedProjectForm from '../../../lib/prototype/components/configure/AutomatedProjectForm'
 
 class SettingsPage extends React.Component {
 
+  static initialProjectList = [{
+    code: 'not-production',
+    title: 'Not production',
+    description: 'To be used for all environments except production',
+    prefix: 'kore',
+    suffix: 'not-prod',
+    plans: ['gke-development']
+  }, {
+    code: 'production',
+    title: 'Production',
+    description: 'Project just for the production environment',
+    prefix: 'kore',
+    suffix: 'prod',
+    plans: ['gke-production']
+  }]
+
+  state = {
+    gcpManagementType: 'KORE',
+    gcpProjectAutomationType: 'CUSTOM',
+    gcpProjectList: SettingsPage.initialProjectList,
+    addProject: false,
+    associatePlanVisible: false
+  }
+
+  async fetchComponentData() {
+    const api = await KoreApi.client()
+    const planList = await api.ListPlans()
+    return planList.items
+  }
+
+  componentDidMount() {
+    this.fetchComponentData().then(plans => {
+      this.setState({ plans })
+    })
+  }
+
+  selectGcpManagementType = e => this.setState({ gcpManagementType: e.target.value })
+  selectGcpProjectAutomationType = e => this.setState({ gcpProjectAutomationType: e.target.value })
+
+  deleteGcpProject = (code) => {
+    return () => this.setState({
+      gcpProjectList: this.state.gcpProjectList.filter(p => p.code !== code)
+    })
+  }
+
+  onChange = (code, property) => {
+    return (value) => {
+      const gcpProjectList = copy(this.state.gcpProjectList)
+      gcpProjectList.find(p => p.code === code)[property] = value
+      this.setState({
+        gcpProjectList
+      })
+    }
+  }
+
+  showPlanDetails = (plan) => {
+    return () => {
+      Modal.info({
+        title: (<><Title level={4}>{plan.spec.description}</Title><Text>{plan.spec.summary}</Text></>),
+        content: <PlanViewer plan={plan} />,
+        width: 700,
+        onOk() {}
+      })
+    }
+  }
+
+  handleAssociatePlanVisibleChange = (projectCode) => () => this.setState({ associatePlanVisible: projectCode })
+
+  associatePlan = (projectCode, plan) => {
+    return () => {
+      const gcpProjectList = copy(this.state.gcpProjectList)
+      gcpProjectList.find(p => p.code === projectCode).plans.push(plan)
+      this.setState({ gcpProjectList })
+    }
+  }
+
+  closeAssociatePlans = () => this.setState({ associatePlanVisible: false })
+
+  associatePlanContent = (projectCode, selectedCloud) => {
+    const project = this.state.gcpProjectList.find(p => p.code === projectCode)
+    const cloudPlans = (this.state.plans || []).filter(p => p.spec.kind === selectedCloud)
+    const unassociatedPlans = cloudPlans.filter(p => !project.plans.includes(p.metadata.name))
+    if (unassociatedPlans.length === 0) {
+      return (
+        <>
+          <Alert style={{ marginBottom: '20px' }} message="All existing plans are already associated with this project type." />
+          <Button type="primary" onClick={this.closeAssociatePlans}>Close</Button>
+        </>
+      )
+    }
+    return (
+      <>
+        <Alert style={{ marginBottom: '20px' }} message="Plans available to be associated with this project type." />
+        <List
+          dataSource={unassociatedPlans}
+          renderItem={plan => <Paragraph>{plan.spec.description} <a style={{ textDecoration: 'underline' }} onClick={this.associatePlan(project.code, plan.metadata.name)}>Associate</a></Paragraph>}
+        />
+        <Button style={{ marginTop: '10px' }} type="primary" onClick={this.closeAssociatePlans}>Close</Button>
+      </>
+    )
+  }
+
+  unassociatePlan = (projectCode, plan) => {
+    return () => {
+      const gcpProjectList = copy(this.state.gcpProjectList)
+      const project = gcpProjectList.find(p => p.code === projectCode)
+      project.plans = project.plans.filter(p => p !== plan)
+      this.setState({ gcpProjectList })
+    }
+  }
+
+  addProject = (enabled) => () => this.setState({ addProject: enabled })
+
+  handleProjectAdded = (project) => {
+    const code = canonical(project.title)
+    this.setState({
+      gcpProjectList: this.state.gcpProjectList.concat([{ code, plans: [], ...project }]),
+      addProject: false
+    })
+  }
+
+  IconTooltip = ({ icon, text }) => (
+    <Tooltip title={text}>
+      <Icon type={icon} theme="twoTone" />
+    </Tooltip>
+  )
+
+  IconTooltipButton = ({ icon, text, onClick }) => (
+    <Tooltip title={text}>
+      <a style={{ marginLeft: '5px' }} onClick={onClick}><Icon type={icon} theme="twoTone" /></a>
+    </Tooltip>
+  )
+
   render() {
-    const targets = [
-      {
-        id: 'notprod',
-        title: 'Not production',
-        description: 'Target covering all but the production environment',
-        plans: {
-          GKE: [{
-            spec: {
-              description: 'GKE Development Cluster',
-              summary: 'Provides a development cluster within GKE',
-            }
-          }, {
-            spec: {
-              description: 'GKE Development Cluster High-CPU',
-              summary: 'Provides a development cluster within GKE, with high-CPU nodes for intensive operations',
-            }
-          }],
-          EKS: [{
-            spec: {
-              description: 'EKS Development Cluster',
-              summary: 'Provides a development cluster within EKS',
-            }
-          }],
-          AKS: []
-        }
-      },
-      {
-        id: 'prod',
-        title: 'Production',
-        description: 'Target covering the production environment',
-        plans: {
-          GKE: [{
-            spec: {
-              description: 'GKE Production Cluster',
-              summary: 'Provides a production cluster within GKE',
-            }
-          }],
-          EKS: [{
-            spec: {
-              description: 'EKS Production Cluster',
-              summary: 'Provides a production cluster within EKS',
-            }
-          }],
-          AKS: []
-        }
-      }
-    ]
-
-    const IconTooltip = ({ icon, text }) => (
-      <Tooltip title={text}>
-        <Icon type={icon} theme="twoTone" />
-      </Tooltip>
-    )
-
-    const IconTooltipButton = ({ icon, text, onClick }) => (
-      <Tooltip title={text}>
-        <a style={{ marginLeft: '5px' }} onClick={onClick}><Icon type={icon} theme="twoTone" /></a>
-      </Tooltip>
-    )
-
-    const CloudPlans = ({ imageFilename, cloudName, plans }) => (
-      <Col span={8}>
-        <Card
-          title={
-            <span>
-              <img src={`/static/images/${imageFilename}`} height="20px" style={{ marginRight: '10px' }}/>
-              {cloudName}
-            </span>
-          }
-          size="small"
-          bordered={false}
-        >
-          {plans.length === 0 ? <div style={{ padding: '5px 0' }}>No plans</div> : null}
-          {plans.map((plan, i) => (
-            <div key={i} style={{ padding: '5px 0' }}>
-              <Text style={{ marginRight: '10px' }}>{plan.spec.description}</Text>
-              <IconTooltip icon="info-circle" text={plan.spec.summary} />
-              <IconTooltipButton icon="eye" text="View plan" onClick={() => {}} />
-            </div>
-          ))}
-          <div style={{ padding: '5px 0' }}>
-            <a>+ Associate plan</a>
-          </div>
-        </Card>
-      </Col>
-    )
+    const { gcpManagementType, gcpProjectAutomationType, gcpProjectList, addProject, plans, associatePlanVisible } = this.state
 
     return (
       <>
         <Breadcrumb items={[{ text: 'Configure' }, { text: 'Settings' }]} />
-        <Alert
-          message="View and configure the settings for Kore"
-          type="info"
-          style={{ marginBottom: '20px' }}
-        />
+        <Title level={3} style={{ marginBottom: '20px' }}>Kore settings</Title>
 
         <Tabs defaultActiveKey={'teams'} tabPosition="left">
           <Tabs.TabPane tab="Teams" key="teams">
+            <Alert
+              message="View and configure the settings for Kore teams."
+              type="info"
+              style={{ marginBottom: '10px' }}
+            />
             <Card
-              title="Targets"
-              extra={<Button type="primary">+ New</Button>}
+              title={
+                <span>
+                  <img src={'/static/images/GCP.png'} height="20px" style={{ marginRight: '10px' }}/>
+                  Google Cloud Platform
+                </span>
+              }
+              bordered={false}
             >
-              <Alert
-                message="This setting controls which targets teams are able to create. When a team sets up a target it will create a project within the chosen cloud provider."
-                type="info"
-                style={{ marginBottom: '20px' }}
-              />
+              <div style={{ marginBottom: '15px' }}>
+                <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>How do you want Kore teams to integrate with GCP projects?</Paragraph>
+                <Radio.Group onChange={this.selectGcpManagementType} value={gcpManagementType}>
+                  <Radio value={'KORE'} style={{ marginRight: '20px' }}>
+                    <Text style={{ fontSize: '16px', fontWeight: '600' }}>Kore managed projects <Text type="secondary">(recommended)</Text></Text>
+                    <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will manage the GCP projects required for teams and their clusters</Paragraph>
+                  </Radio>
+                  <Radio value={'EXTERNAL'}>
+                    <Text style={{ fontSize: '16px', fontWeight: '600' }}>Use existing projects</Text>
+                    <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore teams will use existing GCP projects that it&apos;s given access to</Paragraph>
+                  </Radio>
+                </Radio.Group>
+              </div>
 
-              <Checkbox checked={true} disabled={true}>
-                <Text strong style={{ marginRight: '10px' }}>Allow teams to use project level credentials</Text>
-                <IconTooltip icon="info-circle" text="Upon creation of a target, this will enable the team to choose a project that is already created within the cloud provider, rather than creating a new one. Note, it must be configured by an admin and allocated to teams to be available." />
-              </Checkbox>
+              {gcpManagementType === 'EXTERNAL' ? (
+                <>
+                  <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Project credential access for teams</Paragraph>
+                  <Alert
+                    message="Team access"
+                    description="When using Kore with existing GCP projects, you must allocate the project credentials to teams in order for them to provision clusters within those projects. When a new team is created they may not have access to any project credentials, here you can provide an email address which will be displayed to a team in this situation, in order to request access to a GCP project through Kore."
+                    type="info"
+                    showIcon
+                    style={{ marginBottom: '20px' }}
+                  />
+                  <Form.Item labelAlign="left" labelCol={{ span: 2 }} wrapperCol={{ span: 6 }} label="Email" help="Email for teams who need access to project credentails">
+                    <Input placeholder="Title" />
+                  </Form.Item>
+                </>
+              ) : null}
 
-              {targets.map(target => (
-                <Card style={{ marginTop: '20px' }} key={target.id}>
-                  <Title level={4} style={{ display: 'inline', marginRight: '10px' }}>{target.title}</Title>
-                  <IconTooltip icon="info-circle" text={target.description} />
-                  <Tag style={{ marginLeft: '15px' }}>{target.id}</Tag>
-                  <Text strong style={{ fontSize: '16px', display: 'block', marginBottom: '5px', marginTop: '10px' }}>Cluster plans</Text>
-                  <Row gutter={16}>
-                    <CloudPlans imageFilename="GCP.png" cloudName="Google Cloud Platform" plans={target.plans.GKE} />
-                    <CloudPlans imageFilename="AWS.png" cloudName="Amazon Web Services" plans={target.plans.EKS} />
-                    <CloudPlans imageFilename="Azure.svg" cloudName="Microsoft Azure" plans={target.plans.AKS} />
-                  </Row>
-                </Card>
-              ))}
+              {gcpManagementType === 'KORE' ? (
+                <>
+                  <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>Configure GCP project automation</Paragraph>
+                  <Alert
+                    message="This defines how Kore will automate GCP projects for teams"
+                    description="When a team is created in Kore and a cluster is requested, Kore will ensure the GCP project is also created and the cluster placed inside it. You must also specify the plans available for each type of project, this is to ensure the correct cluster specification is being used."
+                    type="info"
+                    showIcon
+                    style={{ marginBottom: '20px' }}
+                  />
 
+                  <div style={{ marginBottom: '15px' }}>
+                    <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>How do you want Kore to automate GCP projects for teams?</Paragraph>
+                    <Radio.Group onChange={this.selectGcpProjectAutomationType} value={gcpProjectAutomationType}>
+                      <Radio value={'CLUSTER'} style={{ marginRight: '20px' }}>
+                        <Text style={{ fontSize: '16px', fontWeight: '600' }}>One per cluster</Text>
+                        <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will create a GCP project for each cluster a team provisions</Paragraph>
+                      </Radio>
+                      <Radio value={'CUSTOM'}>
+                        <Text style={{ fontSize: '16px', fontWeight: '600' }}>Custom</Text>
+                        <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Configure how Kore will create GCP projects for teams</Paragraph>
+                      </Radio>
+                    </Radio.Group>
+                  </div>
+
+                  {gcpProjectAutomationType === 'CLUSTER' ? (
+                    <Alert
+                      message="For every cluster a team creates Kore will also create a GCP project and provision the cluster inside it. The GCP project will share the name given to the cluster."
+                      type="info"
+                      showIcon
+                      style={{ marginBottom: '20px' }}
+                    />
+                  ) : null}
+
+                  {gcpProjectAutomationType === 'CUSTOM' ? (
+                    <>
+                      <Alert
+                        message="When a team is created in Kore and a cluster is requested, Kore will ensure the associated GCP project is also created and the cluster placed inside it. You must also specify the plans available for each type of project, this is to ensure the correct cluster specification is being used."
+                        type="info"
+                        showIcon
+                        style={{ marginBottom: '20px' }}
+                      />
+                      <Button type="primary" onClick={this.addProject(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
+                      <List
+                        itemLayout="vertical"
+                        bordered={true}
+                        dataSource={gcpProjectList}
+                        renderItem={project => (
+                          <List.Item actions={[<a key="delete" onClick={this.deleteGcpProject(project.code)}><Icon type="delete" /> Remove</a>]}>
+                            <List.Item.Meta
+                              title={<Text editable={{ onChange: this.onChange(project.code, 'title') }} style={{ fontSize: '16px' }}>{project.title}</Text>}
+                              description={<Text editable={{ onChange: this.onChange(project.code, 'description') }}>{project.description}</Text>}
+                            />
+
+                            <Row gutter={16}>
+                              <Col span={8}>
+                                <Card
+                                  title="Naming"
+                                  size="small"
+                                  bordered={false}
+                                >
+                                  <Paragraph>The project will be named using the team name, with the prefix and suffix below</Paragraph>
+                                  <Row style={{ padding: '5px 0' }}>
+                                    <Col span={8}>
+                                Prefix
+                                    </Col>
+                                    <Col span={16}>
+                                      <Text editable={{ onChange: this.onChange(project.code, 'prefix') }}>{project.prefix}</Text>
+                                    </Col>
+                                  </Row>
+                                  <Row style={{ padding: '5px 0' }}>
+                                    <Col span={8}>
+                                Suffix
+                                    </Col>
+                                    <Col span={16}>
+                                      <Text editable={{ onChange: this.onChange(project.code, 'suffix') }}>{project.suffix}</Text>
+                                    </Col>
+                                  </Row>
+                                  <Row style={{ paddingTop: '15px' }}>
+                                    <Col span={8}>
+                                Example
+                                    </Col>
+                                    <Col span={16}>
+                                      <Text>{project.prefix}-<span style={{ fontStyle: 'italic' }}>team-name</span>-{project.suffix}</Text>
+                                    </Col>
+                                  </Row>
+                                </Card>
+                              </Col>
+                              <Col span={8}>
+                                <Card
+                                  title="Cluster plans"
+                                  size="small"
+                                  bordered={false}
+                                >
+                                  <Paragraph>The cluster plans associated with this project.</Paragraph>
+                                  {project.plans.length === 0 ? <div style={{ padding: '5px 0' }}>No plans</div> : null}
+                                  {(plans || []).filter(p => project.plans.includes(p.metadata.name)).map((plan, i) => (
+                                    <div key={i} style={{ padding: '5px 0' }}>
+                                      <Text style={{ marginRight: '10px' }}>{plan.spec.description}</Text>
+                                      <this.IconTooltip icon="info-circle" text={plan.spec.summary} />
+                                      <this.IconTooltipButton icon="eye" text="View plan" onClick={this.showPlanDetails(plan)} />
+                                      <this.IconTooltipButton icon="delete" text="Unassociate plan" onClick={this.unassociatePlan(project.code, plan.metadata.name)} />
+                                    </div>
+                                  ))}
+                                  <div style={{ padding: '5px 0' }}>
+
+                                    <Popover
+                                      content={this.associatePlanContent(project.code, 'GKE')}
+                                      title={`${project.title}: Associate plans`}
+                                      trigger="click"
+                                      visible={associatePlanVisible === project.code}
+                                      onVisibleChange={this.handleAssociatePlanVisibleChange(project.code)}
+                                    >
+                                      <a>+ Associate plan</a>
+                                    </Popover>
+                                  </div>
+                                </Card>
+                              </Col>
+                            </Row>
+
+                          </List.Item>
+                        )}
+                      />
+                      {addProject ? (
+                        <Drawer
+                          title={<Title level={4}>New project</Title>}
+                          visible={addProject}
+                          onClose={this.addProject(false)}
+                          width={700}
+                        >
+                          <AutomatedProjectForm handleSubmit={this.handleProjectAdded} handleCancel={this.addProject(false)} />
+                        </Drawer>
+                      ) : null}
+                    </>
+
+                  ) : null}
+                </>
+              ) : null}
+
+
+              {/*{gcpProjectAutomationType === 'CLUSTER'}*/}
             </Card>
+
           </Tabs.TabPane>
           <Tabs.TabPane tab="Setting 2" key="2" />
           <Tabs.TabPane tab="Setting 3" key="3" />

--- a/ui/pages/prototype/index.js
+++ b/ui/pages/prototype/index.js
@@ -3,13 +3,13 @@ import { Typography, List, Button } from 'antd'
 const { Title, Text } = Typography
 
 const prototypeList = [{
-  title: 'Team settings',
-  description: 'Configure teams settings, such as targets available for teams',
-  path: '/prototype/configure/settings'
-}, {
   title: 'Setup wizard',
   description: 'Setup Kore cloud access and team project settings for GCP',
   path: '/prototype/setup/kore'
+}, {
+  title: 'Team settings',
+  description: 'Configure teams settings, such as targets available for teams',
+  path: '/prototype/configure/settings'
 }, {
   title: 'Security',
   description: 'Review the security posture of all Kore-provisioned clusters and plans',

--- a/ui/pages/prototype/setup/kore/cloud-access.js
+++ b/ui/pages/prototype/setup/kore/cloud-access.js
@@ -1,89 +1,20 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import Link from 'next/link'
-import { Typography, Card, Alert, Divider, Radio, List, Icon, Tooltip, Steps, Button, Row, Col, Modal , Drawer, Form, Input, Popover, Result } from 'antd'
+import { Typography, Card, Alert, Divider, Tooltip, Radio, List, Icon, Steps, Button, Row, Col, Modal , Drawer, Form, Input, Popover, Result } from 'antd'
 const { Title, Text, Paragraph } = Typography
 const { Step } = Steps
 
 import copy from '../../../../lib/utils/object-copy'
 import canonical from '../../../../lib/utils/canonical'
 import KoreApi from '../../../../lib/kore-api'
-import GCPOrganizationsList from '../../../../lib/components/configure/GCPOrganizationsList'
 import GKECredentialsList from '../../../../lib/components/configure/GKECredentialsList'
 import PlanList from '../../../../lib/components/configure/PlanList'
 import PlanViewer from '../../../../lib/components/configure/PlanViewer'
 import CloudSelector from '../../../../lib/components/cluster-build/CloudSelector'
-import FormErrorMessage from '../../../../lib/components/forms/FormErrorMessage'
 
-class ProjectForm extends React.Component {
-  static propTypes = {
-    form: PropTypes.object.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    handleCancel: PropTypes.func.isRequired,
-  }
-
-  state = {
-    submitting: false,
-    formErrorMessage: false
-  }
-
-  handleSubmit = (e) => {
-    e.preventDefault()
-    this.setState({ submitting: true })
-    this.props.form.validateFields((err, values) => {
-      if (err) {
-        this.setState({ submitting: false, formErrorMessage: 'Validation failed' })
-        return
-      }
-      this.props.handleSubmit(values)
-    })
-  }
-
-  fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
-
-  render() {
-    const { getFieldDecorator } = this.props.form
-    const formConfig = {
-      layout: 'horizontal',
-      labelAlign: 'left',
-      hideRequiredMark: true,
-      labelCol: { span: 8 },
-      wrapperCol: { span: 16 }
-    }
-    return (
-      <>
-        <FormErrorMessage message={this.state.formErrorMessage} />
-        <Form { ...formConfig } onSubmit={this.handleSubmit}>
-          <Form.Item label="Title" help={this.fieldError('title') || ''}>
-            {getFieldDecorator('title', { rules: [{ required: true, message: 'Please enter the title!' }] })(
-              <Input placeholder="Title" />
-            )}
-          </Form.Item>
-          <Form.Item label="Description" help={this.fieldError('description') || ''}>
-            {getFieldDecorator('description', { rules: [{ required: true, message: 'Please enter the description!' }] })(
-              <Input placeholder="Description" />
-            )}
-          </Form.Item>
-          <Form.Item label="Prefix" help={this.fieldError('prefix') || 'The project ID prefix'}>
-            {getFieldDecorator('prefix', { initialValue: 'kore' })(
-              <Input placeholder="Prefix" />
-            )}
-          </Form.Item>
-          <Form.Item label="Suffix" help={this.fieldError('suffix') || 'The project ID suffix'}>
-            {getFieldDecorator('suffix', { rules: [{ required: true, message: 'Please enter the suffix!' }] })(
-              <Input placeholder="Suffix" />
-            )}
-          </Form.Item>
-          <Form.Item>
-            <Button type="primary" htmlType="submit" loading={this.state.submitting}>Save</Button>
-            <Button type="link" onClick={this.props.handleCancel}>Cancel</Button>
-          </Form.Item>
-        </Form>
-      </>
-    )
-  }
-}
-const WrappedProjectForm = Form.create({ name: 'project_form' })(ProjectForm)
+// prototype components
+import GCPOrganizationsList from '../../../../lib/prototype/components/credentials/GCPOrganizationsList'
+import AutomatedProjectForm from '../../../../lib/prototype/components/configure/AutomatedProjectForm'
 
 class CloudAccessPage extends React.Component {
 
@@ -306,15 +237,15 @@ class CloudAccessPage extends React.Component {
           <Card>
 
             <div style={{ marginBottom: '15px' }}>
-              <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>How do you want Kore to integrate with GCP projects?</Paragraph>
+              <Paragraph style={{ fontSize: '16px', fontWeight: '600' }}>How do you want Kore teams to integrate with GCP projects?</Paragraph>
               <Radio.Group onChange={this.selectGcpManagementType} value={gcpManagementType} disabled={stepsKoreManagedComplete || stepsExistingComplete}>
                 <Radio value={'KORE'} style={{ marginRight: '20px' }}>
-                  <Text style={{ fontSize: '16px', fontWeight: '600' }}>Kore managed <Text type="secondary">(recommended)</Text></Text>
-                  <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will manage the lifecycle of GCP projects along with Kore teams</Paragraph>
+                  <Text style={{ fontSize: '16px', fontWeight: '600' }}>Kore managed projects <Text type="secondary">(recommended)</Text></Text>
+                  <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will manage the GCP projects required for teams and their clusters</Paragraph>
                 </Radio>
                 <Radio value={'EXTERNAL'}>
-                  <Text style={{ fontSize: '16px', fontWeight: '600' }}>Use existing</Text>
-                  <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore will use existing GCP projects that it&apos;s given access to</Paragraph>
+                  <Text style={{ fontSize: '16px', fontWeight: '600' }}>Use existing projects</Text>
+                  <Paragraph style={{ marginLeft: '24px', marginBottom: '0' }}>Kore teams will use existing GCP projects that it&apos;s given access to</Paragraph>
                 </Radio>
               </Radio.Group>
             </div>
@@ -465,7 +396,7 @@ class CloudAccessPage extends React.Component {
 
                                           <Popover
                                             content={this.associatePlanContent(project.code)}
-                                            title={`${project.title}: associate plans`}
+                                            title={`${project.title}: Associate plans`}
                                             trigger="click"
                                             visible={associatePlanVisible === project.code}
                                             onVisibleChange={this.handleAssociatePlanVisibleChange(project.code)}
@@ -487,7 +418,7 @@ class CloudAccessPage extends React.Component {
                                 onClose={this.addProject(false)}
                                 width={700}
                               >
-                                <WrappedProjectForm handleSubmit={this.handleProjectAdded} handleCancel={this.addProject(false)} />
+                                <AutomatedProjectForm handleSubmit={this.handleProjectAdded} handleCancel={this.addProject(false)} />
                               </Drawer>
                             ) : null}
                           </>


### PR DESCRIPTION
* setup wizard - don't show allocations on GCP organization credentials
* this required copying all the various GCP Organization components to the prototypes directories to make changes
* amending team settings inline with the setup wizard