### PR TITLE
Separate check step on Circle CI, do not run tests twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,21 @@ e2e_job_template: &E2E_JOB_TEMPLATE
 #
 
 jobs:
+  check:
+    environment:
+      GOFLAGS: "-mod=vendor"
+      USE_GIT_VERSION: "true"
+
+    docker:
+      - image: circleci/golang:1.14
+
+    steps:
+      - checkout
+      - run:
+          name: Check
+          command: |
+            make check
+
   build:
     environment:
       GOFLAGS: "-mod=vendor"
@@ -403,6 +418,10 @@ workflows:
   workflow:
     unless: << pipeline.parameters.enable_e2e >>
     jobs:
+      - check:
+          filters:
+            tags:
+              only: /^v.*$/
       - build:
           filters:
             tags:
@@ -413,6 +432,7 @@ workflows:
               only: /^v.*$/
       - release:
           requires:
+            - check
             - build
             - check-apis
           filters:
@@ -454,6 +474,7 @@ workflows:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+))$/
       - publish-release:
           requires:
+            - check
             - build
             - check-apis
             - check-release-notes

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CLI_PLATFORMS=darwin linux windows
 CLI_ARCHITECTURES=386 amd64
 export GOFLAGS = -mod=vendor
 
-.PHONY: test authors changelog build docker release cover vet glide-install demo golangci-lint apis swagger images
+.PHONY: test authors changelog build docker release check vet glide-install demo golangci-lint apis swagger images
 
 default: build
 
@@ -318,10 +318,6 @@ coverage:
 	@go test -coverprofile cover.out
 	@go tool cover -html=cover.out -o cover.html
 
-cover:
-	@echo "--> Running go cover"
-	@go test --cover $(PACKAGES)
-
 spelling:
 	@echo "--> Checking the spelling"
 	@find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./ui/node_modules/*" | xargs go run github.com/client9/misspell/cmd/misspell -error -source=go *.go
@@ -331,16 +327,18 @@ golangci-lint:
 	@echo "--> Checking against the golangci-lint"
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./...
 
-test: generate-clusterappman-manifests
-	@echo "--> Running the tests"
-	@go test -v $(PACKAGES)
+check: generate-clusterappman-manifests
+	@echo "--> Running code checkers"
 	@$(MAKE) golang
 	@$(MAKE) gofmt
 	@$(MAKE) golangci-lint
 	@$(MAKE) spelling
 	@$(MAKE) vet
-	@$(MAKE) cover
 	@$(MAKE) verify-licences
+
+test: generate-clusterappman-manifests
+	@echo "--> Running the tests"
+	@go test --cover -v $(PACKAGES)
 
 run-api-test:
 	(cd ${ROOT_DIR}/pkg/apiserver; go test -tags=integration -ginkgo.v)

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ docker-build:
 		make in-docker-build
 
 verify-circleci:
-	@echo "--> Verifiying the circleci config"
+	@echo "--> Verifying the circleci config"
 	@docker run -ti --rm -v ${PWD}:/workspace \
 		-w /workspace circleci/circleci-cli \
 		circleci config validate
@@ -310,7 +310,7 @@ bench:
 	@go test -bench=. -benchmem
 
 verify-licences:
-	@echo "--> Verifiying the licence headers"
+	@echo "--> Verifying the licence headers"
 	@hack/verify-licence.sh
 
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,12 @@ build: golang generate-clusterappman-manifests
 		go build -ldflags "${LFLAGS}" -tags=jsoniter -o bin/$${binary} cmd/$${binary}/*.go || exit 1; \
 	done
 
-kore: golang deps
+kore: golang
 	@echo "--> Compiling the kore binary"
 	@mkdir -p bin
 	go build -ldflags "${LFLAGS}" -tags=jsoniter -o bin/kore cmd/kore/*.go
 
-auth-proxy: golang deps
+auth-proxy: golang
 	@echo "--> Compiling the auth-proxy binary"
 	@mkdir -p bin
 	go build -ldflags "${LFLAGS}" -o bin/auth-proxy cmd/auth-proxy/*.go
@@ -77,12 +77,12 @@ auth-proxy-image: golang
 	@echo "--> Build the auth-proxy docker image"
 	docker build -t ${REGISTRY}/${AUTHOR}/auth-proxy:${VERSION} -f images/Dockerfile.auth-proxy .
 
-kore-apiserver: golang deps generate-clusterappman-manifests
+kore-apiserver: golang generate-clusterappman-manifests
 	@echo "--> Compiling the kore-apiserver binary"
 	@mkdir -p bin
 	go build -ldflags "${LFLAGS}" -o bin/kore-apiserver cmd/kore-apiserver/*.go
 
-kore-clusterappman: golang generate-clusterappman-manifests deps
+kore-clusterappman: golang generate-clusterappman-manifests
 	@echo "--> Compiling the kore-clusterappman binary"
 	@mkdir -p bin
 	go build -ldflags "${LFLAGS}" -o bin/kore-clusterappman cmd/kore-clusterappman/*.go
@@ -289,9 +289,6 @@ dep-install:
 	@echo "--> Installing dependencies"
 	@dep ensure -v
 
-deps:
-	@echo "--> Installing build dependencies"
-
 vet:
 	@echo "--> Running go vet $(VETARGS) $(PACKAGES)"
 	@go vet $(VETARGS) $(PACKAGES)
@@ -336,9 +333,6 @@ golangci-lint:
 
 test: generate-clusterappman-manifests
 	@echo "--> Running the tests"
-	@if [ ! -d "vendor" ]; then \
-		make deps; \
-  	fi
 	@go test -v $(PACKAGES)
 	@$(MAKE) golang
 	@$(MAKE) gofmt


### PR DESCRIPTION
## What

I think we were running the tests twice on CircleCI (without and with coverage).

Also I added a separate check job, which runs parallel to the tests (this way we can see linting errors quicker).