### PR TITLE
Fix team existence checking in the Kore CLI

### DIFF
--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -42,8 +42,8 @@ func IsNotFound(err error) bool {
 	return isExpectedError(err, http.StatusNotFound)
 }
 
-// IsNotAuthentication checks if the error as a 401
-func IsNotAuthentication(err error) bool {
+// IsNotAuthorized checks if the error as a 401
+func IsNotAuthorized(err error) bool {
 	return isExpectedError(err, http.StatusUnauthorized)
 }
 

--- a/pkg/cmd/kore/kore.go
+++ b/pkg/cmd/kore/kore.go
@@ -17,7 +17,6 @@
 package kore
 
 import (
-	"os"
 	"strings"
 
 	"github.com/appvia/kore/pkg/client"
@@ -81,28 +80,6 @@ func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
 			}
 
 			log.WithField("profile", cfg.CurrentProfile).Debug("running with the selected profile")
-
-			team := cmdutil.GetTeam(cmd)
-			if team != "" {
-				exists, err := factory.ClientWithResource(factory.Resources().MustLookup("team")).Name(team).Exists()
-				if err != nil {
-					factory.Println("Error: %s\n", err)
-					os.Exit(1)
-				}
-				if !exists {
-					// Let's check whether the current profile has a non-existing team and remove it
-					if cfg.GetCurrentProfile().Team == team {
-						factory.Println("Error: team %q does not exist, please update your profile using\n  $ kore profiles set current.team <EXISTING TEAM>", team)
-						cfg.GetCurrentProfile().Team = ""
-						if err := config.UpdateConfig(cfg, config.GetClientConfigurationPath()); err != nil {
-							factory.Println("Error: %s", err)
-						}
-					} else {
-						factory.Println("Error: team %q does not exist\n", team)
-					}
-					os.Exit(1)
-				}
-			}
 		},
 	}
 

--- a/pkg/cmd/utils/factory.go
+++ b/pkg/cmd/utils/factory.go
@@ -101,7 +101,7 @@ func (f *factory) ClientWithTeamResource(team string, resource Resource) client.
 func (f *factory) CheckError(kerror error) {
 	err := func() error {
 		switch {
-		case client.IsNotAuthentication(kerror):
+		case client.IsNotAuthorized(kerror):
 			return errors.ErrAuthentication
 		case client.IsMethodNotAllowed(kerror):
 			return errors.ErrOperationNotPermitted

--- a/pkg/cmd/utils/wait.go
+++ b/pkg/cmd/utils/wait.go
@@ -66,7 +66,7 @@ func (f *factory) WaitForDeletion(request client.RestInterface, name string, now
 			if client.IsNotAllowed(err) {
 				return false, err
 			}
-			if client.IsNotAuthentication(err) {
+			if client.IsNotAuthorized(err) {
 				return false, err
 			}
 			if client.IsNotFound(err) {
@@ -163,7 +163,7 @@ func (f *factory) WaitForCreation(request client.RestInterface, nowait bool) err
 			if client.IsNotAllowed(err) || client.IsMethodNotAllowed(err) {
 				return false, err
 			}
-			if client.IsNotAuthentication(err) {
+			if client.IsNotAuthorized(err) {
 				return false, err
 			}
 

--- a/pkg/utils/reflect.go
+++ b/pkg/utils/reflect.go
@@ -49,6 +49,11 @@ func IsEqualType(a, b interface{}) bool {
 
 // SetReflectedField checks if the interface has the field
 func SetReflectedField(name string, value, o interface{}) {
+	_ = SetAndValidateReflectedField(name, value, o, nil)
+}
+
+// SetAndValidateReflectedField checks if the interface has the field
+func SetAndValidateReflectedField(name string, value, o interface{}, validate func(value interface{}) error) error {
 	var caller reflect.Value
 
 	if reflect.ValueOf(o).Kind() == reflect.Ptr {
@@ -60,9 +65,18 @@ func SetReflectedField(name string, value, o interface{}) {
 	field := caller.FieldByName(name)
 
 	if !field.IsValid() || !field.CanSet() {
-		return
+		return nil
 	}
+
+	if validate != nil {
+		if err := validate(value); err != nil {
+			return err
+		}
+	}
+
 	field.Set(reflect.ValueOf(value))
+
+	return nil
 }
 
 // HasReflectField checks if a field exists in a interface


### PR DESCRIPTION
## What

If you have a team set in your profile and your local token expired, `kore login` will throw an error saying `Authorization required` instead of logging you in.
This happened because we've always tried to check whether a team exists (if set in your profile).

Fix team existence checking in the Kore CLI:
 * If there are authentication errors, ignore them in the check (this fixes e.g. kore login if the token is expired)
 * Only do the team check when running a command which has a team parameter