### PR TITLE
Create service provider for AWS VPCs

### DIFF
--- a/pkg/apis/eks/v1alpha1/ekscredential_types.go
+++ b/pkg/apis/eks/v1alpha1/ekscredential_types.go
@@ -19,7 +19,15 @@ package v1alpha1
 import (
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// EKSCredentialsGVK is the GroupVersionKind for EKSCredentials
+var EKSCredentialsGVK = schema.GroupVersionKind{
+	Group:   GroupVersion.Group,
+	Version: GroupVersion.Version,
+	Kind:    "EKSCredentials",
+}
 
 // EKSCredentialsSpec defines the desired state of EKSCredential
 // +k8s:openapi-gen=true

--- a/pkg/serviceproviders/aws/vpc/delete.go
+++ b/pkg/serviceproviders/aws/vpc/delete.go
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpc
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/appvia/kore/pkg/kore"
+
+	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (p Provider) Delete(
+	ctx kore.ServiceProviderContext,
+	service *servicesv1.Service,
+) (reconcile.Result, error) {
+	client, err := p.createVPCClient(ctx, service)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("configuration is invalid: %w", err)
+	}
+
+	exists, err := client.Exists()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("checking if vpc exists - %s", err)
+	}
+
+	if exists {
+		ready, err := client.Delete(ctx)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to delete the EKS VPC: %w", err)
+		}
+		if !ready {
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/serviceproviders/aws/vpc/factory.go
+++ b/pkg/serviceproviders/aws/vpc/factory.go
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpc
+
+import (
+	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
+	"github.com/appvia/kore/pkg/kore"
+)
+
+func init() {
+	kore.RegisterServiceProviderFactory(ProviderFactory{})
+}
+
+type ProviderFactory struct{}
+
+func (p ProviderFactory) Type() string {
+	return "aws-vpc"
+}
+
+func (p ProviderFactory) JSONSchema() string {
+	return `{
+		"$id": "https://appvia.io/schemas/serviceprovider/aws-vpc.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"description": "AWS VPC service provider schema",
+		"type": "object",
+		"additionalProperties": false
+	}`
+}
+
+func (p ProviderFactory) CreateProvider(provider servicesv1.ServiceProvider) (kore.ServiceProvider, error) {
+	return Provider{
+		name: provider.Name,
+	}, nil
+}

--- a/pkg/serviceproviders/aws/vpc/helper.go
+++ b/pkg/serviceproviders/aws/vpc/helper.go
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpc
+
+import (
+	"fmt"
+
+	"github.com/appvia/kore/pkg/kore"
+
+	"github.com/appvia/kore/pkg/controllers"
+
+	eksv1alpha1 "github.com/appvia/kore/pkg/apis/eks/v1alpha1"
+	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
+	"github.com/appvia/kore/pkg/utils/cloud/aws"
+)
+
+func (p Provider) createVPCClient(ctx kore.ServiceProviderContext, service *servicesv1.Service) (*aws.VPCClient, error) {
+	ctx.Logger.Debug("retrieving the VPC credentials")
+
+	credentials := &eksv1alpha1.EKSCredentials{}
+	if err := ctx.Client.Get(ctx, service.Spec.Credentials.NamespacedName(), credentials); err != nil {
+		return nil, fmt.Errorf("failed to retrieve EKS credentials: %w", err)
+	}
+
+	var config Configuration
+	if err := service.Spec.GetConfiguration(&config); err != nil {
+		return nil, controllers.NewCriticalError(fmt.Errorf("failed to unmarshal service configuration: %w", err))
+	}
+	if config.Name == "" {
+		config.Name = service.Name
+	}
+
+	return aws.NewVPCClient(aws.Credentials{
+		AccessKeyID:     credentials.Spec.AccessKeyID,
+		SecretAccessKey: credentials.Spec.SecretAccessKey,
+	}, aws.VPC{
+		Name:        config.Name,
+		Region:      config.Region,
+		CidrBlock:   config.PrivateIPV4Cidr,
+		SubnetCount: config.SubnetCount,
+		Tags: map[string]string{
+			aws.TagKoreManaged: "true",
+		},
+	})
+}

--- a/pkg/serviceproviders/aws/vpc/provider.go
+++ b/pkg/serviceproviders/aws/vpc/provider.go
@@ -1,0 +1,128 @@
+package vpc
+
+import (
+	"errors"
+
+	eksv1alpha1 "github.com/appvia/kore/pkg/apis/eks/v1alpha1"
+	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
+	"github.com/appvia/kore/pkg/kore"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ kore.ServiceProvider = Provider{}
+
+type Provider struct {
+	name string
+}
+
+func (p Provider) Name() string {
+	return p.name
+}
+
+func (p Provider) Kinds() []string {
+	return []string{"aws-vpc"}
+}
+
+func (p Provider) Plans() []servicesv1.ServicePlan {
+	return []servicesv1.ServicePlan{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ServicePlan",
+				APIVersion: servicesv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eks-dev",
+				Namespace: "kore",
+			},
+			Spec: servicesv1.ServicePlanSpec{
+				Kind:        "aws-vpc",
+				Summary:     "AWS VPC for a development EKS cluster",
+				Description: "Two private subnets with NAT gateways and two public subnets with direct Internet connection",
+				Configuration: v1beta1.JSON{Raw: []byte(`{
+					"region": "eu-west-2",
+					"privateIPV4Cidr": "10.0.0.0/16",
+					"subnetCount": 2
+				}`)},
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ServicePlan",
+				APIVersion: servicesv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eks-prod",
+				Namespace: "kore",
+			},
+			Spec: servicesv1.ServicePlanSpec{
+				Kind:        "aws-vpc",
+				Summary:     "AWS VPC for a production EKS cluster",
+				Description: "Three private subnets with NAT gateways and three public subnets with direct Internet connection",
+				Configuration: v1beta1.JSON{Raw: []byte(`{
+					"region": "eu-west-2",
+					"privateIPV4Cidr": "10.0.0.0/16",
+					"subnetCount": 3
+				}`)},
+			},
+		},
+	}
+}
+
+func (p Provider) PlanJSONSchema(kind string, plan string) (string, error) {
+	return `{
+		"$id": "https://appvia.io/schemas/services/dummy/dummy.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"description": "Dummy service plan schema",
+		"type": "object",
+		"additionalProperties": false,
+		"required": [
+			"region",
+			"privateIPV4Cidr",
+			"subnetCount"
+		],
+		"properties": {
+			"name": {
+				"type": "string",
+				"minLength": 1
+			},
+			"region": {
+				"type": "string",
+				"minLength": 1
+			},
+			"privateIPV4Cidr": {
+				"type": "string",
+				"format": "1.2.3.4/16"
+			},
+			"subnetCount": {
+				"type": "integer"
+			}
+		}
+	}`, nil
+}
+
+func (p Provider) CredentialsJSONSchema(kind string, plan string) (string, error) {
+	return "", nil
+}
+
+func (p Provider) RequiredCredentialTypes(kind string) ([]schema.GroupVersionKind, error) {
+	return []schema.GroupVersionKind{
+		eksv1alpha1.EKSCredentialsGVK,
+	}, nil
+}
+
+func (p Provider) ReconcileCredentials(
+	kore.ServiceProviderContext,
+	*servicesv1.Service,
+	*servicesv1.ServiceCredentials) (reconcile.Result, map[string]string, error) {
+	return reconcile.Result{}, nil, errors.New("service credentials are not supported for this service")
+}
+
+func (p Provider) DeleteCredentials(
+	kore.ServiceProviderContext,
+	*servicesv1.Service,
+	*servicesv1.ServiceCredentials) (reconcile.Result, error) {
+	return reconcile.Result{}, errors.New("service credentials are not supported for this service")
+}

--- a/pkg/serviceproviders/aws/vpc/reconcile.go
+++ b/pkg/serviceproviders/aws/vpc/reconcile.go
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpc
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/appvia/kore/pkg/kore"
+
+	"github.com/appvia/kore/pkg/controllers"
+
+	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (p Provider) Reconcile(
+	ctx kore.ServiceProviderContext,
+	service *servicesv1.Service,
+) (reconcile.Result, error) {
+	client, err := p.createVPCClient(ctx, service)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("configuration is invalid: %w", err)
+	}
+
+	// Ensure this only reports if it exists when all resources exist or ensure update works
+	ready, err := client.Ensure()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to create or update the EKS VPC: %w", err)
+	}
+
+	if !ready {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	providerData := ProviderData{
+		PrivateSubnetIDs:          client.VPC.PrivateSubnetIDs,
+		PublicSubnetIDs:           client.VPC.PublicSubnetIDs,
+		SecurityGroupIDs:          []string{client.VPC.ControlPlaneSecurityGroupID},
+		PublicIPV4EgressAddresses: client.VPC.PublicIPV4EgressAddresses,
+	}
+
+	if err := service.Status.SetProviderData(providerData); err != nil {
+		return reconcile.Result{}, controllers.NewCriticalError(err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/serviceproviders/aws/vpc/types.go
+++ b/pkg/serviceproviders/aws/vpc/types.go
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpc
+
+type Configuration struct {
+	// Name is the VPC name. If empty it defaults to the service's name
+	Name string `json:"name"`
+	// PrivateIPV4Cidr is the private range used for the VPC
+	PrivateIPV4Cidr string `json:"privateIPV4Cidr"`
+	// Region is the AWS region of the VPC and any resources created
+	Region string `json:"region"`
+	// SubnetCount is the maximum number of subnets of each subnet type
+	SubnetCount int `json:subnetCount`
+}
+
+type ProviderData struct {
+	// PrivateSubnetIds is a list of subnet IDs to use for the worker nodes
+	PrivateSubnetIDs []string `json:"privateSubnetIDs,omitempty"`
+	// PublicSubnetIDs is a list of subnet IDs to use for resources that need a public IP (e.g. load balancers)
+	PublicSubnetIDs []string `json:"publicSubnetIDs,omitempty"`
+	// SecurityGroupIds is a list of security group IDs to use for a cluster
+	SecurityGroupIDs []string `json:"securityGroupIDs,omitempty"`
+	// PublicIPV4EgressAddresses provides the source addresses for traffic coming from the cluster
+	// - can provide input for securing Kube API endpoints in managed clusters
+	PublicIPV4EgressAddresses []string `json:"ipv4EgressAddresses,omitempty"`
+}

--- a/pkg/utils/cloud/aws/types.go
+++ b/pkg/utils/cloud/aws/types.go
@@ -48,6 +48,8 @@ type VPC struct {
 	Tags map[string]string
 	// PublicIPV4EgressAddresses provides the source addresses for traffic coming from the cluster
 	PublicIPV4EgressAddresses []string
+	// SubnetCount is the maximum number of subnets of each subnet type
+	SubnetCount int
 	// Cache of aws VPC
 	awsObj *ec2.Vpc
 }

--- a/pkg/utils/cloud/aws/vpc_client.go
+++ b/pkg/utils/cloud/aws/vpc_client.go
@@ -31,10 +31,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	AZLimit = 3
-)
-
 // VPCClient for aws VPC
 type VPCClient struct {
 	// credentials are the aws credentials
@@ -49,6 +45,10 @@ type VPCClient struct {
 
 // NewVPCClient gets an AWS and session with a reference to a matching VPC
 func NewVPCClient(creds Credentials, vpc VPC) (*VPCClient, error) {
+	if vpc.SubnetCount == 0 {
+		vpc.SubnetCount = 3
+	}
+
 	sess := getNewSession(creds, vpc.Region)
 
 	// TODO: verify the current CIDR is big enough for the required subnets given:
@@ -126,7 +126,7 @@ func (c *VPCClient) Ensure() (ready bool, _ error) {
 		return false, err
 	}
 
-	azs, err := c.getAZs(AZLimit)
+	azs, err := c.getAZs(c.VPC.SubnetCount)
 	if err != nil {
 		return false, err
 	}
@@ -235,7 +235,7 @@ func (c *VPCClient) Delete(ctx context.Context) (ready bool, _ error) {
 		return true, nil
 	}
 
-	azs, err := c.getAZs(AZLimit)
+	azs, err := c.getAZs(c.VPC.SubnetCount)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## What

This is a service provider demonstration with a real life example - in this case creating VPCs for a cluster with a service provider.

If you want to test this, you have to merge this on top of https://github.com/appvia/kore/pull/712

First you have to register the service provider in the code (this would be part of this PR normally):
```
cat << EOF | git apply - 
diff --git a/pkg/serviceproviders/register/register.go b/pkg/serviceproviders/register/register.go
index 1462f416..3ef6ab64 100644
--- a/pkg/serviceproviders/register/register.go
+++ b/pkg/serviceproviders/register/register.go
@@ -18,5 +18,6 @@ package register

 import (
 	_ "github.com/appvia/kore/pkg/serviceproviders"
+	_ "github.com/appvia/kore/pkg/serviceproviders/aws/vpc"
 	_ "github.com/appvia/kore/pkg/serviceproviders/openservicebroker"
 )
EOF
```

Then you have to create the service provider in Kore:
```
cat <<EOF | kore apply -f -
apiVersion: serviceproviders.kore.appvia.io/v1
kind: ServiceProvider
metadata:
  name: aws-vpc
  namespace: kore
spec:
  description: AWS VPC service provider
  type: aws-vpc
  summary: AWS VPC service provider
  configuration: {}
EOF
```

This will create two new plans (dev is with two subnets, prod is with three):
```
➜ kore get serviceplans
NAME                SUMMARY                                  KIND       AGE
aws-vpc-eks-dev     AWS VPC for a development EKS cluster    aws-vpc    31m53s
aws-vpc-eks-prod    AWS VPC for a production EKS cluster     aws-vpc    31m53s
```

Create a vpc (you will need the same AWS credentials that you use for creating clusters):
```
➜ kore create service andras-dev --plan aws-vpc-eks-dev --credentials aws
```

Get the VPC service details:
```
➜ kore get service andras-dev -o yaml
apiVersion: services.kore.appvia.io/v1
kind: Service
metadata:
  creationTimestamp: "2020-05-02T09:41:53Z"
  finalizers:
  - services.kore.appvia.io
  generation: 1
  name: andras-dev
  namespace: a-team
  resourceVersion: "259028"
  selfLink: /apis/services.kore.appvia.io/v1/namespaces/a-team/services/andras-dev
  uid: 5a318b2c-2c30-4b99-af3e-e5f3ddb3e6b9
spec:
  configuration:
    privateIPV4Cidr: 10.0.0.0/16
    region: eu-west-2
    subnetCount: 2
  credentials:
    group: aws.compute.kore.appvia.io
    kind: EKSCredentials
    name: aws
    namespace: kore-admin
    version: v1alpha1
  kind: aws-vpc
  plan: aws-vpc-eks-dev
status:
  configuration:
    privateIPV4Cidr: 10.0.0.0/16
    region: eu-west-2
    subnetCount: 2
  plan: aws-vpc-eks-dev
  providerData:
    ipv4EgressAddresses:
    - 18.132.75.193
    - 35.179.30.17
    privateSubnetIDs:
    - subnet-00a7a147dd65e9717
    - subnet-03991a92e94c9a786
    publicSubnetIDs:
    - subnet-0b299e02d2c60d8a4
    - subnet-08f63ac5816d80bdd
    securityGroupIDs:
    - sg-05d9c546de4f1e429
  status: Success
```

Delete the service:
```
➜ kore delete service andras-dev
```