### PR TITLE
Set owning team correctly when doing security scans

### DIFF
--- a/pkg/persistence/security.go
+++ b/pkg/persistence/security.go
@@ -190,7 +190,7 @@ func (s *securityImpl) StoreScan(ctx context.Context, result *model.SecurityScan
 		// the checked_at time.
 		newResult := resultCurrent == nil
 		if resultCurrent != nil {
-			newResult = resultCurrent.OverallStatus != result.OverallStatus || len(resultCurrent.Results) != len(result.Results)
+			newResult = resultCurrent.OverallStatus != result.OverallStatus || len(resultCurrent.Results) != len(result.Results) || resultCurrent.OwningTeam != result.OwningTeam
 			if !newResult {
 				for i, rr := range result.Results {
 					if resultCurrent.Results[i].Status != rr.Status || resultCurrent.Results[i].Message != rr.Message {

--- a/pkg/security/scanner.go
+++ b/pkg/security/scanner.go
@@ -126,7 +126,10 @@ func (s *scannerImpl) scanRules(typeMeta metav1.TypeMeta, objMeta metav1.ObjectM
 				Namespace: objMeta.Namespace,
 				Name:      objMeta.Name,
 			},
-			CheckedAt: metav1.NewTime(time.Now()),
+			// Assuming for now that the namespace will be the owning team - may change this assumption as some future point
+			// if, e.g., we're scanning in-cluster objects in their own namespaces:
+			OwningTeam: objMeta.Namespace,
+			CheckedAt:  metav1.NewTime(time.Now()),
 		},
 	}
 


### PR DESCRIPTION
Tested locally, now shows clusters on the team security page as expected:

![image](https://user-images.githubusercontent.com/7505593/81915681-d3f1e800-95ca-11ea-80ca-57c1c800de6e.png)

Addresses #817 