### PR TITLE
Fix kind deploy script: only create ns if doesn't exist, run helm upgrade with install

### DIFF
--- a/scripts/kind_dev.sh
+++ b/scripts/kind_dev.sh
@@ -51,6 +51,10 @@ fi
 
 kubectl config use-context kind-kore
 
-kubectl create ns kore
+if ! kubectl get ns kore; then
+  kubectl create ns kore
+fi
 
 make kind-image-dev
+
+helm upgrade -i --namespace kore kore ./charts/kore --wait -f ./charts/my_values.yaml


### PR DESCRIPTION
I forgot to add these two changes to a previous PR.