### PR TITLE
Fix Segmentation Fault

### DIFF
--- a/pkg/kore/setup.go
+++ b/pkg/kore/setup.go
@@ -150,7 +150,7 @@ func (h hubImpl) Setup(ctx context.Context) error {
 		if !strings.HasPrefix(allocation.ObjectMeta.Name, strings.ToLower(allocation.Spec.Resource.Kind)) {
 			newName := strings.ToLower(allocation.Spec.Resource.Kind) + "-" + allocation.ObjectMeta.Name
 
-			allocation, err := h.Teams().Team(HubAdminTeam).Allocations().Get(getAdminContext(ctx), newName)
+			_, err := h.Teams().Team(HubAdminTeam).Allocations().Get(getAdminContext(ctx), newName)
 			if err == nil {
 				logger.Infof("allocation with name %s already exists, don't migrate to the new name, just delete the old one", newName)
 


### PR DESCRIPTION
- fixing up the segmentation fault during an allocation migration

Trying to use the overwritten var at https://github.com/appvia/kore/pull/858/files#diff-cb9b42c972bf87145daaab12f65a6e6bR164