### PR TITLE
Allow to specify secret name for a service credential

### DIFF
--- a/pkg/apiclient/models/v1_service_credentials_spec.go
+++ b/pkg/apiclient/models/v1_service_credentials_spec.go
@@ -30,6 +30,9 @@ type V1ServiceCredentialsSpec struct {
 	// Required: true
 	Kind *string `json:"kind"`
 
+	// secret name
+	SecretName string `json:"secretName,omitempty"`
+
 	// service
 	Service *V1Ownership `json:"service,omitempty"`
 }

--- a/pkg/apis/services/v1/service_credentials_types.go
+++ b/pkg/apis/services/v1/service_credentials_types.go
@@ -50,6 +50,10 @@ type ServiceCredentialsSpec struct {
 	// ClusterNamespace is the target namespace in the cluster where the secret will be created
 	// +kubebuilder:validation:Required
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`
+	// SecretName is the Kubernetes Secret's name that will contain the service access information
+	// If not set the secret's name will default to `Name`
+	// +kubebuilder:validation:Optional
+	SecretName string `json:"secretName,omitempty"`
 	// Configuration are the configuration values for this service credentials
 	// It will be used by the service provider to provision the credentials
 	// +kubebuilder:validation:Type=object
@@ -153,6 +157,15 @@ func NewServiceCredentials(name, namespace string) *ServiceCredentials {
 			Namespace: namespace,
 		},
 	}
+}
+
+// SecretName returns with the Kubernetes Secret's name which will contain the service credential details
+func (s ServiceCredentials) SecretName() string {
+	if s.Spec.SecretName != "" {
+		return s.Spec.SecretName
+	}
+
+	return s.Name
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/services/v1/zz_generated_openapi.go
+++ b/pkg/apis/services/v1/zz_generated_openapi.go
@@ -166,6 +166,13 @@ func schema_pkg_apis_services_v1_ServiceCredentialsSpec(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"secretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecretName is the Kubernetes Secret's name that will contain the service access information If not set the secret's name will default to `Name`",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"configuration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configuration are the configuration values for this service credentials It will be used by the service provider to provision the credentials",

--- a/pkg/apiserver/service_credentials.go
+++ b/pkg/apiserver/service_credentials.go
@@ -29,11 +29,6 @@ func (u teamHandler) listServiceCredentials(req *restful.Request, resp *restful.
 	handleErrors(req, resp, func() error {
 		team := req.PathParameter("team")
 
-		list, err := u.Teams().Team(team).ServiceCredentials().List(req.Request.Context())
-		if err != nil {
-			return err
-		}
-
 		var filters []func(servicesv1.ServiceCredentials) bool
 
 		cluster := req.QueryParameter("cluster")
@@ -46,18 +41,9 @@ func (u teamHandler) listServiceCredentials(req *restful.Request, resp *restful.
 			filters = append(filters, func(s servicesv1.ServiceCredentials) bool { return s.Spec.Service.Name == service })
 		}
 
-		if len(filters) > 0 {
-			filtered := []servicesv1.ServiceCredentials{}
-			for _, item := range list.Items {
-				include := true
-				for _, filter := range filters {
-					include = include && filter(item)
-				}
-				if include {
-					filtered = append(filtered, item)
-				}
-			}
-			list.Items = filtered
+		list, err := u.Teams().Team(team).ServiceCredentials().List(req.Request.Context(), filters...)
+		if err != nil {
+			return err
 		}
 
 		return resp.WriteHeaderAndEntity(http.StatusOK, list)

--- a/pkg/cmd/kore/get/get.go
+++ b/pkg/cmd/kore/get/get.go
@@ -105,6 +105,7 @@ func NewCmdGet(factory cmdutil.Factory) *cobra.Command {
 	if factory.Config().FeatureGates[kore.FeatureGateServices] {
 		command.AddCommand(
 			NewCmdGetServicePlan(factory),
+			NewCmdGetServiceCredential(factory),
 		)
 	}
 

--- a/pkg/cmd/kore/get/servicecredential.go
+++ b/pkg/cmd/kore/get/servicecredential.go
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package get
+
+import (
+	"errors"
+
+	"github.com/appvia/kore/pkg/client"
+	kerrors "github.com/appvia/kore/pkg/cmd/errors"
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	"github.com/appvia/kore/pkg/utils/render"
+
+	"github.com/spf13/cobra"
+)
+
+// GetServiceCredentialOptions the are the options for a get servicecredential command
+type GetServiceCredentialOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+	// Team string
+	Team string
+	// Name is an optional name for the resource
+	Name string
+	// Output is the output format
+	Output string
+	// Headers indicates no headers on the table output
+	Headers bool
+	// Service filters the service credentials for a specific service
+	Service string
+	// Cluster filters the service credentials for a specific cluster
+	Cluster string
+}
+
+// NewCmdGetServiceCredential creates and returns the get servicecredential command
+func NewCmdGetServiceCredential(factory cmdutil.Factory) *cobra.Command {
+	o := &GetServiceCredentialOptions{Factory: factory}
+
+	resource := o.Resources().MustLookup("servicecredential")
+
+	command := &cobra.Command{
+		Use:     "servicecredential",
+		Aliases: []string{"servicecredentials", resource.ShortName},
+		Short:   "Returns all the service plans",
+		Example: "kore get servicecredential [NAME] [options]",
+		Run:     cmdutil.DefaultRunFunc(o),
+	}
+
+	flags := command.Flags()
+	flags.StringVarP(&o.Service, "service", "s", "", "if set the command only returns the service credentials for the given service")
+	flags.StringVarP(&o.Cluster, "cluster", "c", "", "if set the command only returns the service credentials for the given cluster")
+
+	return command
+}
+
+// Validate is used to validate the options
+func (o *GetServiceCredentialOptions) Validate() error {
+	if o.Team == "" {
+		return kerrors.ErrTeamMissing
+	}
+	if o.Name != "" && o.Service != "" {
+		return errors.New("the --service parameter should only be used when listing service credentials")
+	}
+
+	if o.Name != "" && o.Cluster != "" {
+		return errors.New("the --cluster parameter should only be used when listing service credentials")
+	}
+
+	return nil
+}
+
+// Run implements the action
+func (o *GetServiceCredentialOptions) Run() error {
+	resource := o.Resources().MustLookup("servicecredential")
+	request := o.ClientWithTeamResource(o.Team, resource)
+
+	if o.Name != "" {
+		request.Name(o.Name)
+	}
+	if o.Service != "" {
+		request.Parameters(client.QueryParameter("service", o.Service))
+	}
+	if o.Cluster != "" {
+		request.Parameters(client.QueryParameter("cluster", o.Cluster))
+	}
+
+	if err := request.Get().Error(); err != nil {
+		return err
+	}
+
+	display := render.Render().
+		Writer(o.Writer()).
+		ShowHeaders(o.Headers).
+		Format(o.Output).
+		Resource(
+			render.FromReader(request.Body()),
+		).
+		Printer(cmdutil.ConvertColumnsToRender(resource.Printer)...)
+
+	if o.Name == "" {
+		display.Foreach("items")
+	}
+
+	return display.Do()
+}

--- a/pkg/controllers/servicecredentials/delete.go
+++ b/pkg/controllers/servicecredentials/delete.go
@@ -82,7 +82,7 @@ func (c *Controller) delete(
 				APIVersion: k8scorev1.SchemeGroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceCreds.Name,
+				Name:      serviceCreds.SecretName(),
 				Namespace: serviceCreds.Spec.ClusterNamespace,
 			},
 		}

--- a/pkg/controllers/servicecredentials/ensure.go
+++ b/pkg/controllers/servicecredentials/ensure.go
@@ -129,7 +129,7 @@ func (c *Controller) ensureSecret(
 			return reconcile.Result{}, fmt.Errorf("failed to create client from cluster secret: %w", err)
 		}
 
-		exists, err := kubernetes.HasSecret(ctx, client, serviceCreds.Spec.ClusterNamespace, serviceCreds.Name)
+		exists, err := kubernetes.HasSecret(ctx, client, serviceCreds.Spec.ClusterNamespace, serviceCreds.SecretName())
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to get secret from cluster: %w", err)
 		}
@@ -164,7 +164,7 @@ func (c *Controller) ensureSecret(
 				APIVersion: k8scorev1.SchemeGroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceCreds.Name,
+				Name:      serviceCreds.SecretName(),
 				Namespace: serviceCreds.Spec.ClusterNamespace,
 			},
 			Type:       "generic",

--- a/pkg/kore/korefakes/fake_service_credentials.go
+++ b/pkg/kore/korefakes/fake_service_credentials.go
@@ -52,10 +52,11 @@ type FakeServiceCredentials struct {
 		result1 string
 		result2 error
 	}
-	ListStub        func(context.Context) (*v1.ServiceCredentialsList, error)
+	ListStub        func(context.Context, ...func(credentials v1.ServiceCredentials) bool) (*v1.ServiceCredentialsList, error)
 	listMutex       sync.RWMutex
 	listArgsForCall []struct {
 		arg1 context.Context
+		arg2 []func(credentials v1.ServiceCredentials) bool
 	}
 	listReturns struct {
 		result1 *v1.ServiceCredentialsList
@@ -273,16 +274,17 @@ func (fake *FakeServiceCredentials) GetSchemaReturnsOnCall(i int, result1 string
 	}{result1, result2}
 }
 
-func (fake *FakeServiceCredentials) List(arg1 context.Context) (*v1.ServiceCredentialsList, error) {
+func (fake *FakeServiceCredentials) List(arg1 context.Context, arg2 ...func(credentials v1.ServiceCredentials) bool) (*v1.ServiceCredentialsList, error) {
 	fake.listMutex.Lock()
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		arg1 context.Context
-	}{arg1})
-	fake.recordInvocation("List", []interface{}{arg1})
+		arg2 []func(credentials v1.ServiceCredentials) bool
+	}{arg1, arg2})
+	fake.recordInvocation("List", []interface{}{arg1, arg2})
 	fake.listMutex.Unlock()
 	if fake.ListStub != nil {
-		return fake.ListStub(arg1)
+		return fake.ListStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -297,17 +299,17 @@ func (fake *FakeServiceCredentials) ListCallCount() int {
 	return len(fake.listArgsForCall)
 }
 
-func (fake *FakeServiceCredentials) ListCalls(stub func(context.Context) (*v1.ServiceCredentialsList, error)) {
+func (fake *FakeServiceCredentials) ListCalls(stub func(context.Context, ...func(credentials v1.ServiceCredentials) bool) (*v1.ServiceCredentialsList, error)) {
 	fake.listMutex.Lock()
 	defer fake.listMutex.Unlock()
 	fake.ListStub = stub
 }
 
-func (fake *FakeServiceCredentials) ListArgsForCall(i int) context.Context {
+func (fake *FakeServiceCredentials) ListArgsForCall(i int) (context.Context, []func(credentials v1.ServiceCredentials) bool) {
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
 	argsForCall := fake.listArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeServiceCredentials) ListReturns(result1 *v1.ServiceCredentialsList, result2 error) {

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -6642,6 +6642,11 @@ spec:
               description: Kind refers to the service type
               minLength: 1
               type: string
+            secretName:
+              description: SecretName is the Kubernetes Secret's name that will contain
+                the service access information If not set the secret's name will default
+                to ` + "`" + `Name` + "`" + `
+              type: string
             service:
               description: Service contains the reference to the service object
               properties:

--- a/ui/kore-api-swagger.json
+++ b/ui/kore-api-swagger.json
@@ -6761,6 +6761,9 @@
         "kind": {
           "type": "string"
         },
+        "secretName": {
+          "type": "string"
+        },
         "service": {
           "$ref": "#/definitions/v1.Ownership"
         }

--- a/ui/lib/components/teams/service/ServiceCredential.js
+++ b/ui/lib/components/teams/service/ServiceCredential.js
@@ -75,7 +75,7 @@ class ServiceCredential extends AutoRefreshComponent {
           description={
             <>
               <div>
-                <Text>Cluster: <b>{serviceCredential.spec.cluster.name}</b>, namespace: <b>{serviceCredential.spec.clusterNamespace}</b></Text>
+                <Text>Cluster: <b>{serviceCredential.spec.cluster.name}</b>, namespace: <b>{serviceCredential.spec.clusterNamespace}</b>, secret name: <b>{serviceCredential.spec.secretName}</b></Text>
               </div>
               <div>
                 <Text type='secondary'>Created {created}</Text>

--- a/ui/lib/components/teams/service/ServiceCredentialForm.js
+++ b/ui/lib/components/teams/service/ServiceCredentialForm.js
@@ -150,7 +150,7 @@ class ServiceCredentialForm extends React.Component {
       const cluster = clusters.items.find(c => c.metadata.name === values.cluster)
       const service = services.items.find(s => s.metadata.name === values.service)
       const namespaceClaim = namespaceClaims.items.find(n => n.spec.name === values.namespace)
-      const name = values.name
+      const name = `${values.cluster}-${values.namespace}-${values.secretName}`
 
       try {
         const existing = await (await KoreApi.client()).GetServiceCredentials(this.props.team.metadata.name, name)
@@ -187,6 +187,7 @@ class ServiceCredentialForm extends React.Component {
         namespace: this.props.team.metadata.name
       }))
       serviceCredentialSpec.setClusterNamespace(namespaceClaim.spec.name)
+      serviceCredentialSpec.setSecretName(values.secretName)
       serviceCredentialSpec.setConfiguration(config)
 
       serviceCredential.setSpec(serviceCredentialSpec)
@@ -235,7 +236,7 @@ class ServiceCredentialForm extends React.Component {
     }
 
     // Only show error after a field is touched.
-    const nameError = isFieldTouched('name') && getFieldError('name')
+    const secretNameError = isFieldTouched('secretName') && getFieldError('secretName')
     const clusterError = isFieldTouched('cluster') && getFieldError('cluster')
     const serviceError = isFieldTouched('service') && getFieldError('service')
     const namespaceError = (isFieldTouched('cluster') || isFieldTouched('namespace')) && getFieldError('namespace')
@@ -258,14 +259,14 @@ class ServiceCredentialForm extends React.Component {
     return (
       <Form {...formConfig} onSubmit={this.handleSubmit} style={{ marginBottom: '30px' }}>
         <FormErrorMessage />
-        <Form.Item label="Name" validateStatus={nameError ? 'error' : ''} help={nameError || ''}>
-          {getFieldDecorator('name', {
+        <Form.Item label="Secret Name" validateStatus={secretNameError ? 'error' : ''} help={secretNameError || ''}>
+          {getFieldDecorator('secretName', {
             rules: [
-              { required: true, message: 'Please enter the service credential name!' },
+              { required: true, message: 'Please enter the secret name!'  },
               { ...patterns.uriCompatible63CharMax }
             ]
           })(
-            <Input placeholder="Name" />,
+            <Input placeholder="The name of the Kubernetes Secret" />
           )}
         </Form.Item>
         <Form.Item label="Service" validateStatus={serviceError ? 'error' : ''} help={serviceError || ''}>

--- a/ui/lib/kore-api/model/V1ServiceCredentialsSpec.js
+++ b/ui/lib/kore-api/model/V1ServiceCredentialsSpec.js
@@ -62,6 +62,9 @@ class V1ServiceCredentialsSpec {
             if (data.hasOwnProperty('kind')) {
                 obj['kind'] = ApiClient.convertToType(data['kind'], 'String');
             }
+            if (data.hasOwnProperty('secretName')) {
+                obj['secretName'] = ApiClient.convertToType(data['secretName'], 'String');
+            }
             if (data.hasOwnProperty('service')) {
                 obj['service'] = V1Ownership.constructFromObject(data['service']);
             }
@@ -122,6 +125,19 @@ class V1ServiceCredentialsSpec {
         this['kind'] = kind;
     }
 /**
+     * @return {String}
+     */
+    getSecretName() {
+        return this.secretName;
+    }
+
+    /**
+     * @param {String} secretName
+     */
+    setSecretName(secretName) {
+        this['secretName'] = secretName;
+    }
+/**
      * @return {module:model/V1Ownership}
      */
     getService() {
@@ -156,6 +172,11 @@ V1ServiceCredentialsSpec.prototype['configuration'] = undefined;
  * @member {String} kind
  */
 V1ServiceCredentialsSpec.prototype['kind'] = undefined;
+
+/**
+ * @member {String} secretName
+ */
+V1ServiceCredentialsSpec.prototype['secretName'] = undefined;
 
 /**
  * @member {module:model/V1Ownership} service


### PR DESCRIPTION
## What

This PR allows to set the secret name for service credentials, which is required if you want to have secrets with the same name in different namespaces.

I simplified the UI, so you only have to set the Secret Name when creating a secret and we automatically create the credentials object with the name: `[cluster name]-[namespace name]-[secret name]`.