### PR TITLE
Fixing allocation naming clash

### DIFF
--- a/pkg/apis/config/v1/plan_policy_types.go
+++ b/pkg/apis/config/v1/plan_policy_types.go
@@ -78,7 +78,7 @@ func (p PlanPolicy) CreateAllocation(teams []string) *Allocation {
 	}
 	return &Allocation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   p.Name,
+			Name:   "planpolicy-" + p.Name,
 			Labels: labels,
 		},
 		Spec: AllocationSpec{

--- a/pkg/apiserver/allocations.go
+++ b/pkg/apiserver/allocations.go
@@ -117,7 +117,7 @@ func (u teamHandler) deleteAllocation(req *restful.Request, resp *restful.Respon
 		team := req.PathParameter("team")
 		name := req.PathParameter("name")
 
-		obj, err := u.Teams().Team(team).Allocations().Delete(req.Request.Context(), name)
+		obj, err := u.Teams().Team(team).Allocations().Delete(req.Request.Context(), name, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/kore/create/ekscredential.go
+++ b/pkg/cmd/kore/create/ekscredential.go
@@ -199,7 +199,7 @@ func (o *CreateEKSCredentialsOptions) GenerateAllocation() *configv1.Allocation 
 			APIVersion: confv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      o.Name,
+			Name:      "ekscredentials-" + o.Name,
 			Namespace: kore.HubAdminTeam,
 		},
 		Spec: confv1.AllocationSpec{

--- a/pkg/cmd/kore/create/gkecredential.go
+++ b/pkg/cmd/kore/create/gkecredential.go
@@ -182,7 +182,7 @@ func (o *CreateGKECredentialsOptions) GenerateAllocation() *configv1.Allocation 
 			APIVersion: confv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      o.Name,
+			Name:      "gkecredentials-" + o.Name,
 			Namespace: kore.HubAdminTeam,
 		},
 		Spec: confv1.AllocationSpec{

--- a/test/e2e/integration/eks.bats
+++ b/test/e2e/integration/eks.bats
@@ -30,7 +30,7 @@ setup() {
 }
 
 @test "We should have an allocation for EKS credentials" {
-  runit "${KORE} get allocations aws -t ${TEAM}"
+  runit "${KORE} get allocations ekscredentials-aws -t ${TEAM}"
   [[ "$status" -eq 0 ]]
 }
 

--- a/test/e2e/integration/gke-credentials.bats
+++ b/test/e2e/integration/gke-credentials.bats
@@ -66,18 +66,18 @@ load helper
 }
 
 @test "We should be able to see the gke allocations in the ${TEAM} team" {
-  runit "${KORE} get allocations gke -t ${TEAM}"
+  runit "${KORE} get allocations gkecredentials-gke -t ${TEAM}"
   [[ "$status" -eq 0 ]]
-  runit "${KORE} get allocations gke -o json -t ${TEAM} | jq '.status.status' | grep -i success"
+  runit "${KORE} get allocations gkecredentials-gke -o json -t ${TEAM} | jq '.status.status' | grep -i success"
   [[ "$status" -eq 0 ]]
 }
 
 @test "If we delete the allocation, the ${TEAM} should no longer see the gke credentials" {
-  runit "${KORE} get allocations gke -t kore-admin"
+  runit "${KORE} get allocations gkecredentials-gke -t kore-admin"
   [[ "$status" -eq 0 ]]
-  runit "${KORE} delete allocations gke -t kore-admin"
+  runit "${KORE} delete allocations gkecredentials-gke -t kore-admin"
   [[ "$status" -eq 0 ]]
-  retry 5 "${KORE} get allocations -t ${TEAM} | grep ^gke || true"
+  retry 5 "${KORE} get allocations -t ${TEAM} | grep ^gkecredentials-gke || true"
   [[ "$status" -eq 0 ]]
 }
 
@@ -88,6 +88,6 @@ load helper
   [[ "$status" -eq 0 ]]
   retry 5 "${KORE} get gkecredentials gke -t kore-admin -o json | jq '.status.status' | grep -i success"
   [[ "$status" -eq 0 ]]
-  retry 5 "${KORE} get allocations gke -t ${TEAM}"
+  retry 5 "${KORE} get allocations gkecredentials-gke -t ${TEAM}"
   [[ "$status" -eq 0 ]]
 }

--- a/test/e2e/integration/gke-deletion.bats
+++ b/test/e2e/integration/gke-deletion.bats
@@ -18,7 +18,7 @@
 load helper
 
 setup() {
-  ${KORE} get allocation gke -t ${TEAM} | grep GKE || skip && true
+  ${KORE} get allocation gkecredentials-gke -t ${TEAM} | grep GKE || skip && true
 }
 
 @test "We should be able to delete the gke cluster" {

--- a/test/e2e/integration/gke.bats
+++ b/test/e2e/integration/gke.bats
@@ -17,7 +17,7 @@
 load helper
 
 @test "Ensuring we have an allocation to build a cluster in GKE" {
-  runit "${KORE} get allocations -t ${TEAM} | grep ^gke"
+  runit "${KORE} get allocations -t ${TEAM} | grep ^gkecredentials-gke"
   [[ "$status" -eq 0 ]]
 }
 

--- a/test/e2e/integration/plan-policies.bats
+++ b/test/e2e/integration/plan-policies.bats
@@ -26,8 +26,8 @@ load helper
 }
 
 @test "We should see the default policies are allocated to all teams" {
-  runit "${KORE} get allocations default-eks -t ${TEAM}"  
+  runit "${KORE} get allocations planpolicy-default-eks -t ${TEAM}"  
   [[ "$status" -eq 0 ]]
-  runit "${KORE} get allocations default-gke -t ${TEAM}"  
+  runit "${KORE} get allocations planpolicy-default-gke -t ${TEAM}"  
   [[ "$status" -eq 0 ]]
 }

--- a/test/e2e/integration/safeguards.bats
+++ b/test/e2e/integration/safeguards.bats
@@ -38,7 +38,7 @@ setup() {
 }
 
 #@test "We should not be able to create a gke cluster with an disallowed paramater" {
-#  ${KORE} get allocation gke -t ${TEAM} || skip
+#  ${KORE} get allocation gkecredentials-gke -t ${TEAM} || skip
 #
 #  runit "${KORE} create cluster ${CLUSTER} -p gke-development -a gke --param '{\"enableIstio\":\"true\"}' || true"
 #  [[ "$status" -eq 0 ]]

--- a/ui/__tests__/unit/lib/components/credentials/EKSCredentialsForm.test.js
+++ b/ui/__tests__/unit/lib/components/credentials/EKSCredentialsForm.test.js
@@ -17,7 +17,7 @@ describe('EKSCredentialsForm', () => {
     spec: { accountID: '1234567890', accessKeyID: '123', secretAccessKey: 'aws-account-cred' }
   }
   const allocation = {
-    metadata: { name: 'eks' },
+    metadata: { name: 'ekscredentials-eks' },
     spec: { resource: { kind: 'EKSCredentials' } }
   }
 
@@ -66,7 +66,7 @@ describe('EKSCredentialsForm', () => {
     beforeEach(() => {
       apiScope
         .get(`${ApiTestHelpers.basePath}/teams/kore-admin/ekscredentials/eks`).reply(200, eksCredential)
-        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/eks`).reply(200, allocation)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/ekscredentials-eks`).reply(200, allocation)
     })
 
     it('returns EKS credential and allocation from API', async () => {
@@ -82,7 +82,7 @@ describe('EKSCredentialsForm', () => {
       apiScope
         .put(`${ApiTestHelpers.basePath}/teams/kore-admin/secrets/eks`).reply(200, secret)
         .put(`${ApiTestHelpers.basePath}/teams/kore-admin/ekscredentials/eks`).reply(200, eksCredential)
-        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/eks`).reply(200, allocation)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/ekscredentials-eks`).reply(200, allocation)
     })
 
     it('creates/updates and returns EKS credential and allocation from API', async () => {

--- a/ui/__tests__/unit/lib/components/credentials/GCPOrganizationsForm.test.js
+++ b/ui/__tests__/unit/lib/components/credentials/GCPOrganizationsForm.test.js
@@ -17,7 +17,7 @@ describe('GCPOrganizationForm', () => {
     spec: { parentID: 'org-id', billingAccount: 'billing@example.com', account: 'org-cred' }
   }
   const allocation = {
-    metadata: { name: 'gcp' },
+    metadata: { name: 'organization-gcp' },
     spec: { resource: { kind: 'Organization' } }
   }
 
@@ -64,7 +64,7 @@ describe('GCPOrganizationForm', () => {
     beforeEach(() => {
       apiScope
         .get(`${ApiTestHelpers.basePath}/teams/kore-admin/organizations/gcp`).reply(200, gcpOrganization)
-        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gcp`).reply(200, allocation)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/organization-gcp`).reply(200, allocation)
     })
 
     it('returns Organization and allocation from API', async () => {
@@ -80,7 +80,7 @@ describe('GCPOrganizationForm', () => {
       apiScope
         .put(`${ApiTestHelpers.basePath}/teams/kore-admin/secrets/gcp`).reply(200, secret)
         .put(`${ApiTestHelpers.basePath}/teams/kore-admin/organizations/gcp`).reply(200, gcpOrganization)
-        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gcp`).reply(200, allocation)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/organization-gcp`).reply(200, allocation)
     })
 
     it('creates/updates and returns Organization and allocation from API', async () => {

--- a/ui/__tests__/unit/lib/components/credentials/GKECredentialsForm.test.js
+++ b/ui/__tests__/unit/lib/components/credentials/GKECredentialsForm.test.js
@@ -17,7 +17,7 @@ describe('GKECredentialsForm', () => {
     spec: { project: 'project-id', account: 'gke-service-account-cred' }
   }
   const allocation = {
-    metadata: { name: 'gke' },
+    metadata: { name: 'gkecredentials-gke' },
     spec: { resource: { kind: 'GKECredentials' } }
   }
 
@@ -65,7 +65,7 @@ describe('GKECredentialsForm', () => {
     beforeEach(() => {
       apiScope
         .get(`${ApiTestHelpers.basePath}/teams/kore-admin/gkecredentials/gke`).reply(200, gkeCredential)
-        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gke`).reply(200, allocation)
+        .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gkecredentials-gke`).reply(200, allocation)
     })
 
     it('returns GKE credential and allocation from API', async () => {
@@ -81,7 +81,7 @@ describe('GKECredentialsForm', () => {
       apiScope
         .put(`${ApiTestHelpers.basePath}/teams/kore-admin/secrets/gke`).reply(200, secret)
         .put(`${ApiTestHelpers.basePath}/teams/kore-admin/gkecredentials/gke`).reply(200, gkeCredential)
-        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gke`).reply(200, allocation)
+        .put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/gkecredentials-gke`).reply(200, allocation)
     })
 
     it('creates/updates and returns GKE credential and allocation from API', async () => {

--- a/ui/__tests__/unit/lib/components/policies/PolicyForm.test.js
+++ b/ui/__tests__/unit/lib/components/policies/PolicyForm.test.js
@@ -20,7 +20,7 @@ describe('PolicyForm', () => {
     apiScope = (ApiTestHelpers.getScope())
       .get(`${ApiTestHelpers.basePath}/planschemas/GKE`).reply(200, schema)
       .get(`${ApiTestHelpers.basePath}/teams`).reply(200, { items: [] })
-      .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/allow-gke-node-type-changes`).reply(404)
+      .get(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/planpolicy-allow-gke-node-type-changes`).reply(404)
 
     props = {
       form: {
@@ -123,7 +123,7 @@ describe('PolicyForm', () => {
 
     test('creates the resource and calls the wrapper component handleSubmit function', async () => {
       apiScope.put(`${ApiTestHelpers.basePath}/planpolicies/allow-gke-node-type-changes`).reply(200, policyResource)
-      apiScope.put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/allow-gke-node-type-changes`).reply(200)
+      apiScope.put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/planpolicy-allow-gke-node-type-changes`).reply(200)
       await form._process(null, { summary: 'Allow GKE node type changes', description: 'Description of policy' })
       expect(props.handleSubmit).toHaveBeenCalledTimes(1)
       expect(props.handleSubmit.mock.calls[0]).toEqual([policyResource])

--- a/ui/__tests__/unit/lib/utils/allocation-helpers.test.js
+++ b/ui/__tests__/unit/lib/utils/allocation-helpers.test.js
@@ -15,7 +15,7 @@ describe('AllocationHelpers', () => {
     it('should return an allocation when called with a resource', () => {
       const allocation = AllocationHelpers.generateAllocation({ resourceToAllocate: resource, teams: [] })
       expect(allocation).toBeDefined()
-      expect(allocation.metadata.name).toEqual(resource.metadata.name)
+      expect(allocation.metadata.name).toEqual(`${resource.kind.toLowerCase()}-${resource.metadata.name}`)
       expect(allocation.metadata.namespace).toEqual(config.kore.koreAdminTeamName)
       expect(allocation.spec.resource.group).toEqual('testgroup.appvia.io')
       expect(allocation.spec.resource.version).toEqual('v1alpha1')

--- a/ui/lib/components/credentials/EKSCredentialsForm.js
+++ b/ui/lib/components/credentials/EKSCredentialsForm.js
@@ -11,10 +11,6 @@ import AllocationHelpers from '../../utils/allocation-helpers'
 
 class EKSCredentialsForm extends VerifiedAllocatedResourceForm {
 
-  state = {
-    replaceKey: false
-  }
-
   generateSecretResource = values => {
     const resource = new V1Secret()
     resource.setApiVersion('config.kore.appvia.io')

--- a/ui/lib/components/credentials/GKECredentialsForm.js
+++ b/ui/lib/components/credentials/GKECredentialsForm.js
@@ -11,10 +11,6 @@ import AllocationHelpers from '../../utils/allocation-helpers'
 
 class GKECredentialsForm extends VerifiedAllocatedResourceForm {
 
-  state = {
-    replaceKey: false
-  }
-
   generateSecretResource = values => {
     const resource = new V1Secret()
     resource.setApiVersion('config.kore.appvia.io')

--- a/ui/lib/components/resources/VerifiedAllocatedResourceForm.js
+++ b/ui/lib/components/resources/VerifiedAllocatedResourceForm.js
@@ -30,7 +30,8 @@ class VerifiedAllocatedResourceForm extends React.Component {
       submitting: false,
       formErrorMessage: false,
       allocations,
-      inlineVerificationFailed: false
+      inlineVerificationFailed: false,
+      replaceKey: false
     }
   }
 
@@ -48,7 +49,6 @@ class VerifiedAllocatedResourceForm extends React.Component {
 
   onAllocationsChange = value => {
     this.setState({
-      ...this.state,
       allocations: value
     })
   }

--- a/ui/lib/utils/allocation-helpers.js
+++ b/ui/lib/utils/allocation-helpers.js
@@ -7,7 +7,7 @@ import config from '../../config'
 
 export default class AllocationHelpers {
   static getAllocationNameForResource = (resource) => {
-    return resource.metadata.name
+    return `${resource.kind.toLowerCase()}-${resource.metadata.name}`
   }
 
   static generateAllocation = ({ resourceToAllocate, teams, name, summary }) => {


### PR DESCRIPTION
* allocation resources will now be named using the resource kind (lowercase) as a prefix eg. gkecredentials-gke
* migrate old allocation name to new names on setup
* create allocations in the UI and CLI using the new name
* fixing UI bug where it was not showing the allocated teams correctly
* fixing the e2e tests

Note: the `PlanPolicy` allocations are created during setup, these will be created with the new names and momentarily the old ones will also be present until the renaming code is run. This will then check if an allocation with the new name exists before trying to create it. In this case, the allocation with the old name will be deleted. 

Fixes #679 

I tested this by creating all the different kind of allocations on the master branch, as follows:
```
dave@kore (master) $ k -n kore-admin get allocations.config.kore.appvia.io
NAME                SUMMARY                                                                               GROUP                        RESOURCE NAMESPACE   RESOURCE NAME
am-appvia-gcp       Allocation of am-appvia-gcp                                                           accounts.kore.appvia.io      kore-admin           am-appvia-gcp
appvia-gcp          The appvia.io GCP estate                                                              gcp.compute.kore.appvia.io   kore-admin           appvia-gcp
daves-policy        Allocation of daves-policy                                                            config.kore.appvia.io        kore-admin           daves-policy
default-eks         This policy defines which plan properties can be edited by default for EKS clusters   config.kore.appvia.io        kore-admin           default-eks
default-gke         This policy defines which plan properties can be edited by default for GKE clusters   config.kore.appvia.io        kore-admin           default-gke
for-carrot          For carrot                                                                            gke.compute.kore.appvia.io   kore-admin           for-carrot
kore-test-project   Project for testing Kore locally                                                      gke.compute.kore.appvia.io   kore-admin           kore-test-project
policy-for-carrot   Allocation of policy-for-carrot                                                       config.kore.appvia.io        kore-admin           policy-for-carrot
```

Once switching to this branch the allocations were migrated as follows:

```
dave@kore (allocation-naming) $ k -n kore-admin get allocations.config.kore.appvia.io
NAME                               SUMMARY                                                                               GROUP                        RESOURCE NAMESPACE   RESOURCE NAME
accountmanagement-am-appvia-gcp    Allocation of am-appvia-gcp                                                           accounts.kore.appvia.io      kore-admin           am-appvia-gcp
gkecredentials-for-carrot          For carrot                                                                            gke.compute.kore.appvia.io   kore-admin           for-carrot
gkecredentials-kore-test-project   Project for testing Kore locally                                                      gke.compute.kore.appvia.io   kore-admin           kore-test-project
organization-appvia-gcp            The appvia.io GCP estate                                                              gcp.compute.kore.appvia.io   kore-admin           appvia-gcp
planpolicy-daves-policy            Allocation of daves-policy                                                            config.kore.appvia.io        kore-admin           daves-policy
planpolicy-default-eks             This policy defines which plan properties can be edited by default for EKS clusters   config.kore.appvia.io        kore-admin           default-eks
planpolicy-default-gke             This policy defines which plan properties can be edited by default for GKE clusters   config.kore.appvia.io        kore-admin           default-gke
planpolicy-policy-for-carrot       Allocation of policy-for-carrot                                                       config.kore.appvia.io        kore-admin           policy-for-carrot
```