### PR TITLE
Services UI improvements part 2

### DIFF
--- a/ui/assets/styles.less
+++ b/ui/assets/styles.less
@@ -76,6 +76,29 @@
   }
 }
 
+.large-list-item {
+
+  .ant-list-item-meta-avatar img {
+    height: 75px
+  }
+
+  .ant-list-item-meta-content {
+    margin-top: 15px;
+
+    h4.ant-list-item-meta-title {
+      font-size: 22px;
+    }
+  }
+}
+
+.hide-empty-text {
+
+  .ant-list-empty-text {
+    padding: 0
+  }
+
+}
+
 .coming-soon {
   height: inherit;
   position: absolute;

--- a/ui/lib/components/plans/UsePlanForm.js
+++ b/ui/lib/components/plans/UsePlanForm.js
@@ -8,8 +8,8 @@ import PlanViewEdit from './PlanViewEdit'
 import { Icon } from 'antd'
 
 /**
- * UsePlanForm is for *using* a plan to configure a cluster, service or service credential. 
- * 
+ * UsePlanForm is for *using* a plan to configure a cluster, service or service credential.
+ *
  * To *manage* a plan (create, view, edit the plan itself), use Manage(Service/Cluster)PlanForm.
  */
 class UsePlanForm extends React.Component {
@@ -119,10 +119,10 @@ class UsePlanForm extends React.Component {
           team={this.props.team}
           kind={this.props.kind}
           plan={this.state.planValues}
-          schema={this.state.schema} 
-          parameterEditable={this.state.parameterEditable} 
+          schema={this.state.schema}
+          parameterEditable={this.state.parameterEditable}
           onPlanValueChange={(n, v) => this.onValueChange(n, v)}
-          validationErrors={this.props.validationErrors} 
+          validationErrors={this.props.validationErrors}
         />
       </>
     )

--- a/ui/lib/components/services/ServiceOptionsForm.js
+++ b/ui/lib/components/services/ServiceOptionsForm.js
@@ -82,6 +82,7 @@ class ServiceOptionsForm extends React.Component {
         <Form.Item label="Service plan">
           {getFieldDecorator('servicePlan', {
             rules: [{ required: true, message: 'Please select your service plan!' }],
+            initialValue: servicePlans.length === 1 ? servicePlans[0].metadata.name : undefined,
           })(
             <Select onChange={this.onServicePlanChange} placeholder="Choose service plan">
               {servicePlans.map(p => <Option key={p.metadata.name} value={p.metadata.name}>{p.spec.displayName || p.spec.summary}</Option>)}

--- a/ui/lib/components/teams/cluster/Cluster.js
+++ b/ui/lib/components/teams/cluster/Cluster.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import Link from 'next/link'
-import { List, Icon, Typography, Modal, Popconfirm, message, Tooltip } from 'antd'
+import { List, Icon, Typography, Modal, Popconfirm, message, Tag, Tooltip } from 'antd'
 const { Text, Paragraph } = Typography
 
 import { clusterProviderIconSrcMap, inProgressStatusList } from '../../../utils/ui-helpers'
@@ -12,6 +12,7 @@ class Cluster extends AutoRefreshComponent {
   static propTypes = {
     team: PropTypes.string.isRequired,
     cluster: PropTypes.object.isRequired,
+    plan: PropTypes.object.isRequired,
     namespaceClaims: PropTypes.array.isRequired,
     deleteCluster: PropTypes.func.isRequired
   }
@@ -55,7 +56,7 @@ class Cluster extends AutoRefreshComponent {
   }
 
   render() {
-    const { cluster, team } = this.props
+    const { cluster, team, plan } = this.props
 
     if (cluster.deleted) {
       return null
@@ -69,7 +70,7 @@ class Cluster extends AutoRefreshComponent {
       const status = cluster.status.status || 'Pending'
 
       actions.push((
-        <Link key="view" href="/teams/[name]/clusters/[cluster]" as={`/teams/${team}/clusters/${cluster.metadata.name}`}><a><Tooltip title="Cluster status details"><Icon type="info-circle" /></Tooltip></a></Link>
+        <Link key="view" href="/teams/[name]/clusters/[cluster]" as={`/teams/${team}/clusters/${cluster.metadata.name}`}><a><Tooltip title="Cluster details"><Icon type="info-circle" /></Tooltip></a></Link>
       ))
 
       if (!inProgressStatusList.includes(status)) {
@@ -92,10 +93,10 @@ class Cluster extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item key={cluster.metadata.name} actions={actions()} style={{ paddingTop: 0 }}>
+      <List.Item key={cluster.metadata.name} actions={actions()} style={{ paddingTop: 0, paddingBottom: '5px' }}>
         <List.Item.Meta
           avatar={<img src={clusterProviderIconSrcMap[cluster.spec.kind]} height="32px" />}
-          title={<Link href="/teams/[name]/clusters/[cluster]" as={`/teams/${team}/clusters/${cluster.metadata.name}`}><a><Text style={{ fontFamily: 'monospace' }}>{cluster.metadata.name}</Text></a></Link>}
+          title={<><Link href="/teams/[name]/clusters/[cluster]" as={`/teams/${team}/clusters/${cluster.metadata.name}`}><a><Text style={{ marginRight: '15px', fontSize: '16px', textDecoration: 'underline' }}>{cluster.metadata.name}</Text></a></Link><Tag style={{ margin: 0 }}>{plan.spec.description}</Tag></>}
         />
         <div>
           <Text type='secondary'>Created {created}</Text>

--- a/ui/lib/components/teams/cluster/ClusterAccessInfo.js
+++ b/ui/lib/components/teams/cluster/ClusterAccessInfo.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Badge, Button, Divider, Icon, Modal, Typography } from 'antd'
+const { Paragraph, Text } = Typography
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
+
+class ClusterAccessInfo extends React.Component {
+  static propTypes = {
+    team: PropTypes.object.isRequired,
+    buttonStyle: PropTypes.object
+  }
+
+  state = {
+    visible: false
+  }
+
+  infoItem = ({ num, title }) => (
+    <div style={{ marginBottom: '10px' }}>
+      <Badge style={{ backgroundColor: '#1890ff', marginRight: '10px' }} count={num} />
+      <Text strong>{title}</Text>
+    </div>
+  )
+
+  render() {
+    const apiUrl = new URL(publicRuntimeConfig.koreApiPublicUrl)
+
+    const profileConfigureCommand = `kore profile configure ${apiUrl.hostname}`
+    const loginCommand = 'kore login'
+    const kubeconfigCommand = `kore kubeconfig -t ${this.props.team.metadata.name}`
+
+    return (
+      <>
+        <Button style={{ ...this.props.buttonStyle }} type="link" onClick={() => this.setState({ visible: true })}><Icon type="eye" />Access</Button>
+        <Modal
+          title="Cluster access"
+          visible={this.state.visible}
+          onCancel={() => this.setState({ visible: false })}
+          footer={[<Button type="primary" key="ok" onClick={() => this.setState({ visible: false })}>Ok</Button>]}
+          width={700}
+        >
+          <div style={{ margin: '0 20px' }}>
+            {this.infoItem({ num: '1', title: 'Download' })}
+            <Paragraph>If you haven&apos;t already, download the CLI from <a href="https://github.com/appvia/kore/releases">https://github.com/appvia/kore/releases</a></Paragraph>
+
+            <Divider />
+
+            {this.infoItem({ num: '2', title: 'Setup profile' })}
+            <Paragraph>Create a profile</Paragraph>
+            <Paragraph className="copy-command" copyable>{profileConfigureCommand}</Paragraph>
+            <Paragraph>Enter the Kore API URL as follows</Paragraph>
+            <Paragraph className="copy-command" copyable>{apiUrl.origin}</Paragraph>
+
+            <Divider />
+
+            {this.infoItem({ num: '3', title: 'Login' })}
+            <Paragraph>Login to the CLI</Paragraph>
+            <Paragraph className="copy-command" copyable>{loginCommand}</Paragraph>
+
+            <Divider />
+
+            {this.infoItem({ num: '4', title: 'Setup access' })}
+            <Paragraph>Then, you can use the Kore CLI to setup access to your team&apos;s clusters</Paragraph>
+            <Paragraph className="copy-command" copyable>{kubeconfigCommand}</Paragraph>
+            <Paragraph>This will add local kubernetes configuration to allow you to use <Text
+              style={{ fontFamily: 'monospace' }}>kubectl</Text> to talk to the provisioned cluster(s).</Paragraph>
+            <Paragraph>See examples: <a href="https://kubernetes.io/docs/reference/kubectl/overview/" target="_blank" rel="noopener noreferrer">https://kubernetes.io/docs/reference/kubectl/overview/</a></Paragraph>
+          </div>
+        </Modal>
+      </>
+    )
+  }
+}
+
+export default ClusterAccessInfo

--- a/ui/lib/components/teams/cluster/ClusterBuildForm.js
+++ b/ui/lib/components/teams/cluster/ClusterBuildForm.js
@@ -135,7 +135,7 @@ class ClusterBuildForm extends React.Component {
         message.loading('Cluster build requested...')
         return redirect({
           router: Router,
-          path: `/teams/${this.props.team.metadata.name}`
+          path: `/teams/${this.props.team.metadata.name}/clusters/${values.clusterName}`
         })
       } catch (err) {
         this.setState({

--- a/ui/lib/components/teams/namespace/NamespaceClaim.js
+++ b/ui/lib/components/teams/namespace/NamespaceClaim.js
@@ -65,7 +65,7 @@ class NamespaceClaim extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item actions={actions()}>
+      <List.Item style={{ paddingTop: 0 }} actions={actions()}>
         <List.Item.Meta title={namespaceClaim.spec.name} />
         <div>
           <Text type='secondary'>Created {created}</Text>

--- a/ui/lib/components/teams/service/Service.js
+++ b/ui/lib/components/teams/service/Service.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Icon, Typography, Popconfirm, message, Tooltip, Avatar } from 'antd'
+import { List, Icon, Typography, Popconfirm, message, Tooltip, Avatar, Tag } from 'antd'
 const { Text } = Typography
 
 import { inProgressStatusList } from '../../../utils/ui-helpers'
@@ -51,7 +51,7 @@ class Service extends AutoRefreshComponent {
       const status = service.status.status || 'Pending'
 
       actions.push((
-        <Link key="view" href="/teams/[name]/services/[service]" as={`/teams/${team}/services/${service.metadata.name}`}><a><Tooltip title="Service status details"><Icon type="info-circle" /></Tooltip></a></Link>
+        <Link key="view" href="/teams/[name]/services/[service]" as={`/teams/${team}/services/${service.metadata.name}`}><a><Tooltip title="Service details"><Icon type="info-circle" /></Tooltip></a></Link>
       ))
 
       if (!inProgressStatusList.includes(status)) {
@@ -74,10 +74,10 @@ class Service extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item actions={actions()}>
+      <List.Item actions={actions()} style={{ paddingTop: 0, paddingBottom: '5px' }}>
         <List.Item.Meta
           avatar={serviceKind && serviceKind.spec.imageURL ? <Avatar src={serviceKind.spec.imageURL} /> : <Avatar icon="cloud-server" />}
-          title={<Link href="/teams/[name]/services/[service]" as={`/teams/${team}/services/${service.metadata.name}`}><a><Text>{service.spec.kind} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{service.metadata.name}</Text></Text></a></Link>}
+          title={<><Link href="/teams/[name]/services/[service]" as={`/teams/${team}/services/${service.metadata.name}`}><a><Text style={{ marginRight: '15px', fontSize: '16px', textDecoration: 'underline' }}>{service.metadata.name}</Text></a></Link><Tag style={{ margin: 0 }}>{serviceKind.spec.displayName}</Tag></>}
         />
         <div>
           <Text type='secondary'>Created {created}</Text>

--- a/ui/lib/components/teams/service/ServiceCredential.js
+++ b/ui/lib/components/teams/service/ServiceCredential.js
@@ -1,16 +1,21 @@
 import PropTypes from 'prop-types'
+import Link from 'next/link'
 import moment from 'moment'
-import { List, Icon, Typography, Popconfirm, message, Tooltip, Avatar } from 'antd'
+import { Divider, List, Icon, Typography, Popconfirm, message, Tooltip, Tag } from 'antd'
 const { Text } = Typography
 
+import ServiceCredentialSnippet from './ServiceCredentialSnippet'
 import { inProgressStatusList } from '../../../utils/ui-helpers'
 import ResourceStatusTag from '../../resources/ResourceStatusTag'
 import AutoRefreshComponent from '../AutoRefreshComponent'
 
 class ServiceCredential extends AutoRefreshComponent {
   static propTypes = {
+    viewPerspective: PropTypes.oneOf(['cluster', 'service']),
+    hideClusterInfo: PropTypes.bool,
     team: PropTypes.string.isRequired,
     serviceCredential: PropTypes.object.isRequired,
+    serviceKind: PropTypes.object.isRequired,
     deleteServiceCredential: PropTypes.func.isRequired
   }
 
@@ -32,6 +37,31 @@ class ServiceCredential extends AutoRefreshComponent {
     this.props.deleteServiceCredential(this.props.serviceCredential.metadata.name, () => {
       this.startRefreshing()
     })
+  }
+
+  title = () => {
+    const { serviceCredential, serviceKind } = this.props
+    if (this.props.viewPerspective === 'cluster') {
+      return (
+        <>
+          {serviceKind && <><Tag style={{ margin: 0 }}>{serviceKind.spec.displayName}</Tag><Divider type="vertical" /></>}
+          <Link href="/teams/[name]/services/[service]" as={`/teams/${this.props.team}/services/${serviceCredential.spec.service.name}`}><a style={{ textDecoration: 'underline' }}>{serviceCredential.spec.service.name}</a></Link>
+          <Divider type="vertical" />
+          <Text>Secret name: <Text copyable style={{ fontWeight: 'normal', fontStyle: 'italic' }}>{serviceCredential.spec.secretName}</Text><ServiceCredentialSnippet serviceCredential={serviceCredential} /></Text>
+        </>
+      )
+    }
+    if (this.props.viewPerspective === 'service') {
+      return (
+        <>
+          <Text>Cluster: <Link href="/teams/[name]/clusters/[cluster]" as={`/teams/${this.props.team}/clusters/${serviceCredential.spec.cluster.name}`}><a style={{ textDecoration: 'underline' }}>{serviceCredential.spec.cluster.name}</a></Link></Text>
+          <Divider type="vertical" />
+          <Text>namespace: <Text strong>{serviceCredential.spec.clusterNamespace}</Text></Text>
+          <Divider type="vertical" />
+          <Text>Secret name: <Text copyable style={{ fontWeight: 'normal', fontStyle: 'italic' }}>{serviceCredential.spec.secretName}</Text><ServiceCredentialSnippet serviceCredential={serviceCredential} /></Text>
+        </>
+      )
+    }
   }
 
   render() {
@@ -69,21 +99,11 @@ class ServiceCredential extends AutoRefreshComponent {
 
     return (
       <List.Item actions={actions()}>
-        <List.Item.Meta
-          avatar={<Avatar icon="database" />}
-          title={<Text>{serviceCredential.spec.kind} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{serviceCredential.metadata.name}</Text></Text>}
-          description={
-            <>
-              <div>
-                <Text>Cluster: <b>{serviceCredential.spec.cluster.name}</b>, namespace: <b>{serviceCredential.spec.clusterNamespace}</b>, secret name: <b>{serviceCredential.spec.secretName}</b></Text>
-              </div>
-              <div>
-                <Text type='secondary'>Created {created}</Text>
-                {deleted ? <Text type='secondary'><br/>Deleted {deleted}</Text> : null }
-              </div>
-            </>
-          }
-        />
+        <List.Item.Meta title={this.title()} />
+        <div>
+          <Text type='secondary'>Created {created}</Text>
+          {deleted ? <Text type='secondary'><br/>Deleted {deleted}</Text> : null }
+        </div>
       </List.Item>
     )
   }

--- a/ui/lib/components/teams/service/ServiceCredentialForm.js
+++ b/ui/lib/components/teams/service/ServiceCredentialForm.js
@@ -1,35 +1,40 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 import { patterns } from '../../../utils/validation'
-import { Button, Form, Input, Alert, Select } from 'antd'
+import { Button, Form, Icon, Input, Alert, Select, Typography } from 'antd'
+const { Paragraph } = Typography
 import KoreApi from '../../../kore-api'
+import DataField from '../../../components/utils/DataField'
 import UsePlanForm from '../../plans/UsePlanForm'
 import V1ServiceCredentials from '../../../kore-api/model/V1ServiceCredentials'
 import V1ServiceCredentialsSpec from '../../../kore-api/model/V1ServiceCredentialsSpec'
 import { NewV1ObjectMeta, NewV1Ownership } from '../../../utils/model'
+import FormErrorMessage from '../../forms/FormErrorMessage'
 
 class ServiceCredentialForm extends React.Component {
   static propTypes = {
     form: PropTypes.any.isRequired,
+    creationSource: PropTypes.oneOf(['namespace', 'service']).isRequired,
     team: PropTypes.object.isRequired,
-    clusters: PropTypes.object,
-    services: PropTypes.object,
+    clusters: PropTypes.array,
+    namespaceClaims: PropTypes.array,
+    services: PropTypes.array,
     handleSubmit: PropTypes.func.isRequired,
     handleCancel: PropTypes.func.isRequired
   }
 
   constructor(props) {
     super(props)
-    this.state =  {
+    this.state = {
       clusters: props.clusters,
       services: props.services,
-      namespaceClaims: { items: [] },
+      namespaceClaims: props.namespaceClaims,
       servicePlan: null,
       submitting: false,
       formErrorMessage: false,
       dataLoading: true,
       validationErrors: null,
-      config: null,
+      config: null
     }
   }
 
@@ -38,35 +43,40 @@ class ServiceCredentialForm extends React.Component {
 
     // Assign the promise chain to a variable so tests can wait for it to complete.
     this.componentDidMountComplete = Promise.resolve().then(async () => {
-      let { services, clusters, namespaceClaims, servicePlan } = this.state
-
+      const team = this.props.team.metadata.name
       const api = await KoreApi.client()
-      if (!services) {
-        services = await api.ListServices(this.props.team.metadata.name)
+      switch (this.props.creationSource) {
+      case 'namespace': {
+        let [services, serviceKinds] = await Promise.all([
+          api.ListServices(team),
+          api.ListServiceKinds()
+        ])
+        services = services.items.filter(s => !s.spec.cluster || !s.spec.cluster.name)
+        services = services.map(s => ({
+          ...s,
+          serviceKind: serviceKinds.items.find(sk => sk.metadata.name === s.spec.kind)
+        }))
+        this.setState({ services, dataLoading: false })
+        this.props.form.validateFields()
+        break
       }
-
-      if (services && services.items && services.items.length === 1) {
-        servicePlan = await api.GetServicePlan(services.items[0].spec.plan)
+      case 'service': {
+        let [clusters, namespaceClaims, serviceKinds] = await Promise.all([
+          api.ListClusters(team),
+          api.ListNamespaces(team),
+          api.ListServiceKinds()
+        ])
+        clusters = clusters.items.filter(cluster => namespaceClaims.items.filter(ns => ns.spec.cluster.name === cluster.metadata.name).length > 0)
+        if (clusters.length === 1) {
+          namespaceClaims = namespaceClaims.items.filter(nc => nc.spec.cluster.name === clusters[0].metadata.name)
+        } else {
+          namespaceClaims = namespaceClaims.items
+        }
+        this.setState({ clusters, namespaceClaims, serviceKinds, dataLoading: false })
+        this.props.form.validateFields()
+        break
       }
-
-      if (!clusters) {
-        clusters = await api.ListClusters(this.props.team.metadata.name) // eslint-disable-line require-atomic-updates
       }
-
-      if (clusters && clusters.items && clusters.items.length === 1) {
-        const allNamespaceClaims = await api.ListNamespaces(this.props.team.metadata.name)
-        namespaceClaims = { items: allNamespaceClaims.items.filter(nc => nc.spec.cluster.name === clusters.items[0].metadata.name) }
-      }
-
-      this.setState({
-        services: services || { items: [] },
-        clusters: clusters || { items: [] },
-        namespaceClaims: namespaceClaims || [],
-        servicePlan,
-        dataLoading: false
-      })
-
-      this.props.form.validateFields()
     })
   }
 
@@ -83,43 +93,23 @@ class ServiceCredentialForm extends React.Component {
   }
 
   onClusterChange = () => {
-    Promise.resolve().then(async () => {
-      const clusterName = this.props.form.getFieldValue('cluster')
-      const api = await KoreApi.client()
-      const namespaceClaims = await api.ListNamespaces(this.props.team.metadata.name)
-      this.setState({
-        namespaceClaims: { items: namespaceClaims.items.filter(nc => nc.spec.cluster.name === clusterName) }
-      })
-
-      this.props.form.resetFields([ 'namespace' ])
-    })
+    this.props.form.resetFields(['namespace'])
+    this.props.form.validateFields()
   }
 
-  onServiceChange = () => {
-    Promise.resolve().then(async () => {
-      const { services, servicePlan: prevServicePlan  } = this.state
-      const serviceName = this.props.form.getFieldValue('service')
-      const service = services.items.find(s => s.metadata.name === serviceName)
+  onServiceChange = async (serviceName) => {
+    const service = this.state.services.find(s => s.metadata.name === serviceName)
 
-      if (prevServicePlan && prevServicePlan.metadata.name === service.spec.plan) {
-        return
-      }
-      
-      const api = await KoreApi.client()
-      const servicePlan = await api.GetServicePlan(service.spec.plan)
-      this.setState({
-        servicePlan: servicePlan,
-        config: null,
-        validationErrors: null
-      })
-    })
-  }
-
-  handleConfigurationUpdate = c => {
+    const api = await KoreApi.client()
+    const servicePlan = await api.GetServicePlan(service.spec.plan)
     this.setState({
-      config: c
+      servicePlan: servicePlan,
+      config: null,
+      validationErrors: null
     })
   }
+
+  handleConfigurationUpdate = (config) => this.setState({ config })
 
   handleSubmit = e => {
     e.preventDefault()
@@ -133,34 +123,24 @@ class ServiceCredentialForm extends React.Component {
 
     return this.props.form.validateFields(async (err, values) => {
       if (err) {
-        return this.setState({
-          submitting: false
-        })
+        return this.setState({ submitting: false })
       }
 
-      if (!values.namespace) {
-        return this.setState({
-          submitting: false,
-          formErrorMessage: 'Please select the namespace!',
-          validationErrors: null
-        })
-      }
-
-      const cluster = clusters.items.find(c => c.metadata.name === values.cluster)
-      const service = services.items.find(s => s.metadata.name === values.service)
-      const namespaceClaim = namespaceClaims.items.find(n => n.spec.name === values.namespace)
-      const name = `${values.cluster}-${values.namespace}-${values.secretName}`
+      const service = services.length === 1 ? services[0] : services.find(s => s.metadata.name === values.service)
+      const cluster = clusters.length === 1 ? clusters[0] : clusters.find(c => c.metadata.name === values.cluster)
+      const namespaceClaim = namespaceClaims.length === 1 ? namespaceClaims[0] : namespaceClaims.find(n => n.spec.name === values.namespace)
+      const name = `${cluster.metadata.name}-${namespaceClaim.spec.name}-${values.secretName}`
 
       try {
         const existing = await (await KoreApi.client()).GetServiceCredentials(this.props.team.metadata.name, name)
         if (existing) {
           return this.setState({
             submitting: false,
-            formErrorMessage: `A service credential with the name "${name}" already exists`,
+            formErrorMessage: `A service credential on this namespace with secret name "${values.secretName}" already exists`,
             validationErrors: null
           })
         }
-      } catch(err) {
+      } catch (err) {
         // TODO: we should differentiate between 404 and other errors
       }
 
@@ -192,19 +172,12 @@ class ServiceCredentialForm extends React.Component {
       serviceCredential.setSpec(serviceCredentialSpec)
 
       try {
-        const result = await (await KoreApi.client()).UpdateServiceCredentials(
-          this.props.team.metadata.name,
-          name,
-          serviceCredential)
-
+        const result = await (await KoreApi.client()).UpdateServiceCredentials(this.props.team.metadata.name, name, serviceCredential)
         this.props.form.resetFields()
-        this.setState({
-          submitting: false
-        })
+        this.setState({ submitting: false })
         await this.props.handleSubmit(result)
       } catch (err) {
         this.setState({
-          ...this.state,
           submitting: false,
           formErrorMessage: (err.fieldErrors && err.message) ? err.message : 'An error occurred creating the service credential, please try again',
           validationErrors: err.fieldErrors // This will be undefined on non-validation errors, which is fine.
@@ -213,13 +186,113 @@ class ServiceCredentialForm extends React.Component {
     })
   }
 
+  createFromNamespace = () => {
+    const { getFieldDecorator } = this.props.form
+    const { services, clusters, namespaceClaims } = this.state
+
+    const namespace = namespaceClaims[0].spec.name
+    const cluster = clusters[0].metadata.name
+
+    return (
+      <>
+        <Alert
+          message="Choose the service and secret name"
+          description={
+            <>
+              <Paragraph>A secret with the chosen name will be populated in the namespace. The secret will contain credentials that can be used to access the service from within the namespace.</Paragraph>
+              <DataField label="Cluster" value={cluster}/>
+              <DataField label="Namespace" value={namespace}/>
+            </>
+          }
+          type="info"
+          showIcon
+          style={{ marginBottom: '20px' }}
+        />
+        <Form.Item label="Service" validateStatus={this.fieldError('service') ? 'error' : ''} help={this.fieldError('service') || ''}>
+          {getFieldDecorator('service', {
+            rules: [{ required: true, message: 'Please select the service!' }],
+            initialValue: services.length === 1 ? services[0].metadata.name : undefined
+          })(
+            <Select placeholder="Service" onChange={this.onServiceChange}>
+              {services.map(s => (
+                <Select.Option key={s.metadata.name} value={s.metadata.name}>{s.serviceKind && s.serviceKind.spec.displayName} - {s.metadata.name}</Select.Option>
+              ))}
+            </Select>
+          )}
+        </Form.Item>
+        {this.secretNameField()}
+      </>
+    )
+  }
+
+  secretNameField = () => (
+    <Form.Item label="Secret Name" validateStatus={this.fieldError('secretName') ? 'error' : ''} help={this.fieldError('secretName') || ''}>
+      {this.props.form.getFieldDecorator('secretName', {
+        rules: [
+          { required: true, message: 'Please enter the secret name!' },
+          { ...patterns.uriCompatible63CharMax }
+        ]
+      })(
+        <Input placeholder="The name of the Kubernetes Secret"/>
+      )}
+    </Form.Item>
+  )
+
+  createFromService = () => {
+    const { getFieldDecorator } = this.props.form
+    const { clusters, namespaceClaims } = this.state
+
+    return (
+      <>
+        <Alert
+          message="Choose the cluster and namespace"
+          description={
+            <Paragraph>A secret with the chosen name will be populated in the namespace. The secret will contain credentials that can be used to access the service from within the namespace.</Paragraph>
+          }
+          type="info"
+          showIcon
+          style={{ marginBottom: '20px' }}
+        />
+
+        <Form.Item label="Cluster" validateStatus={this.fieldError('cluster') ? 'error' : ''} help={this.fieldError('cluster') || ''}>
+          {getFieldDecorator('cluster', {
+            rules: [{ required: true, message: 'Please select the cluster!' }],
+            initialValue: clusters.length === 1 ? clusters[0].metadata.name : undefined
+          })(
+            <Select placeholder="Cluster" onChange={this.onClusterChange}>
+              {clusters.map(c => (
+                <Select.Option key={c.metadata.name} value={c.metadata.name}>{c.metadata.name}</Select.Option>
+              ))}
+            </Select>
+          )}
+        </Form.Item>
+        <Form.Item label="Namespace" validateStatus={this.fieldError('namespace') ? 'error' : ''} help={this.fieldError('namespace') || ''}>
+          {getFieldDecorator('namespace', {
+            rules: [{ required: true, message: 'Please select the namespace!' }],
+            initialValue: namespaceClaims.length === 1 ? namespaceClaims[0].spec.name : undefined
+          })(
+            <Select placeholder="Namespace">
+              {namespaceClaims.filter(nc => nc.spec.cluster.name === this.props.form.getFieldValue('cluster')).map(n => (
+                <Select.Option key={n.spec.name} value={n.spec.name}>{n.spec.name}</Select.Option>
+              ))}
+            </Select>
+          )}
+        </Form.Item>
+        {this.secretNameField()}
+      </>
+    )
+  }
+
+  // Only show error after a field is touched.
+  fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
+
   render() {
     if (this.state.dataLoading) {
-      return null
+      return <Icon type="loading"/>
     }
 
-    const { getFieldDecorator, getFieldsError, getFieldError, isFieldTouched } = this.props.form
-    const { clusters, services, namespaceClaims, submitting, formErrorMessage, servicePlan, validationErrors } = this.state
+    const { getFieldsError } = this.props.form
+    const { submitting, formErrorMessage, servicePlan, validationErrors } = this.state
     const formConfig = {
       layout: 'horizontal',
       labelAlign: 'left',
@@ -234,77 +307,14 @@ class ServiceCredentialForm extends React.Component {
       }
     }
 
-    // Only show error after a field is touched.
-    const secretNameError = isFieldTouched('secretName') && getFieldError('secretName')
-    const clusterError = isFieldTouched('cluster') && getFieldError('cluster')
-    const serviceError = isFieldTouched('service') && getFieldError('service')
-    const namespaceError = (isFieldTouched('cluster') || isFieldTouched('namespace')) && getFieldError('namespace')
-
-    const FormErrorMessage = () => {
-      if (formErrorMessage) {
-        return (
-          <Alert
-            message={formErrorMessage}
-            type="error"
-            showIcon
-            closable
-            style={{ marginBottom: '20px' }}
-          />
-        )
-      }
-      return null
-    }
-
     return (
       <Form {...formConfig} onSubmit={this.handleSubmit} style={{ marginBottom: '30px' }}>
-        <FormErrorMessage />
-        <Form.Item label="Secret Name" validateStatus={secretNameError ? 'error' : ''} help={secretNameError || ''}>
-          {getFieldDecorator('secretName', {
-            rules: [
-              { required: true, message: 'Please enter the secret name!'  },
-              { ...patterns.uriCompatible63CharMax }
-            ]
-          })(
-            <Input placeholder="The name of the Kubernetes Secret" />
-          )}
-        </Form.Item>
-        <Form.Item label="Service" validateStatus={serviceError ? 'error' : ''} help={serviceError || ''}>
-          {getFieldDecorator('service', {
-            rules: [{ required: true, message: 'Please select the service!' }],
-            initialValue: services.items.length === 1 ? services.items[0].metadata.name : undefined
-          })(
-            <Select placeholder="Service" onChange={this.onServiceChange}>
-              {services.items.map(s => (
-                <Select.Option key={s.metadata.name} value={s.metadata.name}>{s.metadata.name}</Select.Option>
-              ))}
-            </Select>
-          )}
-        </Form.Item>
-        <Form.Item label="Cluster" validateStatus={clusterError ? 'error' : ''} help={clusterError || ''}>
-          {getFieldDecorator('cluster', {
-            rules: [{ required: true, message: 'Please select the cluster!' }],
-            initialValue: clusters.items.length === 1 ? clusters.items[0].metadata.name : undefined
-          })(
-            <Select placeholder="Cluster" onChange={this.onClusterChange}>
-              {clusters.items.map(c => (
-                <Select.Option key={c.metadata.name} value={c.metadata.name}>{c.metadata.name}</Select.Option>
-              ))}
-            </Select>
-          )}
-        </Form.Item>
-        <Form.Item label="Namespace" validateStatus={namespaceError ? 'error' : ''} help={namespaceError || ''}>
-          {getFieldDecorator('namespace', {
-            rules: [{ required: true, message: 'Please select the namespace!' }],
-            initialValue: namespaceClaims.items.length === 1 ? namespaceClaims.items[0].spec.name : undefined
-          })(
-            <Select placeholder="Namespace">
-              {namespaceClaims.items.map(n => (
-                <Select.Option key={n.spec.name} value={n.spec.name}>{n.spec.name}</Select.Option>
-              ))}
-            </Select>
-          )}
-        </Form.Item>
-        {servicePlan ? (
+        <FormErrorMessage message={formErrorMessage}/>
+
+        {this.props.creationSource === 'namespace' && this.createFromNamespace() }
+        {this.props.creationSource === 'service' && this.createFromService() }
+
+        {servicePlan && (
           <UsePlanForm
             team={this.props.team}
             resourceType="servicecredential"
@@ -314,7 +324,8 @@ class ServiceCredentialForm extends React.Component {
             validationErrors={validationErrors}
             onPlanChange={this.handleConfigurationUpdate}
           />
-        ) : null}
+        )}
+
         <Form.Item>
           <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
           <Button type="link" onClick={this.cancel}>Cancel</Button>

--- a/ui/lib/components/teams/service/ServiceCredentialSnippet.js
+++ b/ui/lib/components/teams/service/ServiceCredentialSnippet.js
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types'
+import { Alert, Button, Icon, Modal, Typography, Tooltip } from 'antd'
+const { Paragraph } = Typography
+
+class ServiceCredentialSnippet extends React.Component {
+  static propTypes = {
+    serviceCredential: PropTypes.object.isRequired
+  }
+
+  state = {
+    visible: false
+  }
+  /* eslint-disable indent */
+  render() {
+    return (
+      <>
+      <Tooltip key="snippet" title="See usage snippet"><Icon onClick={() => this.setState({ visible: true })} style={{ marginLeft: '5px', color: '#3d5b58' }} type="eye" /></Tooltip>
+      <Modal
+        title="Service binding usage"
+        visible={this.state.visible}
+        onCancel={() => this.setState({ visible: false })}
+        footer={[<Button type="primary" key="ok" onClick={() => this.setState({ visible: false })}>Ok</Button>]}
+        width={700}
+      >
+        <div style={{ margin: '0 20px' }}>
+          <Alert
+            message="You can use the service binding secret in a Kubernetes Pod template using the following snippet."
+            type="info"
+            showIcon
+            style={{ marginBottom: '20px' }}
+          />
+          <Paragraph copyable className="copy-command" style={{ whiteSpace: 'pre' }}>
+{`envFrom:
+  - secretRef:
+      name: ${this.props.serviceCredential.spec.secretName}`}
+          </Paragraph>
+          <Paragraph>For more information, see <a target="_blank" rel="noopener noreferrer" href="https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates">https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates</a></Paragraph>
+        </div>
+      </Modal>
+      </>
+    )
+  }
+  /* eslint-enable indent */
+}
+
+export default ServiceCredentialSnippet

--- a/ui/lib/components/utils/DataField.js
+++ b/ui/lib/components/utils/DataField.js
@@ -17,8 +17,8 @@ DataField.propTypes = {
     PropTypes.string,
     PropTypes.node
   ]),
-  labelColSpan: PropTypes.string,
-  valueColSpan: PropTypes.string,
+  labelColSpan: PropTypes.number,
+  valueColSpan: PropTypes.number,
   textProps: PropTypes.object,
   style: PropTypes.object
 }

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -89,12 +89,9 @@ class KoreApiClient {
   UpdateServicePlan = (name, servicePlan) => this.apis.default.UpdateServicePlan({ name, body: JSON.stringify(servicePlan) })
   DeleteServicePlan = (name) => this.apis.default.DeleteServicePLan({ name })
   GetServicePlanSchema = (name) => this.apis.default.GetServicePlanSchema({ name })
-
-  // Services
-  ListServiceProviders = () => this.apis.default.ListServiceProviders()
-  ListServiceKinds = () => this.apis.default.ListServiceKinds()
   GetServiceKind = (name) => this.apis.default.GetServiceKind({ name })
   UpdateServiceKind = (name, kind) => this.apis.default.UpdateServiceKind({ name, body: kind })
+  GetServiceCredentialSchema = (name) => this.apis.default.GetServiceCredentialSchema({ name })
 
   // Audit
   ListAuditEvents = () => this.apis.default.ListAuditEvents()
@@ -163,7 +160,6 @@ class KoreApiClient {
   UpdateServiceCredentials = (team, name, serviceCredential) => this.apis.default.UpdateServiceCredentials({ team, name, body: JSON.stringify(serviceCredential) })
   ListServiceCredentials = (team, cluster, service) => this.apis.default.ListServiceCredentials({ team, cluster, service })
   DeleteServiceCredentials = (team, name) => this.apis.default.DeleteServiceCredentials({ team, name })
-  GetServiceCredentialSchema = (team, name) => this.apis.default.GetServiceCredentialSchema({ team, name })
 }
 
 module.exports = KoreApiClient

--- a/ui/lib/utils/ui-helpers.js
+++ b/ui/lib/utils/ui-helpers.js
@@ -3,6 +3,12 @@ module.exports = {
     'Success': 'green',
     'Pending': 'orange'
   },
+  statusIconMap: {
+    'Success': 'check-circle',
+    'Pending': 'loading',
+    'Failure': 'exclamation-circle',
+    'Error': 'exclamation-circle',
+  },
   clusterProviderIconSrcMap: {
     'GKE': '/static/images/GCP.png',
     'EKS': '/static/images/AWS.png'


### PR DESCRIPTION
### New look for the following pages

**Team page - clusters tab**
- namespaces are shown as a single line for each cluster, in a tag with the color showing the status of the namespace and tooltip with created date
- adding namespaces moved from here to cluster detail page
- show the cluster plan name that was used to create the cluster

<img width="1366" alt="Screen Shot 2020-05-29 at 17 10 20" src="https://user-images.githubusercontent.com/1334068/83281790-88495c00-a1d0-11ea-9df8-fa40ee74b32a.png">

**Team page - services tab**
- credentials are shown as a single line under each service, described as `cluster/namespace` in a tag with the color showing the status

<img width="1365" alt="Screen Shot 2020-05-29 at 17 10 30" src="https://user-images.githubusercontent.com/1334068/83281799-8aabb600-a1d0-11ea-956c-61f1d1555f97.png">

**Cluster detail page**
- improved look, with larger header
- cluster access instructions added
- list and create namespaces from here
- improved form for creating service bindings
- service bindings are shown/created from under the relevant namespace
- bindings show `envFrom:` snippet for use in a k8s manifest

<img width="1351" alt="Screen Shot 2020-05-29 at 17 10 44" src="https://user-images.githubusercontent.com/1334068/83281803-8bdce300-a1d0-11ea-91d9-25c30b54d073.png">

**Service detail page**
- improved form for creating service bindings
- bindings show `envFrom:` snippet for use in a k8s manifest

<img width="1364" alt="Screen Shot 2020-05-29 at 17 11 18" src="https://user-images.githubusercontent.com/1334068/83281808-8c757980-a1d0-11ea-9a9b-47161111a5a6.png">

**Other screenshots**

Binding usage snippet

<img width="873" alt="Screen Shot 2020-05-29 at 17 13 16" src="https://user-images.githubusercontent.com/1334068/83281810-8c757980-a1d0-11ea-980d-b291d492dbcf.png">

Create bindings from service detail page

<img width="783" alt="Screen Shot 2020-05-29 at 17 13 25" src="https://user-images.githubusercontent.com/1334068/83281811-8d0e1000-a1d0-11ea-9d57-a000317b230a.png">

Create binding from cluster page

<img width="756" alt="Screen Shot 2020-05-29 at 17 13 39" src="https://user-images.githubusercontent.com/1334068/83281812-8da6a680-a1d0-11ea-99a9-1f8116439076.png">
