### PR TITLE
Update GKE versions to latest

### DIFF
--- a/pkg/kore/assets/plans.go
+++ b/pkg/kore/assets/plans.go
@@ -79,7 +79,7 @@ func GetDefaultPlans() []*configv1.Plan {
 							"region":                        "europe-west2",
 							"size":                          1,
 							"subnetwork":                    "default",
-							"version":                       "1.15.11-gke.1"
+							"version":                       "1.15.11-gke.11"
 						}`,
 					),
 				},
@@ -133,7 +133,7 @@ func GetDefaultPlans() []*configv1.Plan {
 							"region":                        "europe-west2",
 							"size":                          2,
 							"subnetwork":                    "default",
-							"version":                       "1.15.11-gke.1"
+							"version":                       "1.15.11-gke.11"
 						}`,
 					),
 				},


### PR DESCRIPTION
## What

The versions in our plans are not available anymore, so I bumped them to the latest.

`"1.15.11-gke.1` -> `1.15.11-gke.11`