### PR TITLE
UI: Allow definition of custom form controls for named plan properties

### DIFF
--- a/ui/assets/antd-var-overrides.less
+++ b/ui/assets/antd-var-overrides.less
@@ -11,6 +11,7 @@
 @primary-color: @kore-primary-color; // primary color for all components
 @link-color: @primary-color; // link color
 @menu-item-active-bg: rgba(61, 91, 88, 0.2); // primary at 20%; default is primary at 90% opacity which results in too-dark-to-read menu item.
+@table-row-hover-bg: rgba(61, 91, 88, 0.2); // primary at 20%; default is primary at 90% opacity which results in too-dark-to-read table row.
 // Non-overridden:
 //@info-color: #b9d9eb; // info state color
 //@success-color: #52c41a; // success state color

--- a/ui/lib/components/plans/PlanForm.js
+++ b/ui/lib/components/plans/PlanForm.js
@@ -129,7 +129,7 @@ class PlanForm extends React.Component {
   fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
 
   render() {
-    const { form, data, validationErrors } = this.props
+    const { form, kind, data, validationErrors } = this.props
     const { dataLoading, submitting, schema, planValues, formErrorMessage } = this.state
     const { getFieldDecorator, getFieldsError } = form
 
@@ -192,6 +192,9 @@ class PlanForm extends React.Component {
 
           {Object.keys(schema.properties).map(property =>
             <PlanOption
+              mode="manage"
+              resourceType="cluster"
+              kind={kind}
               key={property}
               name={property}
               property={schema.properties[property]}

--- a/ui/lib/components/plans/PlanOptionBase.js
+++ b/ui/lib/components/plans/PlanOptionBase.js
@@ -1,0 +1,68 @@
+import * as React from 'react'
+import PropTypes from 'prop-types'
+import { Alert } from 'antd'
+
+export default class PlanOptionBase extends React.Component {
+  static propTypes = {
+    resourceType: PropTypes.string.isRequired,
+    kind: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    property: PropTypes.object.isRequired,
+    value: PropTypes.any,
+    editable: PropTypes.bool,
+    hideNonEditable: PropTypes.bool,
+    onChange: PropTypes.func,
+    displayName: PropTypes.string,
+    validationErrors: PropTypes.array,
+    mode: PropTypes.oneOf(['manage','use']), // mode=manage means we're editing a PLAN, mode=use means we're USING a plan e.g. to make/edit a cluster
+    team: PropTypes.object, // may be optionally used by custom plan option components to give richer interface when mode=use.
+  }
+
+  describe = (property) => {
+    let descriptionPieces = []
+    if (property.description) {
+      descriptionPieces.push(property.description)
+    }
+    if (property.format) {
+      descriptionPieces.push(`Format: ${property.format}`)
+    } else if (property.items && property.items.format) {
+      descriptionPieces.push(`Format: ${property.items.format}`)
+    }
+    if (property.immutable) {
+      descriptionPieces.push('Cannot be edited after cluster is created.')
+    }
+    if (descriptionPieces.length === 0) {
+      return null
+    }
+    return descriptionPieces.join(' | ')
+  }
+
+  addComplexItemToArray = (property, values) => {
+    if (property.items.type === 'array') {
+      values.push([])
+      return values
+    }
+    let newItem = {}
+    Object.keys(property.items.properties).forEach((p) => newItem[p] = null)
+    values.push(newItem)
+    return values
+  }
+
+  removeFromArray = (values, indToRemove) => {
+    values.splice(indToRemove, 1)
+    return values
+  }
+
+  validationErrors = name => {
+    if (!this.props.validationErrors) {
+      return null
+    }
+    const dotName = name.replace(/\[([0-9+])\]/g, '.$1')
+    const valErrors = this.props.validationErrors.filter(v => v.field.indexOf(dotName) === 0)
+    if (valErrors.length === 0) {
+      return null
+    }
+    return valErrors.map((ve, i) => <Alert key={`${name}.valError.${i}`} type="error" message={ve.message} style={{ marginTop: '10px' }} />)
+  }
+  
+}

--- a/ui/lib/components/plans/PlanOptionsForm.js
+++ b/ui/lib/components/plans/PlanOptionsForm.js
@@ -126,6 +126,10 @@ class PlanOptionsForm extends React.Component {
 
           return (
             <PlanOption 
+              mode="use"
+              team={this.props.team}
+              resourceType={this.props.resourceType}
+              kind={this.props.kind}
               key={name} 
               name={name} 
               property={this.state.schema.properties[name]} 

--- a/ui/lib/components/plans/custom/PlanOptionClusterUsers.js
+++ b/ui/lib/components/plans/custom/PlanOptionClusterUsers.js
@@ -1,0 +1,161 @@
+import * as React from 'react'
+import { Form, Select, Table, Icon } from 'antd'
+import { startCase, debounce } from 'lodash'
+import PlanOptionBase from '../PlanOptionBase'
+import KoreApi from '../../../kore-api'
+
+export default class PlanOptionClusterUsers extends PlanOptionBase {
+  constructor(props) {
+    super(props)
+    this.lastSearchId = 0
+    this.searchUsers = debounce(this.searchUsers, 250)
+  }
+
+  state = {
+    loadingUsers: false,
+    allUsers: null,
+    searchUsers: []
+  }
+
+  searchUsers = async (value) => {
+    this.lastSearchId += 1
+    const searchId = this.lastSearchId
+
+    // Load the user list once (we're doing filtering client-side at the moment)
+    let allUsers = this.state.allUsers
+    if (!allUsers) {
+      this.setState({ loadingUsers: true })
+      if (this.props.mode === 'manage') {
+        allUsers = await (await KoreApi.client()).ListUsers()
+        // all users and team members have different shaped return objects, so map them both to a plain array of usernames
+        allUsers = allUsers.items.map((u) => u.spec.username)
+      } else {
+        allUsers = await (await KoreApi.client()).ListTeamMembers(this.props.team.metadata.name)
+        // all users and team members have different shaped return objects, so map them both to a plain array of usernames
+        allUsers = allUsers.items
+      }
+      this.setState({ allUsers, loadingUsers: false })
+    }
+
+    if (searchId !== this.lastSearchId) {
+      // if this has been superceded by another search, just bin it it.
+      return
+    }
+
+    const searchUsers = allUsers.filter((u) => {
+      // remove users already in the list
+      if (this.props.value && this.props.value.find((existingUser) => existingUser.username === u)) {
+        return false
+      }
+      // remove users who don't match the entered value
+      if (u.indexOf(value) === -1) {
+        return false
+      }
+      return true
+    })
+
+    this.setState({
+      loadingUsers: false,
+      searchUsers: searchUsers
+    })
+  }
+
+  addUser = (username) => {
+    if (!this.props.editable || !this.props.onChange) {
+      return
+    }
+
+    // No-op if already present:
+    if (this.props.value && this.props.value.find((u) => u.username === username)) {
+      return
+    }
+
+    // Need to handle the value being undefined in the case where this is a new plan or no
+    // users are defined yet.
+    let newValue
+    if (this.props.value) {
+      newValue = [...this.props.value, { username, roles: [] }]
+    } else {
+      newValue = [{ username, roles: [] }]
+    }
+
+    this.setState({ searchUsers: [] })
+
+    this.props.onChange(this.props.name, newValue)
+  }
+
+  removeUser = (username) => {
+    if (!this.props.editable || !this.props.onChange) {
+      return
+    }
+
+    this.setState({ searchUsers: [] })
+
+    this.props.onChange(
+      this.props.name, 
+      this.props.value.filter((u) => u.username !== username)
+    )
+  }
+
+  setUserRoles = (username, roles) => {
+    if (!this.props.editable || !this.props.onChange) {
+      return
+    }
+
+    this.props.onChange(
+      this.props.name, 
+      this.props.value.map((u) => u.username !== username ? u : { ...u, roles: roles })
+    )
+  }
+
+  render() {
+    const { name, value, editable } = this.props
+
+    const displayName = this.props.displayName || name
+    const description = this.props.mode === 'manage' ? 'Set default users to be added to every cluster created from this plan' : 'Control which team members have access to this cluster'
+    const roles = ['cluster-admin', 'admin', 'edit', 'view']
+    const columns = [
+      { title: 'User', dataIndex: 'username', key: 'username', width: '45%' },
+      { title: 'Roles', dataIndex: 'roles', key: 'tags', width: '45%', render: function renderRoles(userRoles, r) { 
+        return (
+          <Select mode="multiple" value={userRoles}  onChange={(selectedRoles) => this.setUserRoles(r.username, selectedRoles)}>
+            {!editable ? null : roles.map((role) => userRoles.indexOf(role) === -1 ? <Select.Option key={role} value={role}>{role}</Select.Option> : null)}
+          </Select>
+        )
+      }.bind(this) },
+      { key: 'action', width: '10%', render: function renderAction(_, r) {
+        if (!editable) {
+          return null
+        }
+        return <><div style={{ textAlign: 'right' }}><a onClick={() => this.removeUser(r.username)}><Icon type="delete" title="Delete" /></a></div></>
+      }.bind(this) },
+    ]
+
+    return (
+      <Form.Item label={startCase(displayName)} help={description}>
+        <Table 
+          size="small" 
+          pagination={false} 
+          dataSource={value} 
+          columns={columns} 
+          rowKey={r => r.username}
+          footer={!editable ? null : () => (
+            <Select
+              mode="single" showSearch={true}
+              placeholder="Start typing username to find users to add"
+              onSearch={this.searchUsers}
+              onChange={(v) => this.addUser(v)}
+              value={undefined}
+            >
+              {this.state.searchUsers.map((user, idx) => (
+                <Select.Option key={idx} value={user}>{user}</Select.Option>
+              ))}
+            </Select>
+          )}
+        >
+        </Table>
+        {this.validationErrors(name)}
+      </Form.Item>
+    )
+  }
+}

--- a/ui/lib/components/plans/custom/index.js
+++ b/ui/lib/components/plans/custom/index.js
@@ -1,0 +1,27 @@
+import PlanOptionClusterUsers from './PlanOptionClusterUsers'
+
+export default class CustomPlanOptionRegistry {
+  static controls = {
+    'cluster': {
+      'GKE': {
+        'clusterUsers': function clusterUsers(props) {
+          return <PlanOptionClusterUsers {...props} />
+        }
+      },
+      'EKS': {
+        'clusterUsers': function clusterUsers(props) { 
+          return <PlanOptionClusterUsers {...props} /> 
+        }
+      }
+    }
+  }
+
+  static getCustomPlanOption = (planType, planKind, fieldName, props) => {
+    if (!CustomPlanOptionRegistry.controls[planType] || 
+      !CustomPlanOptionRegistry.controls[planType][planKind] || 
+      !CustomPlanOptionRegistry.controls[planType][planKind][fieldName]) {
+      return null
+    }
+    return CustomPlanOptionRegistry.controls[planType][planKind][fieldName](props)
+  }
+}

--- a/ui/lib/components/services/ServicePlanForm.js
+++ b/ui/lib/components/services/ServicePlanForm.js
@@ -129,7 +129,7 @@ class ServicePlanForm extends React.Component {
   fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
 
   render() {
-    const { form, data, validationErrors } = this.props
+    const { form, kind, data, validationErrors } = this.props
     const { dataLoading, submitting, schema, servicePlanValues, formErrorMessage } = this.state
     const { getFieldDecorator, getFieldsError } = form
 
@@ -192,6 +192,9 @@ class ServicePlanForm extends React.Component {
 
           {Object.keys(schema.properties).map(property =>
             <PlanOption
+              mode="manage"
+              resourceType="service"
+              kind={kind}
               key={property}
               name={property}
               property={schema.properties[property]}


### PR DESCRIPTION
Allows hard-coded rich UI components for those fields that need them, while keeping the generic ones for the rest.

Includes a custom component for managing cluster users on both EKS and GKE.

![image](https://user-images.githubusercontent.com/7505593/81847380-6c488800-954b-11ea-83c0-d5102791954c.png)

Addresses #539 for the generic infra + cluster users, still need to do the EKS node groups control but that can be done as the next PR.