### PR TITLE
Auth Proxy Streams

### DIFF
--- a/cmd/auth-proxy/main.go
+++ b/cmd/auth-proxy/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -87,7 +86,7 @@ func main() {
 	flags.StringSliceVar(&o.Server.AllowedIPs, "allowed-ips", sl("ALLOWED_IPS", []string{"0.0.0.0/0"}), "network cidr allowed access")
 	flags.StringVar(&o.Server.UpstreamURL, "upstream-url", s("UPSTREAM_URL", "https://kubernetes.default.svc.cluster.local"), "upstream url to forward the requests")
 	flags.StringVar(&o.Server.Token, "upstream-token", s("UPSTREAM_AUTHENTICATION_TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "containing the authentication token for upstream")
-	flag.DurationVar(&o.Server.FlushInterval, "flush-interval", 10*time.Millisecond, "the flush interval used on the revervse proxy")
+	flags.DurationVar(&o.Server.FlushInterval, "flush-interval", 10*time.Millisecond, "the flush interval used on the revervse proxy")
 	flags.Bool("verbose", false, "switches on verbose logging for debugging purposes `BOOL`")
 
 	// OpenID options

--- a/cmd/auth-proxy/main.go
+++ b/cmd/auth-proxy/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -86,6 +87,7 @@ func main() {
 	flags.StringSliceVar(&o.Server.AllowedIPs, "allowed-ips", sl("ALLOWED_IPS", []string{"0.0.0.0/0"}), "network cidr allowed access")
 	flags.StringVar(&o.Server.UpstreamURL, "upstream-url", s("UPSTREAM_URL", "https://kubernetes.default.svc.cluster.local"), "upstream url to forward the requests")
 	flags.StringVar(&o.Server.Token, "upstream-token", s("UPSTREAM_AUTHENTICATION_TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "containing the authentication token for upstream")
+	flag.DurationVar(&o.Server.FlushInterval, "flush-interval", 10*time.Millisecond, "the flush interval used on the revervse proxy")
 	flags.Bool("verbose", false, "switches on verbose logging for debugging purposes `BOOL`")
 
 	// OpenID options

--- a/pkg/cmd/auth-proxy/filters/proxy/proxy.go
+++ b/pkg/cmd/auth-proxy/filters/proxy/proxy.go
@@ -35,6 +35,8 @@ import (
 type Options struct {
 	// Endpoint is the destination to proxy
 	Endpoint string
+	// FlushInterval is the flush interval for reverse proxy
+	FlushInterval time.Duration
 }
 
 type pxyImpl struct {
@@ -57,9 +59,10 @@ func New(options Options) (filters.Middleware, error) {
 		return nil, errors.New("no endpoint")
 	}
 
-	log.WithField(
-		"endpoint", options.Endpoint,
-	).Debug("using the endpoint reverse proxy")
+	log.WithFields(log.Fields{
+		"endpoint": options.Endpoint,
+		"flush":    options.FlushInterval,
+	}).Debug("using the endpoint reverse proxy")
 
 	origin, err := url.Parse(options.Endpoint)
 	if err != nil {
@@ -78,7 +81,7 @@ func New(options Options) (filters.Middleware, error) {
 		req.URL.Scheme = origin.Scheme
 		req.URL.Host = origin.Host
 	}
-
+	rv.FlushInterval = options.FlushInterval
 	rv.ModifyResponse = func(resp *http.Response) error {
 		return nil
 	}

--- a/pkg/cmd/auth-proxy/server.go
+++ b/pkg/cmd/auth-proxy/server.go
@@ -159,7 +159,8 @@ func (a *authImpl) makeFilters() (filters.Interface, error) {
 		return nil, err
 	}
 	proxy, err := proxy.New(proxy.Options{
-		Endpoint: a.UpstreamURL,
+		Endpoint:      a.UpstreamURL,
+		FlushInterval: a.FlushInterval,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/auth-proxy/types.go
+++ b/pkg/cmd/auth-proxy/types.go
@@ -19,6 +19,7 @@ package authproxy
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 var (
@@ -40,6 +41,8 @@ type Config struct {
 	AllowedIPs []string `json:"allowed-ips,omitempty"`
 	// EnableProxyProtocol indicates we should use proxy protocol
 	EnableProxyProtocol bool `json:"enable-proxy-protocol,omitempty"`
+	// FlushInterval is flush interval for the proxy
+	FlushInterval time.Duration `json:"flush-interval,omitempty"`
 	// MetricsListen is the interface for metrics to render
 	MetricsListen string `json:"metrics-listen,omitempty"`
 	// Listen is the interface to listen on


### PR DESCRIPTION
The current implementation has an issue when using kubectl log as the FlushInterval is not set in the reverse proxy and so isn't flushed correctly. We set a default here or 10ms (similar to another project) but allow it to be configurable on the command line

```Go
  // FlushInterval specifies the flush interval
  // to flush to the client while copying the
  // response body.
  // If zero, no periodic flushing is done.
  // A negative value means to flush immediately
  // after each write to the client.
  // The FlushInterval is ignored when ReverseProxy
  // recognizes a response as a streaming response;
  // for such responses, writes are flushed to the client
  // immediately.
  FlushInterval time.Duration
```