### PR TITLE
Prevent double docker build of UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,8 +369,8 @@ jobs:
           working_directory: ~/project/ui
           command: |
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} quay.io
-            docker build -t ${KORE_UI_IMAGE}:${CIRCLE_TAG:-latest} --build-arg version=${CIRCLE_TAG:-latest} .
             docker build -t ${KORE_UI_IMAGE}:${CIRCLE_SHA1} --build-arg version=${CIRCLE_SHA1} .
+            docker tag ${KORE_UI_IMAGE}:${CIRCLE_SHA1} ${KORE_UI_IMAGE}:${CIRCLE_TAG:-latest}
             docker push ${KORE_UI_IMAGE}:${CIRCLE_TAG:-latest}
             docker push ${KORE_UI_IMAGE}:${CIRCLE_SHA1}
 


### PR DESCRIPTION
* build once using the commit sha or tag as the version
* docker tag that using the tag, or latest if there is no tag
* I think it makes sense that if you're running the latest image it will state the version as the commit sha or tag, rather than just latest
* this will also speed up the build as it doesn't build the docker image twice (layer caching doesn't seem to be very helpful here)