### PR TITLE
Add service platform label to servicekinds + sort out cloud vs provider names in the UI code

### DIFF
--- a/pkg/apiclient/operations/list_service_kinds_parameters.go
+++ b/pkg/apiclient/operations/list_service_kinds_parameters.go
@@ -60,11 +60,16 @@ for the list service kinds operation typically these are written to a http.Reque
 */
 type ListServiceKindsParams struct {
 
-	/*Kind
-	  Filters service kinds for a specific kind
+	/*Enabled
+	  Filters service kinds for enabled/disabled status
 
 	*/
-	Kind *string
+	Enabled *string
+	/*Platform
+	  Filters service kinds for a specific service platform
+
+	*/
+	Platform *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -104,15 +109,26 @@ func (o *ListServiceKindsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithKind adds the kind to the list service kinds params
-func (o *ListServiceKindsParams) WithKind(kind *string) *ListServiceKindsParams {
-	o.SetKind(kind)
+// WithEnabled adds the enabled to the list service kinds params
+func (o *ListServiceKindsParams) WithEnabled(enabled *string) *ListServiceKindsParams {
+	o.SetEnabled(enabled)
 	return o
 }
 
-// SetKind adds the kind to the list service kinds params
-func (o *ListServiceKindsParams) SetKind(kind *string) {
-	o.Kind = kind
+// SetEnabled adds the enabled to the list service kinds params
+func (o *ListServiceKindsParams) SetEnabled(enabled *string) {
+	o.Enabled = enabled
+}
+
+// WithPlatform adds the platform to the list service kinds params
+func (o *ListServiceKindsParams) WithPlatform(platform *string) *ListServiceKindsParams {
+	o.SetPlatform(platform)
+	return o
+}
+
+// SetPlatform adds the platform to the list service kinds params
+func (o *ListServiceKindsParams) SetPlatform(platform *string) {
+	o.Platform = platform
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -123,16 +139,32 @@ func (o *ListServiceKindsParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	if o.Kind != nil {
+	if o.Enabled != nil {
 
-		// query param kind
-		var qrKind string
-		if o.Kind != nil {
-			qrKind = *o.Kind
+		// query param enabled
+		var qrEnabled string
+		if o.Enabled != nil {
+			qrEnabled = *o.Enabled
 		}
-		qKind := qrKind
-		if qKind != "" {
-			if err := r.SetQueryParam("kind", qKind); err != nil {
+		qEnabled := qrEnabled
+		if qEnabled != "" {
+			if err := r.SetQueryParam("enabled", qEnabled); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.Platform != nil {
+
+		// query param platform
+		var qrPlatform string
+		if o.Platform != nil {
+			qrPlatform = *o.Platform
+		}
+		qPlatform := qrPlatform
+		if qPlatform != "" {
+			if err := r.SetQueryParam("platform", qPlatform); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/kore/get/get.go
+++ b/pkg/cmd/kore/get/get.go
@@ -104,6 +104,7 @@ func NewCmdGet(factory cmdutil.Factory) *cobra.Command {
 
 	if factory.Config().FeatureGates[kore.FeatureGateServices] {
 		command.AddCommand(
+			NewCmdGetServiceKind(factory),
 			NewCmdGetServicePlan(factory),
 			NewCmdGetServiceCredential(factory),
 		)

--- a/pkg/cmd/kore/get/servicekind.go
+++ b/pkg/cmd/kore/get/servicekind.go
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package get
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/appvia/kore/pkg/client"
+	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
+	"github.com/appvia/kore/pkg/utils/render"
+
+	"github.com/spf13/cobra"
+)
+
+// GetServiceKindOptions the are the options for a get servicekind ommand
+type GetServiceKindOptions struct {
+	cmdutil.Factory
+	cmdutil.DefaultHandler
+	cmd *cobra.Command
+	// Name is an optional name for the resource
+	Name string
+	// Output is the output format
+	Output string
+	// Headers indicates no headers on the table output
+	Headers bool
+	// Platform filters the service kinds for a specific service platform
+	Platform string
+	// Enabled filters for the enabled/disabled status
+	Enabled bool
+}
+
+// NewCmdGetServiceKind creates and returns the get servicekind command
+func NewCmdGetServiceKind(factory cmdutil.Factory) *cobra.Command {
+	o := &GetServiceKindOptions{Factory: factory}
+
+	resource := o.Resources().MustLookup("servicekind")
+
+	command := &cobra.Command{
+		Use:     "servicekind",
+		Aliases: []string{"servicekinds", resource.ShortName},
+		Short:   "Returns all the service plans",
+		Example: "kore get servicekind [NAME] [options]",
+		Run:     cmdutil.DefaultRunFunc(o),
+	}
+	o.cmd = command
+
+	flags := command.Flags()
+	flags.StringVarP(&o.Platform, "platform", "p", "", "if set the command only returns the service kinds for the given service platform")
+	flags.BoolVarP(&o.Enabled, "enabled", "e", true, "if set the command only returns the enabled/disabled service kinds")
+
+	return command
+}
+
+// Validate is used to validate the options
+func (o *GetServiceKindOptions) Validate() error {
+	if o.Name != "" && o.Platform != "" {
+		return errors.New("the --platform parameter should only be used when listing service kinds")
+	}
+
+	if o.Name != "" && o.cmd.Flag("enabled").Changed {
+		return errors.New("the --enabled parameter should only be used when listing service kinds")
+	}
+
+	return nil
+}
+
+// Run implements the action
+func (o *GetServiceKindOptions) Run() error {
+	resource := o.Resources().MustLookup("servicekind")
+	request := o.ClientWithResource(resource)
+
+	if o.Name != "" {
+		request.Name(o.Name)
+	}
+
+	if o.Platform != "" {
+		request.Parameters(client.QueryParameter("platform", o.Platform))
+	}
+
+	if o.cmd.Flag("enabled").Changed {
+		request.Parameters(client.QueryParameter("enabled", fmt.Sprintf("%v", o.Enabled)))
+	}
+
+	if err := request.Get().Error(); err != nil {
+		return err
+	}
+
+	display := render.Render().
+		Writer(o.Writer()).
+		ShowHeaders(o.Headers).
+		Format(o.Output).
+		Resource(
+			render.FromReader(request.Body()),
+		).
+		Printer(cmdutil.ConvertColumnsToRender(resource.Printer)...)
+
+	if o.Name == "" {
+		display.Foreach("items")
+	}
+
+	return display.Do()
+}

--- a/pkg/cmd/utils/resource_types.go
+++ b/pkg/cmd/utils/resource_types.go
@@ -321,6 +321,7 @@ var (
 				{"Name", "metadata.name", ""},
 				{"Title", "spec.displayName", ""},
 				{"Summary", "spec.summary", ""},
+				{"Platform", "metadata.labels.kore\\.appvia\\.io/platform", ""},
 				{"Enabled", "spec.enabled", ""},
 				{"Age", "metadata.creationTimestamp", "age"},
 			},

--- a/pkg/kore/korefakes/fake_service_kinds.go
+++ b/pkg/kore/korefakes/fake_service_kinds.go
@@ -52,30 +52,17 @@ type FakeServiceKinds struct {
 		result1 bool
 		result2 error
 	}
-	ListStub        func(context.Context) (*v1.ServiceKindList, error)
+	ListStub        func(context.Context, ...func(v1.ServiceKind) bool) (*v1.ServiceKindList, error)
 	listMutex       sync.RWMutex
 	listArgsForCall []struct {
 		arg1 context.Context
+		arg2 []func(v1.ServiceKind) bool
 	}
 	listReturns struct {
 		result1 *v1.ServiceKindList
 		result2 error
 	}
 	listReturnsOnCall map[int]struct {
-		result1 *v1.ServiceKindList
-		result2 error
-	}
-	ListFilteredStub        func(context.Context, func(v1.ServiceKind) bool) (*v1.ServiceKindList, error)
-	listFilteredMutex       sync.RWMutex
-	listFilteredArgsForCall []struct {
-		arg1 context.Context
-		arg2 func(v1.ServiceKind) bool
-	}
-	listFilteredReturns struct {
-		result1 *v1.ServiceKindList
-		result2 error
-	}
-	listFilteredReturnsOnCall map[int]struct {
 		result1 *v1.ServiceKindList
 		result2 error
 	}
@@ -287,16 +274,17 @@ func (fake *FakeServiceKinds) HasReturnsOnCall(i int, result1 bool, result2 erro
 	}{result1, result2}
 }
 
-func (fake *FakeServiceKinds) List(arg1 context.Context) (*v1.ServiceKindList, error) {
+func (fake *FakeServiceKinds) List(arg1 context.Context, arg2 ...func(v1.ServiceKind) bool) (*v1.ServiceKindList, error) {
 	fake.listMutex.Lock()
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		arg1 context.Context
-	}{arg1})
-	fake.recordInvocation("List", []interface{}{arg1})
+		arg2 []func(v1.ServiceKind) bool
+	}{arg1, arg2})
+	fake.recordInvocation("List", []interface{}{arg1, arg2})
 	fake.listMutex.Unlock()
 	if fake.ListStub != nil {
-		return fake.ListStub(arg1)
+		return fake.ListStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -311,17 +299,17 @@ func (fake *FakeServiceKinds) ListCallCount() int {
 	return len(fake.listArgsForCall)
 }
 
-func (fake *FakeServiceKinds) ListCalls(stub func(context.Context) (*v1.ServiceKindList, error)) {
+func (fake *FakeServiceKinds) ListCalls(stub func(context.Context, ...func(v1.ServiceKind) bool) (*v1.ServiceKindList, error)) {
 	fake.listMutex.Lock()
 	defer fake.listMutex.Unlock()
 	fake.ListStub = stub
 }
 
-func (fake *FakeServiceKinds) ListArgsForCall(i int) context.Context {
+func (fake *FakeServiceKinds) ListArgsForCall(i int) (context.Context, []func(v1.ServiceKind) bool) {
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
 	argsForCall := fake.listArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeServiceKinds) ListReturns(result1 *v1.ServiceKindList, result2 error) {
@@ -345,70 +333,6 @@ func (fake *FakeServiceKinds) ListReturnsOnCall(i int, result1 *v1.ServiceKindLi
 		})
 	}
 	fake.listReturnsOnCall[i] = struct {
-		result1 *v1.ServiceKindList
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServiceKinds) ListFiltered(arg1 context.Context, arg2 func(v1.ServiceKind) bool) (*v1.ServiceKindList, error) {
-	fake.listFilteredMutex.Lock()
-	ret, specificReturn := fake.listFilteredReturnsOnCall[len(fake.listFilteredArgsForCall)]
-	fake.listFilteredArgsForCall = append(fake.listFilteredArgsForCall, struct {
-		arg1 context.Context
-		arg2 func(v1.ServiceKind) bool
-	}{arg1, arg2})
-	fake.recordInvocation("ListFiltered", []interface{}{arg1, arg2})
-	fake.listFilteredMutex.Unlock()
-	if fake.ListFilteredStub != nil {
-		return fake.ListFilteredStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.listFilteredReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeServiceKinds) ListFilteredCallCount() int {
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
-	return len(fake.listFilteredArgsForCall)
-}
-
-func (fake *FakeServiceKinds) ListFilteredCalls(stub func(context.Context, func(v1.ServiceKind) bool) (*v1.ServiceKindList, error)) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = stub
-}
-
-func (fake *FakeServiceKinds) ListFilteredArgsForCall(i int) (context.Context, func(v1.ServiceKind) bool) {
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
-	argsForCall := fake.listFilteredArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeServiceKinds) ListFilteredReturns(result1 *v1.ServiceKindList, result2 error) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = nil
-	fake.listFilteredReturns = struct {
-		result1 *v1.ServiceKindList
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServiceKinds) ListFilteredReturnsOnCall(i int, result1 *v1.ServiceKindList, result2 error) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = nil
-	if fake.listFilteredReturnsOnCall == nil {
-		fake.listFilteredReturnsOnCall = make(map[int]struct {
-			result1 *v1.ServiceKindList
-			result2 error
-		})
-	}
-	fake.listFilteredReturnsOnCall[i] = struct {
 		result1 *v1.ServiceKindList
 		result2 error
 	}{result1, result2}
@@ -486,8 +410,6 @@ func (fake *FakeServiceKinds) Invocations() map[string][][]interface{} {
 	defer fake.hasMutex.RUnlock()
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/serviceproviders/application/provider.go
+++ b/pkg/serviceproviders/application/provider.go
@@ -56,6 +56,9 @@ func (p Provider) Catalog(ctx kore.Context, provider *servicesv1.ServiceProvider
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ServiceKindApp,
 					Namespace: kore.HubNamespace,
+					Labels: map[string]string{
+						kore.Label("platform"): "Kubernetes",
+					},
 				},
 				Spec: servicesv1.ServiceKindSpec{
 					DisplayName: "Kubernetes Application",
@@ -72,6 +75,9 @@ func (p Provider) Catalog(ctx kore.Context, provider *servicesv1.ServiceProvider
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ServiceKindHelmApp,
 					Namespace: kore.HubNamespace,
+					Labels: map[string]string{
+						kore.Label("platform"): "Kubernetes",
+					},
 				},
 				Spec: servicesv1.ServiceKindSpec{
 					DisplayName: "Kubernetes Helm Application",

--- a/pkg/serviceproviders/awsservicebroker/factory.go
+++ b/pkg/serviceproviders/awsservicebroker/factory.go
@@ -41,7 +41,6 @@ const (
 	ComponentDynamoDB    = "DynamoDB Table"
 	ComponentS3Bucket    = "S3 Bucket"
 	ComponentHelmRelease = "Helm Release"
-	ComponentProvider    = "Provider"
 )
 
 type ProviderFactory struct{}
@@ -150,6 +149,10 @@ func (d ProviderFactory) Create(ctx kore.Context, serviceProvider *servicesv1.Se
 
 	if err := serviceProvider.Spec.GetConfiguration(config); err != nil {
 		return nil, fmt.Errorf("failed to process aws-servicebroker configuration: %w", err)
+	}
+
+	config.PlatformMapping = map[string]string{
+		"*": "AWS",
 	}
 
 	namespaceName := "kore-serviceprovider-" + serviceProvider.Name

--- a/pkg/serviceproviders/dummy.go
+++ b/pkg/serviceproviders/dummy.go
@@ -103,6 +103,9 @@ func (d Dummy) kinds() []servicesv1.ServiceKind {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy",
 				Namespace: kore.HubNamespace,
+				Labels: map[string]string{
+					kore.Label("platform"): "Kore",
+				},
 			},
 			Spec: servicesv1.ServiceKindSpec{
 				DisplayName: "Dummy",

--- a/pkg/serviceproviders/openservicebroker/factory.go
+++ b/pkg/serviceproviders/openservicebroker/factory.go
@@ -137,6 +137,11 @@ func (p ProviderFactory) JSONSchema() string {
 					"type": "string",
 					"minLength": 1
 				}
+			},
+			"platformMapping": {
+				"type": "object",
+				"minProperties": 1,
+				"additionalProperties": { "type": "string" }
 			}
 		}
 	}`

--- a/pkg/serviceproviders/openservicebroker/provider.go
+++ b/pkg/serviceproviders/openservicebroker/provider.go
@@ -100,6 +100,11 @@ func (p *Provider) Catalog(ctx kore.Context, serviceProvider *servicesv1.Service
 			summary = strings.Title(catalogService.Name)
 		}
 
+		platform := p.config.PlatformMapping[catalogService.Name]
+		if platform == "" {
+			platform = p.config.PlatformMapping["*"]
+		}
+
 		serviceKind := servicesv1.ServiceKind{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       servicesv1.ServiceKindGVK.Kind,
@@ -108,6 +113,9 @@ func (p *Provider) Catalog(ctx kore.Context, serviceProvider *servicesv1.Service
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      catalogService.Name,
 				Namespace: kore.HubNamespace,
+				Labels: map[string]string{
+					kore.Label("platform"): platform,
+				},
 			},
 			Spec: servicesv1.ServiceKindSpec{
 				DisplayName:      getMetadataStringVal(catalogService.Metadata, MetadataKeyDisplayName, ""),

--- a/pkg/serviceproviders/openservicebroker/provider_test.go
+++ b/pkg/serviceproviders/openservicebroker/provider_test.go
@@ -206,6 +206,9 @@ var _ = Describe("Provider", func() {
 		logger.Out = GinkgoWriter
 
 		providerConfig = openservicebroker.ProviderConfiguration{}
+		providerConfig.PlatformMapping = map[string]string{
+			"*": "testplatform",
+		}
 
 		serviceProvider = servicesv1.NewServiceProvider("test", "testns")
 
@@ -286,6 +289,9 @@ var _ = Describe("Provider", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service-1",
 					Namespace: kore.HubNamespace,
+					Labels: map[string]string{
+						"kore.appvia.io/platform": "testplatform",
+					},
 				},
 				Spec: servicesv1.ServiceKindSpec{
 					DisplayName:      "service-1 displayName",
@@ -304,6 +310,9 @@ var _ = Describe("Provider", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service-2",
 					Namespace: kore.HubNamespace,
+					Labels: map[string]string{
+						"kore.appvia.io/platform": "testplatform",
+					},
 				},
 				Spec: servicesv1.ServiceKindSpec{
 					DisplayName:      "service-2 displayName",

--- a/pkg/serviceproviders/openservicebroker/types.go
+++ b/pkg/serviceproviders/openservicebroker/types.go
@@ -33,6 +33,9 @@ type CatalogConfiguration struct {
 	IncludePlans []string `json:"includePlans,omitempty"`
 	// ExcludePlans is a list of service plan names (`[kind]-[plan name]`) to exclude from the catalog
 	ExcludePlans []string `json:"excludePlans,omitempty"`
+	// PlatformMapping is a list of service kind and platform name pairs, to map service kinds to service platforms
+	// You can use "*" as the service kind name to map all service kinds to a specific platform
+	PlatformMapping map[string]string `json:"platformMapping,omitempty"`
 }
 
 type ProviderConfiguration struct {

--- a/ui/__tests__/unit/lib/components/teams/cluster/ClusterBuildForm.test.js
+++ b/ui/__tests__/unit/lib/components/teams/cluster/ClusterBuildForm.test.js
@@ -54,16 +54,16 @@ describe('ClusterBuildForm', () => {
       // Check API has been accessed as expected.
       apiScope.done()
       expect(form.state.plans).toEqual(plans)
-      expect(form.state.credentials.GKE.credentials).toEqual([{ ...allocations[0] }])
-      expect(form.state.credentials.GKE.accountManagement).toEqual({ ...allocations[2] })
-      expect(form.state.credentials.EKS.credentials).toEqual([{ ...allocations[1] }])
-      expect(form.state.credentials.EKS.accountManagement).toEqual(undefined)
+      expect(form.state.credentials.GCP.credentials).toEqual([{ ...allocations[0] }])
+      expect(form.state.credentials.GCP.accountManagement).toEqual({ ...allocations[2] })
+      expect(form.state.credentials.AWS.credentials).toEqual([{ ...allocations[1] }])
+      expect(form.state.credentials.AWS.accountManagement).toEqual(undefined)
     })
   })
 
   describe('#getClusterResource', () => {
     it('should return a configured cluster object when given valid values', () => {
-      form.handleSelectCloud('GKE')
+      form.handleSelectCloud('GCP')
       const cluster = form.getClusterResource({ credential: 'GKE', plan: plans.items[0].metadata.name, clusterName: 'abc-test-cluster' })
       expect(cluster).toBeDefined()
     })

--- a/ui/config.js
+++ b/ui/config.js
@@ -64,7 +64,4 @@ module.exports = {
     showPrototypes: process.env.NODE_ENV === 'development' || process.env.KORE_UI_SHOW_PROTOTYPES === 'true',
     featureGates: getFeatureGates()
   },
-  cloudServiceProviderMap: {
-    'EKS': 'aws-servicebroker'
-  }
 }

--- a/ui/config.js
+++ b/ui/config.js
@@ -64,4 +64,8 @@ module.exports = {
     showPrototypes: process.env.NODE_ENV === 'development' || process.env.KORE_UI_SHOW_PROTOTYPES === 'true',
     featureGates: getFeatureGates()
   },
+  clusterProviderMap: {
+    'AWS': 'EKS',
+    'GCP': 'GKE'
+  }
 }

--- a/ui/config.public.js
+++ b/ui/config.public.js
@@ -13,5 +13,4 @@ module.exports = {
   gtmId: config.kore.gtmId,
   showPrototypes: config.kore.showPrototypes,
   featureGates: config.kore.featureGates,
-  cloudServiceProviderMap: config.cloudServiceProviderMap
 }

--- a/ui/config.public.js
+++ b/ui/config.public.js
@@ -13,4 +13,5 @@ module.exports = {
   gtmId: config.kore.gtmId,
   showPrototypes: config.kore.showPrototypes,
   featureGates: config.kore.featureGates,
+  clusterProviderMap: config.clusterProviderMap
 }

--- a/ui/kore-api-swagger.json
+++ b/ui/kore-api-swagger.json
@@ -1285,8 +1285,14 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Filters service kinds for a specific kind",
-            "name": "kind",
+            "description": "Filters service kinds for a specific service platform",
+            "name": "platform",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filters service kinds for enabled/disabled status",
+            "name": "enabled",
             "in": "query"
           }
         ],

--- a/ui/lib/components/common/CloudSelector.js
+++ b/ui/lib/components/common/CloudSelector.js
@@ -4,7 +4,7 @@ import { Typography, Row, Col, Card, Tag } from 'antd'
 const { Title, Paragraph } = Typography
 
 class CloudSelector extends React.Component {
-  static DEFAULT_ENABLED_CLOUDS = ['GKE', 'EKS']
+  static DEFAULT_ENABLED_CLOUDS = ['GCP', 'AWS']
 
   static propTypes = {
     selectedCloud: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
@@ -38,11 +38,11 @@ class CloudSelector extends React.Component {
         <Col span={6}>
           <Card
             id="gcp"
-            onClick={this.selectCloud('GKE')}
-            hoverable={enabledCloudList.includes('GKE')}
-            className={ selectedCloud === 'GKE' ? 'cloud-card selected' : 'cloud-card' }
+            onClick={this.selectCloud('GCP')}
+            hoverable={enabledCloudList.includes('GCP')}
+            className={ selectedCloud === 'GCP' ? 'cloud-card selected' : 'cloud-card' }
           >
-            {enabledCloudList.includes('GKE') ? (
+            {enabledCloudList.includes('GCP') ? (
               <>
                 <Paragraph className="logo">
                   <img src="/static/images/GCP.png" height="80px" />
@@ -65,11 +65,11 @@ class CloudSelector extends React.Component {
         <Col span={6}>
           <Card
             id="aws"
-            onClick={this.selectCloud('EKS')}
-            hoverable={enabledCloudList.includes('EKS')}
-            className={ selectedCloud === 'EKS' ? 'cloud-card selected' : 'cloud-card' }
+            onClick={this.selectCloud('AWS')}
+            hoverable={enabledCloudList.includes('AWS')}
+            className={ selectedCloud === 'AWS' ? 'cloud-card selected' : 'cloud-card' }
           >
-            {enabledCloudList.includes('EKS') ? (
+            {enabledCloudList.includes('AWS') ? (
               <>
                 <Paragraph className="logo">
                   <img src="/static/images/AWS.png" height="80px" />

--- a/ui/lib/components/plans/ManageClusterPlanForm.js
+++ b/ui/lib/components/plans/ManageClusterPlanForm.js
@@ -75,7 +75,7 @@ class ManageClusterPlanForm extends ManagePlanForm {
 
       if (this.accountManagementRulesEnabled()) {
         const accountMgtResource = copy(this.state.accountManagement)
-        const currentRule = this.props.data.gcpAutomatedProject ? accountMgtResource.spec.rules.find(r => r.name === this.props.data.gcpAutomatedProject.name) : null
+        const currentRule = this.props.data && this.props.data.gcpAutomatedProject ? accountMgtResource.spec.rules.find(r => r.name === this.props.data.gcpAutomatedProject.name) : null
         if (values.gcpAutomatedProject) {
           // add to the new rule
           const addedToRule = accountMgtResource.spec.rules.find(r => r.name === values.gcpAutomatedProject)
@@ -113,7 +113,7 @@ class ManageClusterPlanForm extends ManagePlanForm {
   allowAutomatedProjectSelectionClear = () => {
     // only allow clearing of the automated project if it's a new selection or there's more than one plan in the rule
     // a rule cannot be left with no plans
-    if (!this.props.data.gcpAutomatedProject) {
+    if (!this.props.data || !this.props.data.gcpAutomatedProject) {
       return true
     }
     const planRule = this.state.accountManagement.spec.rules.find(r => r.name === this.props.data.gcpAutomatedProject.name)

--- a/ui/lib/components/resources/ResourceList.js
+++ b/ui/lib/components/resources/ResourceList.js
@@ -46,7 +46,7 @@ class ResourceList extends React.Component {
       this.setState({
         resources: {
           ...state.resources,
-          items: state.resources.map((r) => r.metadata.name !== updatedResource.metadata.name ? r : { ...r, status: updatedResource.status })
+          items: state.resources.items.map((r) => r.metadata.name !== updatedResource.metadata.name ? r : { ...r, status: updatedResource.status })
         }
       })
     }, done)

--- a/ui/lib/components/services/CloudServiceAdmin.js
+++ b/ui/lib/components/services/CloudServiceAdmin.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 import ServiceKindList from './ServiceKindList'
-import { getKoreLabel } from '../../utils/crd-helpers';
+import { getKoreLabel } from '../../utils/crd-helpers'
 
 export default class CloudServiceAdmin extends React.Component {
   static propTypes = {

--- a/ui/lib/components/services/CloudServiceAdmin.js
+++ b/ui/lib/components/services/CloudServiceAdmin.js
@@ -1,56 +1,17 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import KoreApi from '../../kore-api'
-import { Alert, Icon } from 'antd'
 import ServiceKindList from './ServiceKindList'
+import { getKoreLabel } from '../../utils/crd-helpers';
 
 export default class CloudServiceAdmin extends React.Component {
   static propTypes = {
     cloud: PropTypes.string
   }
 
-  state = {
-    loading: true,
-    provider: null
-  }
-
-  static BROKERS = {
-    'AWS': 'aws-servicebroker'
-  }
-
-  async getServiceProvider(type) {
-    const api = await KoreApi.client()
-    const serviceProviders = await api.ListServiceProviders()
-    return serviceProviders.items.find((p) => p.spec.type === type)
-  }
-
-  componentDidMountComplete = null  
-  componentDidMount = () => {
-    this.componentDidMountComplete = Promise.resolve().then(async () => {
-      let provider = null
-      if (CloudServiceAdmin.BROKERS[this.props.cloud]) {
-        provider = await this.getServiceProvider(CloudServiceAdmin.BROKERS[this.props.cloud])
-      }
-      this.setState({
-        loading: false, provider
-      })
-    })
-  }
-
-  filterKindsForProvider = (kind) => {
-    const { provider } = this.state
-    return provider.status.supportedKinds.indexOf(kind.metadata.name) > -1
-  }
-
   render() {
     const { cloud } = this.props
-    const { loading, provider } = this.state
     return (
-      <>
-        {loading ? <Icon type="loading" /> : (
-          <>{!provider ? <Alert type="warning" message={`No provider available to provision ${cloud} cloud services`}/> : <ServiceKindList filter={this.filterKindsForProvider} />}</>
-        )}
-      </>
+      <ServiceKindList filter={ (s) => getKoreLabel(s, 'platform') === cloud } />
     )
   }
 }

--- a/ui/lib/components/services/ServiceKindList.js
+++ b/ui/lib/components/services/ServiceKindList.js
@@ -78,8 +78,11 @@ export default class ServiceKindList extends React.Component {
 
   render() {
     const { kinds, loading } = this.state
-    if (loading && (!kinds || kinds.length === 0)) {
+    if (loading) {
       return <Icon type="loading" />
+    }
+    if (!kinds || kinds.length === 0) {
+      return <Alert type="warning" message="No services are available to provision" />
     }
     return (
       <>

--- a/ui/lib/components/setup/ExistingCloudAccounts.js
+++ b/ui/lib/components/setup/ExistingCloudAccounts.js
@@ -74,7 +74,7 @@ class ExistingCloudAccounts extends React.Component {
 
   stepsContentAccess = () => {
     return (
-      <RequestCredentialAccessForm cloud="EKS" onChange={(errors) => this.setState({ emailValid: Boolean(!errors) })} />
+      <RequestCredentialAccessForm cloud="AWS" onChange={(errors) => this.setState({ emailValid: Boolean(!errors) })} />
     )
   }
 

--- a/ui/lib/components/setup/GCPProjectAutomationSettings.js
+++ b/ui/lib/components/setup/GCPProjectAutomationSettings.js
@@ -330,7 +330,7 @@ class GCPProjectAutomationSettings extends React.Component {
         </div>
         {gcpManagementType === 'KORE' && !gcpOrgsExist && <this.gcpOrgRequired />}
         {gcpManagementType === 'KORE' && gcpOrgsExist && <this.koreManagedProjectsSettings />}
-        {gcpManagementType === 'EXISTING' && <RequestCredentialAccessForm cloud="GKE" helpInModal={true} onChange={(errors) => this.setState({ emailValid: Boolean(!errors) })}  />}
+        {gcpManagementType === 'EXISTING' && <RequestCredentialAccessForm cloud="GCP" helpInModal={true} onChange={(errors) => this.setState({ emailValid: Boolean(!errors) })}  />}
         <Button style={{ marginTop: '20px', display: 'block' }} type="primary" loading={submitting} disabled={this.disabledSave()} onClick={this.saveSettings}>Save</Button>
       </>
     )

--- a/ui/lib/components/setup/forms/RequestCredentialAccessForm.js
+++ b/ui/lib/components/setup/forms/RequestCredentialAccessForm.js
@@ -10,13 +10,13 @@ class RequestCredentialAccessForm extends React.Component {
 
   static propTypes = {
     form: PropTypes.object.isRequired,
-    cloud: PropTypes.oneOf(['GKE', 'EKS']).isRequired,
+    cloud: PropTypes.oneOf(['GCP', 'AWS']).isRequired,
     onChange: PropTypes.func,
     helpInModal: PropTypes.bool
   }
 
   cloudContent = {
-    'GKE': {
+    'GCP': {
       accountNoun: 'Project',
       help: RequestCredentialAccessForm.ENABLED ? (
         <div>
@@ -30,7 +30,7 @@ class RequestCredentialAccessForm extends React.Component {
         </div>
       )
     },
-    'EKS': {
+    'AWS': {
       accountNoun: 'Account',
       help: RequestCredentialAccessForm.ENABLED ? (
         <div>

--- a/ui/lib/components/teams/cluster/ClusterBuildForm.js
+++ b/ui/lib/components/teams/cluster/ClusterBuildForm.js
@@ -12,6 +12,8 @@ import KoreApi from '../../../kore-api'
 import V1ClusterSpec from '../../../kore-api/model/V1ClusterSpec'
 import V1Cluster from '../../../kore-api/model/V1Cluster'
 import V1ObjectMeta from '../../../kore-api/model/V1ObjectMeta'
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 class ClusterBuildForm extends React.Component {
   static propTypes = {
@@ -30,6 +32,7 @@ class ClusterBuildForm extends React.Component {
       submitting: false,
       formErrorMessage: false,
       selectedCloud: '',
+      selectedProvider: '',
       dataLoading: true,
       credentials: {},
       planOverride: null,
@@ -57,11 +60,11 @@ class ClusterBuildForm extends React.Component {
       const eksCredentials = (allocations.items || []).filter(a => a.spec.resource.kind === 'EKSCredentials')
       this.setState({
         credentials: {
-          GKE: {
+          GCP: {
             credentials: gkeCredentials,
             accountManagement: gcpAccountManagement
           },
-          EKS: {
+          AWS: {
             credentials: eksCredentials,
             accountManagement: undefined
           }
@@ -147,6 +150,7 @@ class ClusterBuildForm extends React.Component {
   handleSelectCloud = cloud => {
     this.setState({
       selectedCloud: cloud,
+      selectedProvider: publicRuntimeConfig.clusterProviderMap[cloud],
       planOverride: null,
       validationErrors: null
     })
@@ -159,8 +163,8 @@ class ClusterBuildForm extends React.Component {
   }
 
   clusterBuildForm = () => {
-    const { submitting, selectedCloud, formErrorMessage } = this.state
-    const filteredPlans = this.state.plans.items.filter(p => p.spec.kind === selectedCloud)
+    const { submitting, selectedCloud, selectedProvider, formErrorMessage } = this.state
+    const filteredPlans = this.state.plans.items.filter(p => p.spec.kind === selectedProvider)
     const filteredCredentials = this.state.credentials[selectedCloud].credentials
     const accountManagement = this.state.credentials[selectedCloud].accountManagement
     const formConfig = {
@@ -185,6 +189,7 @@ class ClusterBuildForm extends React.Component {
         <ClusterOptionsForm
           team={this.props.team}
           selectedCloud={selectedCloud}
+          selectedProvider={selectedProvider}
           credentials={filteredCredentials}
           accountManagement={accountManagement}
           plans={filteredPlans}

--- a/ui/lib/components/teams/cluster/ClusterOptionsForm.js
+++ b/ui/lib/components/teams/cluster/ClusterOptionsForm.js
@@ -14,6 +14,7 @@ class ClusterOptionsForm extends React.Component {
     form: PropTypes.any.isRequired,
     team: PropTypes.object.isRequired,
     selectedCloud: PropTypes.string.isRequired,
+    selectedProvider: PropTypes.string.isRequired,
     credentials: PropTypes.array.isRequired,
     accountManagement: PropTypes.object,
     plans: PropTypes.array.isRequired,
@@ -81,7 +82,7 @@ class ClusterOptionsForm extends React.Component {
 
   render() {
     const { getFieldDecorator, getFieldValue } = this.props.form
-    const { credentials, accountManagement, selectedCloud } = this.props
+    const { credentials, accountManagement, selectedCloud, selectedProvider } = this.props
     const selectedPlan = getFieldValue('plan')
 
     const checkForDuplicateName = (rule, value) => {
@@ -92,7 +93,7 @@ class ClusterOptionsForm extends React.Component {
       return Promise.reject('This name is already used!')
     }
 
-    const cloudAccountName = { 'GKE': 'Project', 'EKS': 'Account' }[selectedCloud]
+    const cloudAccountName = { 'GCP': 'Project', 'AWS': 'Account' }[selectedCloud]
 
     return (
       <Card title="Cluster options">
@@ -166,7 +167,7 @@ class ClusterOptionsForm extends React.Component {
               <UsePlanForm
                 team={this.props.team}
                 resourceType="cluster"
-                kind={selectedCloud}
+                kind={selectedProvider}
                 plan={selectedPlan}
                 validationErrors={this.props.validationErrors}
                 onPlanChange={this.onPlanOverridden}

--- a/ui/lib/components/teams/cluster/MissingCredential.js
+++ b/ui/lib/components/teams/cluster/MissingCredential.js
@@ -5,17 +5,17 @@ const { Paragraph, Text } = Typography
 
 const MissingCredential = ({ team, cloud }) => {
   const message = {
-    'GKE': 'GCP project access not found',
-    'EKS': 'AWS account access not found'
+    'GCP': 'GCP project access not found',
+    'AWS': 'AWS account access not found'
   }
   const description = {
-    'GKE': (
+    'GCP': (
       <>
         <Paragraph>This team does not have access to create clusters in any GCP projects. Please use the contact below to grant this team access to a GCP project.</Paragraph>
         <Text strong>Kore administrator</Text>
       </>
     ),
-    'EKS': (
+    'AWS': (
       <>
         <Paragraph>This team does not have access to create clusters in any AWS accounts. Please use the contact below to grant this team access to an AWS account.</Paragraph>
         <Text strong>Kore administrator</Text>

--- a/ui/lib/components/teams/service/ServiceBuildForm.js
+++ b/ui/lib/components/teams/service/ServiceBuildForm.js
@@ -18,7 +18,7 @@ import V1ObjectMeta from '../../../kore-api/model/V1ObjectMeta'
 import V1ServiceCredentials from '../../../kore-api/model/V1ServiceCredentials'
 import V1ServiceCredentialsSpec from '../../../kore-api/model/V1ServiceCredentialsSpec'
 import { NewV1ObjectMeta, NewV1Ownership } from '../../../utils/model'
-import { getKoreLabel } from '../../../utils/crd-helpers';
+import { getKoreLabel } from '../../../utils/crd-helpers'
 
 class ServiceBuildForm extends React.Component {
   static propTypes = {
@@ -304,7 +304,7 @@ class ServiceBuildForm extends React.Component {
 
     return (
       <div>
-        <CloudSelector showCustom={false} selectedCloud={selectedCloud} handleSelectCloud={this.handleSelectCloud} enabledCloudList={['EKS']}/>
+        <CloudSelector showCustom={false} selectedCloud={selectedCloud} handleSelectCloud={this.handleSelectCloud} enabledCloudList={['AWS']}/>
         {selectedCloud && (
           <Form {...formConfig} onSubmit={this.handleSubmit}>
             <Card style={{ marginBottom: '20px' }}>

--- a/ui/lib/prototype/components/common/CloudSelector.js
+++ b/ui/lib/prototype/components/common/CloudSelector.js
@@ -32,9 +32,9 @@ class CloudSelector extends React.Component {
         <Col span={12}>
           <Card
             id="aws"
-            onClick={this.selectCloud('EKS')}
+            onClick={this.selectCloud('AWS')}
             hoverable={true}
-            className={ selectedCloud === 'EKS' ? 'cloud-card selected' : 'cloud-card' }
+            className={ selectedCloud === 'AWS' ? 'cloud-card selected' : 'cloud-card' }
           >
             <Paragraph className="logo" style={{ marginBottom: '0' }}>
               <img src="/static/images/AWS.png" height="80px" />
@@ -46,7 +46,7 @@ class CloudSelector extends React.Component {
           <Card
             id="gcp"
             hoverable={false}
-            className={ selectedCloud === 'GKE' ? 'cloud-card selected' : 'cloud-card' }
+            className={ selectedCloud === 'GCP' ? 'cloud-card selected' : 'cloud-card' }
           >
             <Paragraph className="logo" style={{ marginBottom: '0' }}>
               <img src="/static/images/GCP.png" height="80px" />

--- a/ui/lib/prototype/components/configure/ProjectAutomationSettings.js
+++ b/ui/lib/prototype/components/configure/ProjectAutomationSettings.js
@@ -322,7 +322,7 @@ class ProjectAutomationSettings extends React.Component {
                               <div style={{ padding: '5px 0' }}>
 
                                 <Popover
-                                  content={this.associatePlanContent(project.code, 'GKE')}
+                                  content={this.associatePlanContent(project.code, 'GCP')}
                                   title={`${project.title}: Associate plans`}
                                   trigger="click"
                                   visible={associatePlanVisible === project.code}

--- a/ui/lib/prototype/components/teams/service/ServiceForm.js
+++ b/ui/lib/prototype/components/teams/service/ServiceForm.js
@@ -51,7 +51,7 @@ class ServiceForm extends React.Component {
   }]
 
   state = {
-    selectedCloud: 'EKS',
+    selectedCloud: 'AWS',
     selectedService: '',
     formErrorMessage: false
   }

--- a/ui/lib/utils/crd-helpers.js
+++ b/ui/lib/utils/crd-helpers.js
@@ -2,3 +2,10 @@
 export function isReadOnlyCRD(crd) {
   return crd && crd.metadata && crd.metadata.annotations && crd.metadata.annotations['kore.appvia.io/readonly']
 }
+
+export function getKoreLabel(obj, name) {
+  if (obj && obj.metadata && obj.metadata.labels) {
+    return obj.metadata.labels[`kore.appvia.io/${name}`] || ''
+  }
+  return ''
+}

--- a/ui/pages/prototype/setup/kore/cloud-access.js
+++ b/ui/pages/prototype/setup/kore/cloud-access.js
@@ -10,6 +10,8 @@ import KoreApi from '../../../../lib/kore-api'
 import GKECredentialsList from '../../../../lib/components/credentials/GKECredentialsList'
 import PlanViewer from '../../../../lib/components/plans/PlanViewer'
 import CloudSelector from '../../../../lib/components/common/CloudSelector'
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 // prototype components
 import GCPOrganizationsList from '../../../../lib/prototype/components/credentials/GCPOrganizationsList'
@@ -51,6 +53,7 @@ class CloudAccessPage extends React.Component {
 
   state = {
     selectedCloud: '',
+    selectedProvider: '',
     gcpManagementType: '',
     gcpProjectAutomationType: '',
     gcpProjectList: [],
@@ -98,11 +101,10 @@ class CloudAccessPage extends React.Component {
   }
 
   handleSelectCloud = cloud => {
-    if (this.state.selectedCloud !== cloud) {
-      const state = copy(this.state)
-      state.selectedCloud = cloud
-      this.setState(state)
-    }
+    this.setState({
+      selectedCloud: cloud,
+      selectedProvider: publicRuntimeConfig.clusterProviderMap[cloud]
+    })
   }
 
   selectGcpManagementType = e => this.setState({ gcpManagementType: e.target.value })
@@ -156,7 +158,7 @@ class CloudAccessPage extends React.Component {
 
   associatePlanContent = (projectCode) => {
     const project = this.state.gcpProjectList.find(p => p.code === projectCode)
-    const cloudPlans = this.state.plans.filter(p => p.spec.kind === this.state.selectedCloud)
+    const cloudPlans = this.state.plans.filter(p => p.spec.kind === this.state.selectedProvider)
     const unassociatedPlans = cloudPlans.filter(p => !project.plans.includes(p.metadata.name))
     if (unassociatedPlans.length === 0) {
       return (
@@ -241,7 +243,7 @@ class CloudAccessPage extends React.Component {
         <div style={{ marginTop: '20px', marginBottom: '20px' }}>
           <CloudSelector selectedCloud={selectedCloud} handleSelectCloud={this.handleSelectCloud} />
         </div>
-        { selectedCloud === 'GKE' ? (
+        { selectedCloud === 'GCP' ? (
           <Card>
 
             <div style={{ marginBottom: '15px' }}>
@@ -532,7 +534,7 @@ class CloudAccessPage extends React.Component {
           </Card>
         ) : null }
 
-        { selectedCloud === 'EKS' ? (
+        { selectedCloud === 'AWS' ? (
           <Card>
             <Alert
               message="Amazon Web Services"

--- a/ui/pages/setup/kore/cloud-access.js
+++ b/ui/pages/setup/kore/cloud-access.js
@@ -74,8 +74,8 @@ class CloudAccessPage extends React.Component {
         <div style={{ marginTop: '20px', marginBottom: '20px' }}>
           <CloudSelector selectedCloud={selectedCloud} handleSelectCloud={this.handleSelectCloud} />
         </div>
-        {selectedCloud === 'GKE' && <GCPSetup accountManagement={gcpAccountManagement} gkeCredentialsList={gkeCredentialsList} />}
-        {selectedCloud === 'EKS' && <AWSSetup />}
+        {selectedCloud === 'GCP' && <GCPSetup accountManagement={gcpAccountManagement} gkeCredentialsList={gkeCredentialsList} />}
+        {selectedCloud === 'AWS' && <AWSSetup />}
       </>
     )
   }


### PR DESCRIPTION
## What

This adds a `kore.appvia.io/platform` label to the ServiceKinds:
 * if it's a cloud service it will be: "AWS", "GCP", etc.
 * if it's an in-cluster service, it will be "Kubernetes"
 * if it's a service provided by Kore, then it will be "Kore" (no real use-case for this yet)

I've added a custom `get servicekind` command, so you can filter for `platform` and/or `enabled` status.
There is a new platformMapping configuration value for the open service broker providers, so that you can map your service kinds to platform. The aws-servicebroker automatically sets this up.

I've also updated the UI to use the new label when filtering service kinds.

Also it sorts out cloud vs provider names in the UI code: https://github.com/appvia/kore/issues/882