### PR TITLE
Config reshuffle

### DIFF
--- a/ui/__tests__/api-test-helpers.js
+++ b/ui/__tests__/api-test-helpers.js
@@ -8,7 +8,7 @@ class ApiTestHelpers {
   static basePath = null
 
   static getScope = () => {
-    const u = url.parse(config.koreApi.url)
+    const u = url.parse(config.api.url)
     ApiTestHelpers.basePath = u.path
     const spec = JSON.parse((fs.readFileSync(path.join(__dirname, '../kore-api-swagger.json'))).toString())
   

--- a/ui/__tests__/unit/pages/_app.test.js
+++ b/ui/__tests__/unit/pages/_app.test.js
@@ -10,10 +10,6 @@ jest.mock('../../../lib/utils/redirect')
 jest.mock('axios')
 
 describe('App', () => {
-  const config = {
-    apiUrl: 'http://localhost:10080',
-    featureGates: {}
-  }
 
   beforeEach(() => {
     OrgService.mockClear()
@@ -45,27 +41,25 @@ describe('App', () => {
           expect(userSession.user).toBe(undefined)
         })
 
-        it('refreshes the user object and returns it, along with the config', async () => {
+        it('refreshes the user object and returns it', async () => {
           const userSession = await App.getUserSession({ req })
           expect(OrgService).toHaveBeenCalledTimes(1)
           const mockOrgServiceInstance = OrgService.mock.instances[0]
           const mockRefreshUser = mockOrgServiceInstance.refreshUser
           expect(mockRefreshUser).toHaveBeenCalledWith(req.session.passport.user)
-          expect(userSession.user).toEqual(req.session.passport.user)
-          expect(userSession.config).toEqual(config)
+          expect(userSession).toEqual(req.session.passport.user)
         })
 
       })
 
       describe('CSR::no request present', () => {
-        test('makes request to get user session and config', async () => {
-          axios.get.mockResolvedValue({ data: { user: sessionUser, config } })
+        test('makes request to get user session', async () => {
+          axios.get.mockResolvedValue({ data: sessionUser })
 
           const userSession = await App.getUserSession({ asPath: '/requested-path' })
           expect(axios.get).toHaveBeenCalledTimes(1)
           expect(axios.get).toHaveBeenCalledWith(`${window.location.origin}/session/user?requestedPath=/requested-path`)
-          expect(userSession.user).toEqual(sessionUser)
-          expect(userSession.config).toEqual(config)
+          expect(userSession).toEqual(sessionUser)
         })
 
         it('returns false if an error occurred', async () => {
@@ -93,7 +87,7 @@ describe('App', () => {
       const getUserSessionOriginal = App.getUserSession
 
       beforeEach(() => {
-        App.getUserSession = jest.fn().mockResolvedValue({ user, config })
+        App.getUserSession = jest.fn().mockResolvedValue(user)
       })
 
       afterEach(() => {
@@ -140,8 +134,7 @@ describe('App', () => {
           pageProps: { myProp: 'myValue' },
           user,
           userTeams: [teamObj('team1'), teamObj('team2')],
-          otherTeams: [teamObj('team3')],
-          config
+          otherTeams: [teamObj('team3')]
         })
       })
 
@@ -158,13 +151,12 @@ describe('App', () => {
         }
         const props = await App.getInitialProps(params)
         expect(params.Component.getInitialProps).toHaveBeenCalledTimes(1)
-        expect(params.Component.getInitialProps).toHaveBeenCalledWith({ ...params.ctx, config })
+        expect(params.Component.getInitialProps).toHaveBeenCalledWith(params.ctx)
         expect(props).toEqual({
           pageProps: { myProp: 'myValue', ...initialProps },
           user,
           userTeams: [teamObj('team1'), teamObj('team2')],
-          otherTeams: [teamObj('team3')],
-          config
+          otherTeams: [teamObj('team3')]
         })
       })
     })

--- a/ui/config.js
+++ b/ui/config.js
@@ -32,14 +32,13 @@ function getFeatureGates() {
   return featureGates
 }
 
+// this config should be exposed to the server only and can contain necessary secrets set via environment variables
 module.exports = {
-  server: {
-    port: process.env.PORT || '3000',
-    session: {
-      sessionSecret: process.env.SESSION_SECRET || 'sessionsecret',
-      url: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
-      ttlInSeconds: 1200
-    }
+  port: process.env.PORT || '3000',
+  session: {
+    sessionSecret: process.env.SESSION_SECRET || 'sessionsecret',
+    url: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+    ttlInSeconds: 1200
   },
   auth: {
     embedded: process.env.KORE_UI_USE_EMBEDDED_AUTH === 'true' || false,
@@ -52,17 +51,17 @@ module.exports = {
       userClaimsOrder: process.env.KORE_IDP_USER_CLAIMS || 'preferred_username,email,name,username'
     }
   },
+  api: {
+    url: process.env.KORE_API_URL || 'http://localhost:10080/api/v1alpha1',
+    token: process.env.KORE_API_TOKEN || 'password',
+    publicUrl: process.env.KORE_API_PUBLIC_URL || 'http://localhost:10080'
+  },
   kore: {
     baseUrl: process.env.KORE_BASE_URL || 'http://localhost:3000',
     koreAdminTeamName: 'kore-admin',
     ignoreTeams: ['kore-admin', 'kore-default'],
     gtmId: 'GTM-T9THH55',
+    showPrototypes: process.env.NODE_ENV === 'development' || process.env.KORE_UI_SHOW_PROTOTYPES === 'true',
     featureGates: getFeatureGates()
-  },
-  koreApi: {
-    url: process.env.KORE_API_URL || 'http://localhost:10080/api/v1alpha1',
-    publicUrl: process.env.KORE_API_PUBLIC_URL || 'http://localhost:10080',
-    token: process.env.KORE_API_TOKEN || 'password'
-  },
-  showPrototypes: process.env.NODE_ENV === 'development' || process.env.KORE_UI_SHOW_PROTOTYPES === 'true'
+  }
 }

--- a/ui/config.public.js
+++ b/ui/config.public.js
@@ -1,0 +1,16 @@
+const config = require('./config')
+
+// pick vales from the config which can be exposed to the client
+// should contain nothing secret
+module.exports = {
+  koreApiPublicUrl: config.api.publicUrl,
+  koreBaseUrl: config.kore.baseUrl,
+  koreAdminTeamName: config.kore.koreAdminTeamName,
+  ignoreTeams: config.kore.ignoreTeams,
+  sessionTtlInSeconds: config.session.ttlInSeconds,
+  authOpenidUrl: config.auth.openid.url,
+  authOpenidCallbackUrl: config.auth.openid.callbackURL,
+  gtmId: config.kore.gtmId,
+  showPrototypes: config.kore.showPrototypes,
+  featureGates: config.kore.featureGates
+}

--- a/ui/jest.setup.js
+++ b/ui/jest.setup.js
@@ -1,4 +1,6 @@
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
+import { setConfig } from 'next/config'
 
 configure({ adapter: new Adapter() })
+setConfig({ publicRuntimeConfig: require('./config.public') })

--- a/ui/lib/components/configure/EKSCredentialsList.js
+++ b/ui/lib/components/configure/EKSCredentialsList.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
 import { Typography, List, Button, Drawer, Alert, Icon } from 'antd'
 const { Title } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
-import { kore } from '../../../config'
 import ResourceList from '../configure/ResourceList'
 import EKSCredentialsForm from '../forms/EKSCredentialsForm'
 import EKSCredentials from '../team/EKSCredentials'
@@ -21,10 +22,10 @@ class EKSCredentialsList extends ResourceList {
     const api = await KoreApi.client()
     const [ allTeams, eksCredentials, allAllocations ] = await Promise.all([
       api.ListTeams(),
-      api.ListEKSCredentials(kore.koreAdminTeamName),
-      api.ListAllocations(kore.koreAdminTeamName)
+      api.ListEKSCredentials(publicRuntimeConfig.koreAdminTeamName),
+      api.ListAllocations(publicRuntimeConfig.koreAdminTeamName)
     ])
-    allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    allTeams.items = allTeams.items.filter(t => !publicRuntimeConfig.ignoreTeams.includes(t.metadata.name))
     eksCredentials.items.forEach(eks => {
       eks.allocation = (allAllocations.items || []).find(alloc => alloc.metadata.name === eks.metadata.name)
     })
@@ -56,7 +57,7 @@ class EKSCredentialsList extends ResourceList {
                   handleUpdate={this.handleStatusUpdated}
                   refreshMs={2000}
                   propsResourceDataKey="eksCredentials"
-                  resourceApiPath={`/teams/${kore.koreAdminTeamName}/ekscredentials/${eks.metadata.name}`}
+                  resourceApiPath={`/teams/${publicRuntimeConfig.koreAdminTeamName}/ekscredentials/${eks.metadata.name}`}
                 />
               }
             >
@@ -70,7 +71,7 @@ class EKSCredentialsList extends ResourceList {
                 width={700}
               >
                 <EKSCredentialsForm
-                  team={kore.koreAdminTeamName}
+                  team={publicRuntimeConfig.koreAdminTeamName}
                   allTeams={allTeams}
                   data={edit}
                   handleSubmit={this.handleEditSave}
@@ -85,7 +86,7 @@ class EKSCredentialsList extends ResourceList {
                 width={700}
               >
                 <EKSCredentialsForm
-                  team={kore.koreAdminTeamName}
+                  team={publicRuntimeConfig.koreAdminTeamName}
                   allTeams={allTeams}
                   handleSubmit={this.handleAddSave}
                 />

--- a/ui/lib/components/configure/GCPOrganizationsList.js
+++ b/ui/lib/components/configure/GCPOrganizationsList.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
 import { Typography, List, Button, Drawer, Icon, Alert } from 'antd'
 const { Title } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
-import { kore } from '../../../config'
 import GCPOrganization from '../team/GCPOrganization'
 import ResourceList from '../configure/ResourceList'
 import GCPOrganizationForm from '../forms/GCPOrganizationForm'
@@ -21,10 +22,10 @@ class GCPOrganizationsList extends ResourceList {
     const api = await KoreApi.client()
     const [ allTeams, gcpOrganizations, allAllocations ] = await Promise.all([
       api.ListTeams(),
-      api.ListGCPOrganizations(kore.koreAdminTeamName),
-      api.ListAllocations(kore.koreAdminTeamName)
+      api.ListGCPOrganizations(publicRuntimeConfig.koreAdminTeamName),
+      api.ListAllocations(publicRuntimeConfig.koreAdminTeamName)
     ])
-    allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    allTeams.items = allTeams.items.filter(t => !publicRuntimeConfig.ignoreTeams.includes(t.metadata.name))
     gcpOrganizations.items.forEach(org => {
       org.allocation = (allAllocations.items || []).find(alloc => alloc.metadata.name === org.metadata.name)
     })
@@ -56,7 +57,7 @@ class GCPOrganizationsList extends ResourceList {
                   handleUpdate={this.handleStatusUpdated}
                   refreshMs={2000}
                   propsResourceDataKey="organization"
-                  resourceApiPath={`/teams/${kore.koreAdminTeamName}/organizations/${org.metadata.name}`}
+                  resourceApiPath={`/teams/${publicRuntimeConfig.koreAdminTeamName}/organizations/${org.metadata.name}`}
                 />
               }
             >
@@ -69,7 +70,7 @@ class GCPOrganizationsList extends ResourceList {
                 width={700}
               >
                 <GCPOrganizationForm
-                  team={kore.koreAdminTeamName}
+                  team={publicRuntimeConfig.koreAdminTeamName}
                   allTeams={allTeams}
                   data={edit}
                   handleSubmit={this.handleEditSave}
@@ -84,7 +85,7 @@ class GCPOrganizationsList extends ResourceList {
                 width={700}
               >
                 <GCPOrganizationForm
-                  team={kore.koreAdminTeamName}
+                  team={publicRuntimeConfig.koreAdminTeamName}
                   allTeams={allTeams}
                   handleSubmit={this.handleAddSave}
                 />

--- a/ui/lib/components/configure/GKECredentialsList.js
+++ b/ui/lib/components/configure/GKECredentialsList.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
 import { Typography, List, Button, Drawer, Alert, Icon } from 'antd'
 const { Title } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
-import { kore } from '../../../config'
 import GKECredentials from '../team/GKECredentials'
 import ResourceList from '../configure/ResourceList'
 import GKECredentialsForm from '../forms/GKECredentialsForm'
@@ -21,10 +22,10 @@ class GKECredentialsList extends ResourceList {
     const api = await KoreApi.client()
     const [ allTeams, gkeCredentials, allAllocations ] = await Promise.all([
       api.ListTeams(),
-      api.ListGKECredentials(kore.koreAdminTeamName),
-      api.ListAllocations(kore.koreAdminTeamName)
+      api.ListGKECredentials(publicRuntimeConfig.koreAdminTeamName),
+      api.ListAllocations(publicRuntimeConfig.koreAdminTeamName)
     ])
-    allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    allTeams.items = allTeams.items.filter(t => !publicRuntimeConfig.ignoreTeams.includes(t.metadata.name))
     gkeCredentials.items.forEach(gke => {
       gke.allocation = (allAllocations.items || []).find(alloc => alloc.metadata.name === gke.metadata.name)
     })
@@ -56,7 +57,7 @@ class GKECredentialsList extends ResourceList {
                   handleUpdate={this.handleStatusUpdated}
                   refreshMs={2000}
                   propsResourceDataKey="gkeCredentials"
-                  resourceApiPath={`/teams/${kore.koreAdminTeamName}/gkecredentials/${gke.metadata.name}`}
+                  resourceApiPath={`/teams/${publicRuntimeConfig.koreAdminTeamName}/gkecredentials/${gke.metadata.name}`}
                 />
               }
             >
@@ -69,7 +70,7 @@ class GKECredentialsList extends ResourceList {
                 width={700}
               >
                 <GKECredentialsForm
-                  team={kore.koreAdminTeamName}
+                  team={publicRuntimeConfig.koreAdminTeamName}
                   allTeams={allTeams}
                   data={edit}
                   handleSubmit={this.handleEditSave}
@@ -84,7 +85,7 @@ class GKECredentialsList extends ResourceList {
                 width={700}
               >
                 <GKECredentialsForm
-                  team={kore.koreAdminTeamName}
+                  team={publicRuntimeConfig.koreAdminTeamName}
                   allTeams={allTeams}
                   handleSubmit={this.handleAddSave}
                 />

--- a/ui/lib/components/forms/AllocationsFormItem.js
+++ b/ui/lib/components/forms/AllocationsFormItem.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Select, Radio, Alert } from 'antd'
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 import KoreApi from '../../kore-api'
-import { kore } from '../../../config'
 
 export default class AllocationsFormItem extends React.Component {
   static propTypes = {
@@ -25,7 +26,7 @@ export default class AllocationsFormItem extends React.Component {
         teams = await (await KoreApi.client()).ListTeams()
       }
       this.setState({
-        allTeams: teams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+        allTeams: teams.items.filter(t => !publicRuntimeConfig.ignoreTeams.includes(t.metadata.name))
       })
     })
   }

--- a/ui/lib/components/policies/PolicyForm.js
+++ b/ui/lib/components/policies/PolicyForm.js
@@ -1,6 +1,8 @@
 import * as React from 'react'
-import { Card, Alert, Form, Input, Button } from 'antd'
 import PropTypes from 'prop-types'
+import { Card, Alert, Form, Input, Button } from 'antd'
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 import KoreApi from '../../kore-api'
 import V1PlanPolicy from '../../kore-api/model/V1PlanPolicy'
@@ -11,7 +13,6 @@ import canonical from '../../utils/canonical'
 import Policy from './Policy'
 import AllocationsFormItem from '../forms/AllocationsFormItem'
 import AllocationHelpers  from '../../utils/allocation-helpers'
-import config from '../../../config'
 
 class PolicyForm extends React.Component {
   static propTypes = {
@@ -82,7 +83,7 @@ class PolicyForm extends React.Component {
 
     const meta = new V1ObjectMeta()
     meta.setName(metadataName)
-    meta.setNamespace(config.kore.koreAdminTeamName)
+    meta.setNamespace(publicRuntimeConfig.koreAdminTeamName)
     resource.setMetadata(meta)
 
     const spec = new V1PlanPolicySpec()

--- a/ui/lib/components/policies/PolicyList.js
+++ b/ui/lib/components/policies/PolicyList.js
@@ -2,13 +2,14 @@ import PropTypes from 'prop-types'
 import moment from 'moment'
 import { message, Avatar, List, Alert, Icon, Drawer, Typography, Button, Tooltip, Modal } from 'antd'
 const { Title, Text, Paragraph } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 import ResourceList from '../configure/ResourceList'
 import KoreApi from '../../kore-api'
 import Policy from './Policy'
 import PolicyForm from './PolicyForm'
 import AllocationHelpers from '../../utils/allocation-helpers'
-import config from '../../../config'
 
 class PolicyList extends ResourceList {
   static propTypes = {
@@ -20,7 +21,7 @@ class PolicyList extends ResourceList {
     const api = await KoreApi.client()
     const [ policyList, allAllocations ] = await Promise.all([
       api.ListPlanPolicies(this.props.kind),
-      api.ListAllocations(config.kore.koreAdminTeamName)
+      api.ListAllocations(publicRuntimeConfig.koreAdminTeamName)
     ])
     policyList.items.forEach((p) => {
       p.allocation = AllocationHelpers.findAllocationForResource(allAllocations, p)

--- a/ui/lib/crd/IDPClient.js
+++ b/ui/lib/crd/IDPClient.js
@@ -1,4 +1,4 @@
-const { auth, kore } = require('../../config')
+const config = require('../../config')
 
 module.exports = {
   apiVersion: 'core.kore.appvia.io/v1',
@@ -8,8 +8,8 @@ module.exports = {
   },
   spec: {
     displayName: 'Kore UI',
-    secret: auth.openid.clientSecret,
-    id: auth.openid.clientID,
-    redirectURIs: [`${kore.baseUrl}/auth/callback`]
+    secret: config.auth.openid.clientSecret,
+    id: config.auth.openid.clientID,
+    redirectURIs: [`${config.kore.baseUrl}/auth/callback`]
   }
 }

--- a/ui/lib/crd/User.js
+++ b/ui/lib/crd/User.js
@@ -1,5 +1,5 @@
 const axios = require('axios')
-const { koreApi } = require('../../config')
+const config = require('../../config')
 
 const template = (user) => ({
   apiVersion: 'org.kore.appvia.io/v1',
@@ -19,10 +19,10 @@ module.exports = async (user) => {
   try {
     const requestOptions = {
       headers: {
-        'Authorization': `Bearer ${koreApi.token}`
+        'Authorization': `Bearer ${config.api.token}`
       }
     }
-    const userResult = await axios.get(`${koreApi.url}/users/${user.id}`, requestOptions)
+    const userResult = await axios.get(`${config.api.url}/users/${user.id}`, requestOptions)
     console.info('*** user found', userResult.data)
     return userResult.data
   } catch (err) {

--- a/ui/lib/kore-api/index.js
+++ b/ui/lib/kore-api/index.js
@@ -48,7 +48,7 @@ class KoreApi {
     if (KoreApi.spec) { 
       return KoreApi.spec 
     }
-    const u = url.parse(config.koreApi.url)
+    const u = url.parse(config.api.url)
     KoreApi.basePath = u.path
     if (process.browser) {
       KoreApi.swaggerUrl = `${window.location.origin}/swagger.json`

--- a/ui/lib/utils/api-request.js
+++ b/ui/lib/utils/api-request.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import redirect from './redirect'
-import { koreApi } from '../../config'
+import config from '../../config'
 import checkUserExpired from '../../server/lib/user-expired'
 
 export default async (reqRes, method, apiPath, body, options) => {
@@ -15,7 +15,7 @@ export default async (reqRes, method, apiPath, body, options) => {
       return res.redirect('/login/refresh')
     }
   }
-  let url = req ? `${koreApi.url}${apiPath}` : `${window.location.origin}/apiproxy${apiPath}`
+  let url = req ? `${config.api.url}${apiPath}` : `${window.location.origin}/apiproxy${apiPath}`
   try {
     console.info('Making api request', method, url)
     const result = await axios[method](

--- a/ui/lib/utils/gtag.js
+++ b/ui/lib/utils/gtag.js
@@ -1,4 +1,4 @@
-import { kore } from '../../config'
+import config from '../../config'
 
 function pageView(url) {
   window.dataLayer = window.dataLayer || []
@@ -9,6 +9,6 @@ function pageView(url) {
 }
 
 module.exports = {
-  GTM_ID: kore.gtmId,
+  GTM_ID: config.kore.gtmId,
   pageView
 }

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -2,6 +2,7 @@ const withLess = require('@zeit/next-less')
 const lessToJS = require('less-vars-to-js')
 const fs = require('fs')
 const path = require('path')
+const publicConfig = require('./config.public')
 
 // Where your antd-custom.less file lives
 const themeVariables = lessToJS(
@@ -38,4 +39,5 @@ module.exports = withLess({
     }
     return config
   },
+  publicRuntimeConfig: publicConfig
 })

--- a/ui/pages/configure/users.js
+++ b/ui/pages/configure/users.js
@@ -2,13 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Typography, List, Avatar, Tag, message } from 'antd'
 const { Text } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 import apiRequest from '../../lib/utils/api-request'
 import apiPaths from '../../lib/utils/api-paths'
 import copy from '../../lib/utils/object-copy'
 import Breadcrumb from '../../lib/components/Breadcrumb'
-
-import { kore } from '../../config'
 
 class ConfigureUsersPage extends React.Component {
   static propTypes = {
@@ -29,7 +29,7 @@ class ConfigureUsersPage extends React.Component {
 
   static getInitialProps = async (ctx) => {
     const users = await apiRequest(ctx, 'get', apiPaths.users)
-    const adminTeamMembers = await apiRequest(ctx, 'get', apiPaths.team(kore.koreAdminTeamName).members)
+    const adminTeamMembers = await apiRequest(ctx, 'get', apiPaths.team(publicRuntimeConfig.koreAdminTeamName).members)
     return {
       users: users.items,
       admins: adminTeamMembers.items
@@ -39,7 +39,7 @@ class ConfigureUsersPage extends React.Component {
   makeAdmin = (username) => {
     return async () => {
       try {
-        await apiRequest(null, 'put', `${apiPaths.team(kore.koreAdminTeamName).members}/${username}`)
+        await apiRequest(null, 'put', `${apiPaths.team(publicRuntimeConfig.koreAdminTeamName).members}/${username}`)
         const state = copy(this.state)
         state.admins.push(username)
         this.setState(state)
@@ -54,7 +54,7 @@ class ConfigureUsersPage extends React.Component {
   revokeAdmin = (username) => {
     return async () => {
       try {
-        await apiRequest(null, 'delete', `${apiPaths.team(kore.koreAdminTeamName).members}/${username}`)
+        await apiRequest(null, 'delete', `${apiPaths.team(publicRuntimeConfig.kore.koreAdminTeamName).members}/${username}`)
         const state = copy(this.state)
         state.admins = state.admins.filter(m => m !== username)
         this.setState(state)

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import { Typography, Statistic, Icon, Row, Col, Card, Alert, Button, Tag } from 'antd'
 const { Title, Paragraph, Text } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 import KoreApi from '../lib/kore-api'
-import { kore } from '../config'
 
 class IndexPage extends React.Component {
   static propTypes = {
@@ -38,10 +39,10 @@ class IndexPage extends React.Component {
       [ allTeams, allUsers, adminMembers, gkeCredentials, gcpOrganizations, eksCredentials ] = await Promise.all([
         api.ListTeams(),
         api.ListUsers(),
-        api.ListTeamMembers(kore.koreAdminTeamName),
-        api.ListGKECredentials(kore.koreAdminTeamName),
-        api.ListGCPOrganizations(kore.koreAdminTeamName),
-        api.ListEKSCredentials(kore.koreAdminTeamName)
+        api.ListTeamMembers(publicRuntimeConfig.koreAdminTeamName),
+        api.ListGKECredentials(publicRuntimeConfig.koreAdminTeamName),
+        api.ListGCPOrganizations(publicRuntimeConfig.koreAdminTeamName),
+        api.ListEKSCredentials(publicRuntimeConfig.koreAdminTeamName)
       ])
     } else {
       [ allTeams, allUsers ] = await Promise.all([
@@ -50,7 +51,7 @@ class IndexPage extends React.Component {
       ])
     }
 
-    allTeams.items = (allTeams.items || []).filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    allTeams.items = (allTeams.items || []).filter(t => !publicRuntimeConfig.ignoreTeams.includes(t.metadata.name))
     return { allTeams, allUsers, adminMembers, gkeCredentials, gcpOrganizations, eksCredentials }
   }
 
@@ -61,7 +62,7 @@ class IndexPage extends React.Component {
 
   render() {
     const { user, allTeams, allUsers, adminMembers, gkeCredentials, gcpOrganizations, eksCredentials, version } = this.props
-    const userTeams = (user.teams.userTeams || []).filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    const userTeams = (user.teams.userTeams || []).filter(t => !publicRuntimeConfig.ignoreTeams.includes(t.metadata.name))
     const noUserTeamsExist = userTeams.length === 0
     const gcpCredsMissing = (gkeCredentials && gkeCredentials.items.length === 0) && (gcpOrganizations && gcpOrganizations.items.length === 0)
     const awsCredsMissing = eksCredentials && eksCredentials.items.length === 0

--- a/ui/pages/setup/authentication/github/index.js
+++ b/ui/pages/setup/authentication/github/index.js
@@ -3,7 +3,9 @@ import axios from 'axios'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import { Typography, Steps, Button, Alert, Form, Input, Card } from 'antd'
-import { auth } from '../../../../config'
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
+
 import CopyTextWithLabel from '../../../../lib/components/CopyTextWithLabel'
 import copy from '../../../../lib/utils/object-copy'
 import redirect from '../../../../lib/utils/redirect'
@@ -45,8 +47,8 @@ class GithubSetupPage extends React.Component {
   static staticProps = {
     title: 'Configure authentication provider',
     hideSider: true,
-    authUrl: auth.openid.url,
-    authCallbackUrl: auth.openid.callbackURL,
+    authUrl: publicRuntimeConfig.authOpenidUrl,
+    authCallbackUrl: publicRuntimeConfig.authOpenidCallbackUrl,
     adminOnly: true
   }
 

--- a/ui/pages/setup/authentication/google/index.js
+++ b/ui/pages/setup/authentication/google/index.js
@@ -2,13 +2,15 @@ import * as React from 'react'
 import axios from 'axios'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
-import { kore, auth } from '../../../../config'
 import { Typography, Steps, Button, Alert, Row, Col, Form, Input, Card, List, Icon } from 'antd'
+const { Step } = Steps
+const { Title, Paragraph, Text } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
+
 import CopyTextWithLabel from '../../../../lib/components/CopyTextWithLabel'
 import copy from '../../../../lib/utils/object-copy'
 import redirect from '../../../../lib/utils/redirect'
-const { Step } = Steps
-const { Title, Paragraph, Text } = Typography
 
 class ConfigureKoreForm extends React.Component {
   static propTypes = {
@@ -43,9 +45,9 @@ class GoogleSetupPage extends React.Component {
   static staticProps = {
     title: 'Configure authentication provider',
     hideSider: true,
-    authUrl: auth.openid.url,
-    authCallbackUrl: auth.openid.callbackURL,
-    baseUrl: kore.baseUrl,
+    authUrl: publicRuntimeConfig.authOpenidUrl,
+    authCallbackUrl: publicRuntimeConfig.authOpenidCallbackUrl,
+    baseUrl: publicRuntimeConfig.koreBaseUrl,
     adminOnly: true
   }
 

--- a/ui/pages/setup/kore/cloud-providers/index.js
+++ b/ui/pages/setup/kore/cloud-providers/index.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types'
 import Router from 'next/router'
 import { Typography, Card } from 'antd'
 const { Title, Paragraph } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 import redirect from '../../../../lib/utils/redirect'
 import copy from '../../../../lib/utils/object-copy'
 import apiRequest from '../../../../lib/utils/api-request'
 import apiPaths from '../../../../lib/utils/api-paths'
-import { kore } from '../../../../config'
 import GKECredentialsForm from '../../../../lib/components/forms/GKECredentialsForm'
 import CloudSelector from '../../../../lib/components/cluster-build/CloudSelector'
 
@@ -29,7 +30,7 @@ class ConfigureCloudProvidersPage extends React.Component {
 
   static getInitialProps = async ctx => {
     const allTeams = await apiRequest(ctx, 'get', apiPaths.teams)
-    allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    allTeams.items = allTeams.items.filter(t => !publicRuntimeConfig.ignoreTeams.includes(t.metadata.name))
     return { allTeams }
   }
 
@@ -61,7 +62,7 @@ class ConfigureCloudProvidersPage extends React.Component {
         </div>
         { selectedCloud === 'GKE' ? (
           <Card title="Enter GKE credentials" style={{ paddingBottom: '0' }}>
-            <GKECredentialsForm team={kore.koreAdminTeamName} allTeams={allTeams} handleSubmit={this.handleFormSubmit} saveButtonText="Save & Verify" inlineVerification={true} />
+            <GKECredentialsForm team={publicRuntimeConfig.koreAdminTeamName} allTeams={allTeams} handleSubmit={this.handleFormSubmit} saveButtonText="Save & Verify" inlineVerification={true} />
           </Card>
         ) : null }
       </div>

--- a/ui/pages/teams/new.js
+++ b/ui/pages/teams/new.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import { Typography, Button, Card, List, Row, Col, Icon, Alert, message, Select, Tooltip } from 'antd'
 const { Title, Paragraph, Text } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 import NewTeamForm from '../../lib/components/forms/NewTeamForm'
 import ClusterBuildForm from '../../lib/components/forms/ClusterBuildForm'
@@ -16,8 +18,7 @@ import KoreApi from '../../lib/kore-api'
 class NewTeamPage extends React.Component {
   static propTypes = {
     user: PropTypes.object.isRequired,
-    teamAdded: PropTypes.func.isRequired,
-    config: PropTypes.object.isRequired
+    teamAdded: PropTypes.func.isRequired
   }
 
   state = {
@@ -97,7 +98,7 @@ class NewTeamPage extends React.Component {
   }
 
   render() {
-    const { user, config } = this.props
+    const { user } = this.props
     const { team, members, membersToAdd, allUsers } = this.state
 
     const membersAvailableToAdd = (allUsers || []).filter(user => !members.includes(user))
@@ -183,7 +184,7 @@ class NewTeamPage extends React.Component {
               />
             </Card>
 
-            {config.featureGates['services'] ? (
+            {publicRuntimeConfig.featureGates['services'] ? (
               <Card title="Create a service for your team" style={{ marginBottom: '30px', marginTop: '20px' }}>
                 <Alert message="Choose a service kind below to create a service" type="info" />
                 <ServiceBuildForm

--- a/ui/server/controllers/apiproxy.js
+++ b/ui/server/controllers/apiproxy.js
@@ -3,7 +3,7 @@ const Router = require('express').Router
 
 const PATH_BLACKLIST = ['/auth']
 
-function apiProxy(koreApi) {
+function apiProxy(koreApiUrl) {
   return async (req, res) => {
     const method = req.method.toLowerCase()
     const apiUrlPath = req.originalUrl.replace('/apiproxy', '')
@@ -14,7 +14,7 @@ function apiProxy(koreApi) {
     }
     try {
       const result = await axios[method](
-        `${koreApi.url}${apiUrlPath}`,
+        `${koreApiUrl}${apiUrlPath}`,
         ['get', 'delete'].includes(method) ? options : req.body,
         ['get', 'delete'].includes(method) ? undefined : options
       )
@@ -40,9 +40,9 @@ function checkBlacklist(req, res, next) {
   next()
 }
 
-function initRouter({ ensureAuthenticated, ensureUserCurrent, koreApi }) {
+function initRouter({ ensureAuthenticated, ensureUserCurrent, koreApiUrl }) {
   const router = Router()
-  router.use('/apiproxy/*', ensureAuthenticated, checkBlacklist, ensureUserCurrent, apiProxy(koreApi))
+  router.use('/apiproxy/*', ensureAuthenticated, checkBlacklist, ensureUserCurrent, apiProxy(koreApiUrl))
   return router
 }
 

--- a/ui/server/controllers/process.js
+++ b/ui/server/controllers/process.js
@@ -2,7 +2,7 @@ const axios = require('axios')
 const Router = require('express').Router
 const apiPaths = require('../../lib/utils/api-paths')
 
-function processTeamInvitation(koreApi) {
+function processTeamInvitation(koreApiUrl) {
   return async (req, res) => {
     const token = req.params.token
     const options = {
@@ -12,7 +12,7 @@ function processTeamInvitation(koreApi) {
       }
     }
     try {
-      const url = koreApi.url + apiPaths.useTeamInvitation(token)
+      const url = koreApiUrl + apiPaths.useTeamInvitation(token)
       const invitationResponse = await axios.put(url, undefined, options)
       let redirectTo = '/'
       if (invitationResponse.data.team) {
@@ -34,9 +34,9 @@ function persistPath(req, res, next) {
   next()
 }
 
-function initRouter({ ensureAuthenticated, ensureUserCurrent, koreApi }) {
+function initRouter({ ensureAuthenticated, ensureUserCurrent, koreApiUrl }) {
   const router = Router()
-  router.get('/process/teams/invitation/:token', persistPath, ensureAuthenticated, ensureUserCurrent, processTeamInvitation(koreApi))
+  router.get('/process/teams/invitation/:token', persistPath, ensureAuthenticated, ensureUserCurrent, processTeamInvitation(koreApiUrl))
   return router
 }
 

--- a/ui/server/controllers/session.js
+++ b/ui/server/controllers/session.js
@@ -1,15 +1,11 @@
 const Router = require('express').Router
 
-function getSessionUser(orgService, config) {
+function getSessionUser(orgService) {
   return async(req, res) => {
     const user = req.session.passport.user
     try {
       await orgService.refreshUser(user)
-      const clientConfig = {
-        apiUrl: config.koreApi.publicUrl,
-        featureGates: config.kore.featureGates
-      }
-      return res.json({ user, config: clientConfig })
+      return res.json(user)
     } catch (err) {
       console.log('Failed to refresh user in /session/user', err)
       return res.status(err.statusCode || 500).send()
@@ -17,16 +13,9 @@ function getSessionUser(orgService, config) {
   }
 }
 
-function getConfig(config) {
-  return (req, res) => {
-    res.json({ apiUrl: config.koreApi.publicUrl })
-  }
-}
-
-function initRouter({ ensureAuthenticated, ensureUserCurrent, persistRequestedPath, orgService, config }) {
+function initRouter({ ensureAuthenticated, ensureUserCurrent, persistRequestedPath, orgService }) {
   const router = Router()
-  router.get('/session/user', ensureAuthenticated, ensureUserCurrent, persistRequestedPath, getSessionUser(orgService, config))
-  router.get('/session/config', ensureAuthenticated, ensureUserCurrent, getConfig(config))
+  router.get('/session/user', ensureAuthenticated, ensureUserCurrent, persistRequestedPath, getSessionUser(orgService))
   return router
 }
 

--- a/ui/server/controllers/swagger.js
+++ b/ui/server/controllers/swagger.js
@@ -2,9 +2,9 @@ const axios = require('axios')
 const Router = require('express').Router
 const url = require('url')
 
-function swagger(koreApi) {
+function swagger(koreApiUrl) {
   return async (req, res) => {
-    const u = url.parse(koreApi.url)
+    const u = url.parse(koreApiUrl)
     const swaggerUrl = `${u.protocol}//${u.host}/swagger.json`
     try {
       const result = await axios['get'](swaggerUrl)
@@ -24,9 +24,9 @@ function swagger(koreApi) {
   }
 }
 
-function initRouter({ koreApi }) {
+function initRouter({ koreApiUrl }) {
   const router = Router()
-  router.use('/swagger.json', swagger(koreApi))
+  router.use('/swagger.json', swagger(koreApiUrl))
   return router
 }
 

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -8,12 +8,12 @@ const app = require('./next')
 const config = require('../config')
 const routes = require('./routes')
 
-const port = config.server.port
+const port = config.port
 
 const RedisStore = require('connect-redis')(session)
-const redisClient = redis.createClient({ url: config.server.session.url })
+const redisClient = redis.createClient({ url: config.session.url })
 
-const nextjsPath = config.showPrototypes ? '*' : /^((?!\/prototype).)*$/
+const nextjsPath = config.kore.showPrototypes ? '*' : /^((?!\/prototype).)*$/
 
 app.prepare().then(() => {
   const server = express()
@@ -24,10 +24,10 @@ app.prepare().then(() => {
   server.use(session({
     store: new RedisStore({
       client: redisClient,
-      url: config.server.session.url,
-      ttl: config.server.session.ttlInSeconds
+      url: config.session.url,
+      ttl: config.session.ttlInSeconds
     }),
-    secret: config.server.session.sessionSecret,
+    secret: config.session.sessionSecret,
     resave: false,
     saveUninitialized: true
   }))

--- a/ui/server/services/org.js
+++ b/ui/server/services/org.js
@@ -1,5 +1,5 @@
 const User = require('../../lib/crd/User')
-const { kore, koreApi } = require('../../config')
+const config = require('../../config')
 
 class OrgService {
   constructor(KoreApi) {
@@ -15,11 +15,11 @@ class OrgService {
     try {
       const userResource = await User(user)
       console.log(`*** putting user ${user.id}`, userResource)
-      const api = await this.getApiClient(koreApi.token)
+      const api = await this.getApiClient(config.api.token)
       const userResult = await api.UpdateUser(user.id, userResource)
-      const adminTeamMembers = await this.getTeamMembers(kore.koreAdminTeamName, koreApi.token)
+      const adminTeamMembers = await this.getTeamMembers(config.kore.koreAdminTeamName, config.api.token)
       if (adminTeamMembers.length === 1) {
-        await this.addUserToTeam(kore.koreAdminTeamName, user.id, koreApi.token)
+        await this.addUserToTeam(config.kore.koreAdminTeamName, user.id, config.api.token)
       }
       userResult.teams = await this.getUserTeams(user)
       userResult.isAdmin = this.isAdmin(userResult.teams.userTeams)
@@ -38,7 +38,7 @@ class OrgService {
   /* eslint-enable require-atomic-updates */
 
   isAdmin(userTeams) {
-    return (userTeams || []).filter(t => t.metadata && t.metadata.name === kore.koreAdminTeamName).length > 0
+    return (userTeams || []).filter(t => t.metadata && t.metadata.name === config.kore.koreAdminTeamName).length > 0
   }
 
   async getTeamMembers(team, requestingIdToken) {


### PR DESCRIPTION
* splitting into config for server and public
* using next config to get config in pages/components
* updating other uses of config
* removing config object from session/user endpoint as this is no longer required

Utilises https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration