### PR TITLE
Adding cluster application services

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1344,6 +1344,7 @@ k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZ
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
 k8s.io/apiserver v0.17.4/go.mod h1:5ZDQ6Xr5MNBxyi3iUZXS84QOhZl+W7Oq2us/29c0j9I=

--- a/ui/lib/components/teams/cluster/applications/ClusterApplicationServiceForm.js
+++ b/ui/lib/components/teams/cluster/applications/ClusterApplicationServiceForm.js
@@ -1,0 +1,278 @@
+import * as React from 'react'
+import PropTypes from 'prop-types'
+import { Alert, Button, Card, Checkbox, Form, Icon, Input, message, Select } from 'antd'
+
+import ServiceOptionsForm from '../../../services/ServiceOptionsForm'
+import FormErrorMessage from '../../../forms/FormErrorMessage'
+import KoreApi from '../../../../kore-api'
+import V1ServiceSpec from '../../../../kore-api/model/V1ServiceSpec'
+import V1Service from '../../../../kore-api/model/V1Service'
+import { NewV1ObjectMeta, NewV1Ownership } from '../../../../utils/model'
+import { getKoreLabel } from '../../../../utils/crd-helpers'
+
+class ClusterApplicationServiceForm extends React.Component {
+  static propTypes = {
+    form: PropTypes.any.isRequired,
+    team: PropTypes.object.isRequired,
+    cluster: PropTypes.object.isRequired,
+    teamServices: PropTypes.array.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    handleCancel: PropTypes.func.isRequired
+  }
+
+  static initialState = {
+    submitButtonText: 'Save',
+    submitting: false,
+    formErrorMessage: false,
+    selectedServiceKind: false,
+    selectedServicePlan: false,
+    dataLoading: true,
+    servicePlanOverride: null,
+    validationErrors: null,
+    createNewNamespace: false
+  }
+
+  state = { ...ClusterApplicationServiceForm.initialState }
+
+  async fetchComponentData() {
+    const api = await KoreApi.client()
+    const [ serviceKinds, servicePlans, namespaceClaims ] = await Promise.all([
+      api.ListServiceKinds(),
+      api.ListServicePlans(),
+      api.ListNamespaces(this.props.team.metadata.name)
+    ])
+    serviceKinds.items = serviceKinds.items.filter(sk => getKoreLabel(sk, 'platform') === 'Kubernetes' && sk.spec.enabled)
+    namespaceClaims.items = namespaceClaims.items.filter(nc => nc.spec.cluster.name === this.props.cluster.metadata.name)
+    return { serviceKinds, servicePlans, namespaceClaims }
+  }
+
+  componentDidMountComplete = null
+  componentDidMount() {
+    // Assign the promise chain to a variable so tests can wait for it to complete.
+    this.componentDidMountComplete = Promise.resolve().then(async () => {
+      const data = await this.fetchComponentData()
+      this.setState({ ...data, dataLoading: false })
+    })
+  }
+
+  generateServiceResource = (values) => {
+    const cluster = this.props.cluster
+    const selectedServicePlan = this.state.servicePlans.items.find(p => p.metadata.name === values.servicePlan)
+
+    const serviceResource = new V1Service()
+    serviceResource.setApiVersion('services.compute.kore.appvia.io/v1')
+    serviceResource.setKind('Service')
+
+    serviceResource.setMetadata(NewV1ObjectMeta(values.serviceName, this.props.team.metadata.name))
+
+    const serviceSpec = new V1ServiceSpec()
+    serviceSpec.setKind(selectedServicePlan.spec.kind)
+    serviceSpec.setPlan(selectedServicePlan.metadata.name)
+    serviceSpec.setClusterNamespace(values.createNamespace || values.namespace)
+
+    serviceSpec.setCluster(NewV1Ownership({
+      group: cluster.apiVersion.split('/')[0],
+      version: cluster.apiVersion.split('/')[1],
+      kind: cluster.kind,
+      name: cluster.metadata.name,
+      namespace: this.props.team.metadata.name
+    }))
+    if (this.state.servicePlanOverride) {
+      serviceSpec.setConfiguration(this.state.servicePlanOverride)
+    } else {
+      serviceSpec.setConfiguration({ ...selectedServicePlan.spec.configuration })
+    }
+
+    serviceResource.setSpec(serviceSpec)
+    return serviceResource
+  }
+
+  validatedFormsFields = (callback) => {
+    this.props.form.validateFields((serviceErr, serviceValues) => {
+      this.serviceOptionsForm.props.form.validateFields((optionsErr, optionsValues) => {
+        const err = serviceErr || optionsErr ? { ...serviceErr, ...optionsErr } : null
+        callback(err, { ...serviceValues, ...optionsValues })
+      })
+    })
+  }
+
+  handleSubmit = async (e) => {
+    e.preventDefault()
+
+    this.setState({ submitting: true, formErrorMessage: false })
+
+    this.validatedFormsFields(async (err, values) => {
+      if (err) {
+        message.error('Validation failed')
+        this.setState({ submitting: false, formErrorMessage: 'Validation failed' })
+        return
+      }
+      try {
+        const existing = await (await KoreApi.client()).GetService(this.props.team.metadata.name, values.serviceName)
+        if (existing) {
+          message.error('Validation failed')
+          return this.setState({
+            submitting: false,
+            formErrorMessage: `A service with the name "${values.serviceName}" already exists in this team.`
+          })
+        }
+
+        const service = await (await KoreApi.client()).UpdateService(this.props.team.metadata.name, values.serviceName, this.generateServiceResource(values))
+        message.loading('Cluster application service requested...')
+
+        return this.props.handleSubmit(service)
+      } catch (err) {
+        console.error('Error saving application service', err)
+        message.error('Error requesting cluster application service, please try again.')
+        this.setState({
+          submitting: false,
+          formErrorMessage: (err.fieldErrors && err.message) ? err.message : 'An error occurred requesting the application service, please try again',
+          validationErrors: err.fieldErrors // This will be undefined on non-validation errors, which is fine.
+        })
+      }
+    })
+  }
+
+  handleSelectKind = (kind) => {
+    this.setState({
+      selectedServiceKind: kind,
+      servicePlanOverride: null,
+      validationErrors: null
+    })
+  }
+
+  handleServicePlanOverride = servicePlanOverrides => {
+    this.setState({ servicePlanOverride: servicePlanOverrides })
+  }
+
+  disableButton = () => {
+    if (!this.state.selectedServicePlan) {
+      return true
+    }
+    return false
+  }
+
+  cancel = () => {
+    this.props.form.resetFields()
+    this.setState({ ...ClusterApplicationServiceForm.initialState })
+    this.props.handleCancel()
+  }
+
+  createNewNamespace = (checked) => {
+    this.setState({ createNewNamespace: checked })
+    this.props.form.resetFields('namespace')
+  }
+
+  render() {
+    if (this.state.dataLoading || !this.props.team) {
+      return <Icon type="loading" />
+    }
+    const formConfig = {
+      layout: 'horizontal',
+      labelAlign: 'left',
+      hideRequiredMark: true,
+      labelCol: {
+        sm: { span: 24 },
+        md: { span: 24 },
+        lg: { span: 6 }
+      },
+      wrapperCol: {
+        sm: { span: 24 },
+        md: { span: 24 },
+        lg: { span: 18 }
+      }
+    }
+
+    const { getFieldDecorator } = this.props.form
+    const { serviceKinds, selectedServiceKind, namespaceClaims, formErrorMessage, submitting, createNewNamespace } = this.state
+
+    let filteredServicePlans = []
+    if (selectedServiceKind) {
+      filteredServicePlans = this.state.servicePlans.items.filter(p => p.spec.kind === selectedServiceKind)
+    }
+
+    return (
+      <Form {...formConfig} onSubmit={this.handleSubmit}>
+        <FormErrorMessage message={formErrorMessage} />
+        <Card style={{ marginBottom: '20px' }}>
+          <Alert
+            message="Cluster application service"
+            description="Select the service you would like to use."
+            type="info"
+            showIcon
+            style={{ marginBottom: '20px' }}
+          />
+
+          <Form.Item label="Service type">
+            {getFieldDecorator('serviceKind', {
+              rules: [{ required: true, message: 'Please select your service type!' }],
+            })(
+              <Select
+                onChange={this.handleSelectKind}
+                placeholder="Choose service type"
+                showSearch
+                optionFilterProp="children"
+                filterOption={(input, option) =>
+                  option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+                }
+              >
+                {serviceKinds.items.map(k => <Select.Option key={k.metadata.name} value={k.metadata.name}>{k.spec.displayName || k.metadata.name}</Select.Option>)}
+              </Select>
+            )}
+          </Form.Item>
+
+          {selectedServiceKind && (
+            <ServiceOptionsForm
+              team={this.props.team}
+              selectedServiceKind={selectedServiceKind}
+              servicePlans={filteredServicePlans}
+              teamServices={this.props.teamServices}
+              onServicePlanSelected={(selectedServicePlan) => this.setState({ selectedServicePlan })}
+              onServicePlanOverridden={this.handleServicePlanOverride}
+              validationErrors={this.state.validationErrors}
+              wrappedComponentRef={inst => this.serviceOptionsForm = inst}
+            />
+          )}
+        </Card>
+
+        <Card>
+          <Alert
+            message="Target namespace"
+            description="The namespace you would like service to be deploying into. Select from the existing cluster namespaces, or create a new one."
+            type="info"
+            showIcon
+            style={{ marginBottom: '20px' }}
+          />
+          <Form.Item label="Namespace">
+            {getFieldDecorator('namespace', {
+              rules: [{ required: !createNewNamespace, message: 'Please select the target namespace!' }]
+            })(
+              <Select placeholder="Choose existing namespace" disabled={createNewNamespace}>
+                {namespaceClaims.items.map(nc => <Select.Option key={nc.spec.name} value={nc.spec.name}>{nc.spec.name}</Select.Option>)}
+              </Select>
+            )}
+            <Checkbox onChange={(e) => this.createNewNamespace(e.target.checked)}>Create a new namespace</Checkbox>
+            {createNewNamespace && (
+              <Form.Item style={{ marginBottom: 0 }}>
+                {getFieldDecorator('createNamespace', {
+                  rules: [{ required: true, message: 'Please enter the new namespace!' }],
+                })(
+                  <Input placeholder="New namespace name" />
+                )}
+              </Form.Item>
+            )}
+          </Form.Item>
+        </Card>
+
+        <Form.Item style={{ marginTop: '20px', marginBottom: 0 }}>
+          <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton()}>{this.state.submitButtonText}</Button>
+          <Button type="link" onClick={this.cancel}>Cancel</Button>
+        </Form.Item>
+      </Form>
+    )
+  }
+}
+
+const WrappedClusterApplicationServiceForm = Form.create({ name: 'cluster_application' })(ClusterApplicationServiceForm)
+
+export default WrappedClusterApplicationServiceForm

--- a/ui/lib/components/teams/service/ServiceBuildForm.js
+++ b/ui/lib/components/teams/service/ServiceBuildForm.js
@@ -199,10 +199,10 @@ class ServiceBuildForm extends React.Component {
               const credentialName = `${cluster.metadata.name}-${namespaceClaim.spec.name}-${secretName}`
               const resource = this.getServiceCredentialsResource(credentialName, secretName, service, cluster, namespaceClaim)
               await api.UpdateServiceCredentials(this.props.team.metadata.name, credentialName, resource)
-              message.loading(`Service binding for namespace "${namespaceClaim.spec.name}" requested...`)
+              message.loading(`Service access for namespace "${namespaceClaim.spec.name}" requested...`)
             } catch (error) {
               console.error('Error creating service binding', error)
-              message.error(`Failed to create service binding for namespace "${namespaceClaim.spec.name}"`)
+              message.error(`Failed to create service access for namespace "${namespaceClaim.spec.name}"`)
             }
           })
         }

--- a/ui/lib/components/teams/service/ServicesTab.js
+++ b/ui/lib/components/teams/service/ServicesTab.js
@@ -85,8 +85,10 @@ class ServicesTab extends React.Component {
     this.setState((state) => ({
       createNewService: false,
       services: [ ...state.services, service ]
-    }))
-    await this.refreshServiceCredentials(service)
+    }), async () => {
+      this.props.getServiceCount && this.props.getServiceCount(this.state.services.length)
+      await this.refreshServiceCredentials(service)
+    })
   }
 
   deleteService = async (name, done) => {
@@ -160,7 +162,7 @@ class ServicesTab extends React.Component {
 
     return (
       <>
-        <Button type="primary" onClick={() => this.setState({ createNewService: true })}>New service</Button>
+        <Button type="primary" onClick={() => this.setState({ createNewService: true })}>New cloud service</Button>
 
         <Divider />
 
@@ -184,6 +186,7 @@ class ServicesTab extends React.Component {
                     refreshMs={10000}
                     propsResourceDataKey="service"
                     resourceApiPath={`/teams/${team.metadata.name}/services/${service.metadata.name}`}
+                    style={{ paddingTop: 0, paddingBottom: '5px' }}
                   />
                   {!service.deleted && filteredServiceCredentials.length > 0 && this.serviceCredentialList({ serviceCredentials: filteredServiceCredentials })}
                   {!service.deleted && idx < services.length - 1 && <Divider />}

--- a/ui/pages/teams/[name].js
+++ b/ui/pages/teams/[name].js
@@ -53,7 +53,7 @@ class TeamDashboard extends React.Component {
 
   static getInitialProps = async ctx => {
     const teamDetails = await TeamDashboard.getTeamDetails(ctx)
-    if (Object.keys(teamDetails.team).length === 0 && ctx.res) {
+    if (!teamDetails.team && ctx.res) {
       /* eslint-disable-next-line require-atomic-updates */
       ctx.res.statusCode = 404
     }
@@ -67,9 +67,8 @@ class TeamDashboard extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const teamFound = Object.keys(this.props.team).length
-    const prevTeamName = prevProps.team.metadata && prevProps.team.metadata.name
-    if (teamFound && this.props.team.metadata.name !== prevTeamName) {
+    const prevTeamName = prevProps.team && prevProps.team.metadata && prevProps.team.metadata.name
+    if (this.props.team && this.props.team.metadata.name !== prevTeamName) {
       this.setState({ tabActiveKey: 'clusters' })
     }
   }
@@ -145,7 +144,7 @@ class TeamDashboard extends React.Component {
   render() {
     const { team, invitation } = this.props
 
-    if (Object.keys(team).length === 0) {
+    if (!team) {
       return <Error statusCode={404} />
     }
 


### PR DESCRIPTION
* adding cluster application specific wrapper around the ServiceOptionsForm
* this adds the namespace selection and has different submission process
* new section on the cluster detail page
* Service component displays different for Cloud and Application services

**Cluster detail page**

<img width="1353" alt="Screen Shot 2020-06-05 at 11 04 44" src="https://user-images.githubusercontent.com/1334068/83864799-2c755a80-a71d-11ea-8114-92b48b76b8d7.png">

**Team page clusters tab**

<img width="1118" alt="Screen Shot 2020-06-05 at 11 04 55" src="https://user-images.githubusercontent.com/1334068/83864817-313a0e80-a71d-11ea-833e-8f67e299a38c.png">

Fixes: #850 