### PR TITLE
EKS E2E Deletion

### DIFF
--- a/test/e2e/integration/eks-deletion.bats
+++ b/test/e2e/integration/eks-deletion.bats
@@ -37,10 +37,7 @@ setup() {
 @test "We should see the kubernetes resource delete" {
   ${KORE} get kubernetes ${CLUSTER} -t ${TEAM} || skip
 
-  retry 20 "${KORE} get kubernetes ${CLUSTER} -t ${TEAM} -o json | jq '.status.status' | grep -i deleting"
-  [[ "$status" -eq 0 ]]
-
-  retry 30 "${KORE} get kubernetes ${CLUSTER} -t ${TEAM} 2>&1 | grep 'not found$'"
+  retry 50 "${KORE} get kubernetes ${CLUSTER} -t ${TEAM} 2>&1 | grep 'not found$'"
   [[ "$status" -eq 0 ]]
 }
 


### PR DESCRIPTION
- we can't use the previous test as the services has introduced a timing error, we probably need to switch the check to use the component statuses instead