### PR TITLE
Fix UI version tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ jobs:
           working_directory: ~/project/ui
           command: |
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} quay.io
-            docker build -t ${KORE_UI_IMAGE}:${CIRCLE_SHA1} --build-arg version=${CIRCLE_SHA1} .
+            docker build -t ${KORE_UI_IMAGE}:${CIRCLE_SHA1} --build-arg version=${CIRCLE_TAG:-${CIRCLE_SHA1}} .
             docker tag ${KORE_UI_IMAGE}:${CIRCLE_SHA1} ${KORE_UI_IMAGE}:${CIRCLE_TAG:-latest}
             docker push ${KORE_UI_IMAGE}:${CIRCLE_TAG:-latest}
             docker push ${KORE_UI_IMAGE}:${CIRCLE_SHA1}


### PR DESCRIPTION
Set to tag if one is set, else go to SHA1. Current setup isn't picking up the tag on tagged releases.