### PR TITLE
Limit golangci-lint to 2 cpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ spelling:
 
 golangci-lint:
 	@echo "--> Checking against the golangci-lint"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout 5m ./...
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout 5m -j 2 ./...
 
 check:
 	@echo "--> Running code checkers"


### PR DESCRIPTION
## What

The `check` Circle CI job is regularly killed. The default CPU limit is 12 for golangci-lint, so hopefully a more conservative one will solve this. 