### PR TITLE
Use Kind and Helm for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,11 @@ images:
 		docker build -t ${REGISTRY}/${AUTHOR}/$${name}:${VERSION} -f images/Dockerfile.$${name} . ; \
 	done
 
+kind-image-dev:
+	@echo "--> Building dev Docker image for Kind"
+	docker build -t ${REGISTRY}/${AUTHOR}/kore-apiserver:dev -f images/Dockerfile.kore-apiserver.dev images
+	kind load docker-image ${REGISTRY}/${AUTHOR}/kore-apiserver:dev --name kore
+
 push-images:
 	@echo "--> Pushing docker images"
 	@for name in ${DOCKER_IMAGES}; do \

--- a/charts/kore/templates/kore.yml
+++ b/charts/kore/templates/kore.yml
@@ -113,10 +113,25 @@ spec:
         - name: ca
           readOnly: true
           mountPath: /ca
+        {{ if eq .Values.api.version "dev" -}}
+        - name: kore
+          mountPath: /go/src/github.com/appvia/kore
+        - name: gocache
+          mountPath: /root/.cache/go-build
+        {{- end }}
       volumes:
       - name: ca
         secret:
           secretName: {{ .Values.ca.secretName }}
+      {{ if eq .Values.api.version "dev" -}}
+      - name: kore
+        hostPath:
+          path: /go/src/github.com/appvia/kore
+          type: Directory
+      - name: gocache
+        persistentVolumeClaim:
+          claimName: {{ include "kore.name" . }}-gocache
+      {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -140,3 +155,19 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kore.name" . }}-admin
   namespace: {{ .Release.Namespace }}
+
+{{ if eq .Values.api.version "dev" -}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kore.name" . }}-gocache
+  labels:
+{{ include "kore.labels" . | indent 4}}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}

--- a/doc/install-kore-in-kind.md
+++ b/doc/install-kore-in-kind.md
@@ -3,7 +3,7 @@
 1. Install kind:
 
     ```
-    GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
+    GO111MODULE="on" go get sigs.k8s.io/kind@v0.8.1
     ```
 
 1. Create a Kind cluster:
@@ -13,15 +13,18 @@
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
     nodes:
-    - role: control-plane
-      image: kindest/node:v1.14.10@sha256:81ae5a3237c779efc4dda43cc81c696f88a194abcc4f8fa34f86cf674aa14977
-      extraPortMappings:
-      - containerPort: 3000
-        hostPort: 3000
-        protocol: TCP
-      - containerPort: 10080
-        hostPort: 10080
-        protocol: TCP
+      - role: control-plane
+        image: kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50
+        extraPortMappings:
+          - containerPort: 3000
+            hostPort: 3000
+            protocol: TCP
+          - containerPort: 10080
+            hostPort: 10080
+            protocol: TCP
+        extraMounts:
+          - hostPath: ${GOPATH}/src/github.com/appvia/kore
+            containerPath: /go/src/github.com/appvia/kore
     EOF
     ```
 
@@ -50,13 +53,20 @@
         detect: false
       serviceType: NodePort
       hostPort: 10080
-      version: v0.0.16
+      version: latest
+      replicas: 1
+      feature_gates: []
     ui:
       endpoint:
         detect: false
       serviceType: NodePort
       hostPort: 3000
-      version: v0.0.6
+      version: latest
+      replicas: 1
+      feature_gates: []
+     mysql:
+       pvc:
+         size: 1Gi
     ```
 
 1. Install the Helm chart
@@ -66,3 +76,27 @@
     ```
 
 1. Navigate to http://localhost:3000 or run `kore login`
+
+## Local development
+
+1. Build the dev Docker image and load it into the Kind cluster:
+
+    ```
+    make kind-image-dev
+    ```
+
+1. Update `charts/my_values.yaml` and set `api.version` to `dev`
+
+### Useful commands
+
+1. Restart the API server
+
+   ```
+   kubectl -n kore rollout restart deployment kore-apiserver
+   ```
+
+1. Tailing the API server logs
+
+   ```
+   kubectl -n kore logs -f -l name=kore-apiserver
+   ```

--- a/hack/bin/run-api-with-kind.sh
+++ b/hack/bin/run-api-with-kind.sh
@@ -10,7 +10,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.15.7
+  image: kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50
 EOF
 }
 

--- a/images/Dockerfile.kore-apiserver.dev
+++ b/images/Dockerfile.kore-apiserver.dev
@@ -1,0 +1,11 @@
+FROM golang:1.14-alpine3.11
+
+ENV CGO_ENABLED=0
+
+RUN apk add --no-cache ca-certificates git make
+
+WORKDIR /go/src/github.com/appvia/kore
+
+VOLUME /root/.cache/go-build
+
+ENTRYPOINT [ "sh", "-c", "time make kore-apiserver && bin/kore-apiserver" ]


### PR DESCRIPTION
## What

This PR makes it possible to run the API server in Kind, while using your local Git repository and build the API server when the container starts.

The restart time is around 1 minute + while the API server initialises, which is not ideal, but still much quicker than having to build an image, push it and redeploy the Helm chart.

For now I only did this for the API server, as the UI doesn't have to run in Kind at all. If you need to run the API in Kind and you still want to develop the UI, you can run it locally on a different port for now.