### PR TITLE
Wait for a an active service status when creating service credentials

### DIFF
--- a/pkg/controllers/servicecredentials/ensure.go
+++ b/pkg/controllers/servicecredentials/ensure.go
@@ -86,6 +86,17 @@ func (c *Controller) ensureFinalizer(logger log.FieldLogger, serviceCreds *servi
 	}
 }
 
+func (c *Controller) EnsureActiveService(logger log.FieldLogger, service *servicesv1.Service) controllers.EnsureFunc {
+	return func(ctx context.Context) (reconcile.Result, error) {
+		// @step: check the overall status of the service
+		if service.Status.Status != corev1.SuccessStatus {
+			logger.Debugf("service status is %s, waiting", service.Status.Status)
+			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+		}
+		return reconcile.Result{}, nil
+	}
+}
+
 func (c *Controller) EnsureActiveCluster(logger log.FieldLogger, serviceCreds *servicesv1.ServiceCredentials) controllers.EnsureFunc {
 	return func(ctx context.Context) (reconcile.Result, error) {
 		// @step: check the status of the cluster
@@ -103,6 +114,7 @@ func (c *Controller) EnsureActiveCluster(logger log.FieldLogger, serviceCreds *s
 
 		// @step: check the overall status of the cluster
 		if cluster.Status.Status != corev1.SuccessStatus {
+			logger.Debugf("cluster status is %s, waiting", cluster.Status.Status)
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 		return reconcile.Result{}, nil

--- a/pkg/controllers/servicecredentials/ensure.go
+++ b/pkg/controllers/servicecredentials/ensure.go
@@ -168,6 +168,17 @@ func (c *Controller) ensureSecret(
 			return result, nil
 		}
 
+		if len(credentials) == 0 {
+			serviceCreds.Status.Components.SetCondition(corev1.Component{
+				Name:    ComponentProviderSecret,
+				Status:  corev1.ErrorStatus,
+				Message: "failed to request secret from service provider",
+				Detail:  "the service provider returned empty credentials",
+			})
+
+			return reconcile.Result{}, fmt.Errorf("the service provider returned empty credentials")
+		}
+
 		serviceCreds.Status.Components.SetStatus(ComponentProviderSecret, corev1.SuccessStatus, "", "")
 
 		secret := &k8scorev1.Secret{


### PR DESCRIPTION
## What

Users can create services and service crendentials at the same time and we have to wait for an active service status until we can safely create credentials.

This fixes https://github.com/appvia/kore/issues/903