### PR TITLE
Make default plans read-only, keep upgraded. Allow UI to delete plans.

### DIFF
--- a/pkg/kore/assets/plans.go
+++ b/pkg/kore/assets/plans.go
@@ -51,6 +51,9 @@ func GetDefaultPlans() []*configv1.Plan {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gke-development",
+				Annotations: map[string]string{
+					"kore.appvia.io/readonly": "true",
+				},
 			},
 			Spec: configv1.PlanSpec{
 				Kind:        "GKE",
@@ -114,6 +117,9 @@ func GetDefaultPlans() []*configv1.Plan {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gke-production",
+				Annotations: map[string]string{
+					"kore.appvia.io/readonly": "true",
+				},
 			},
 			Spec: configv1.PlanSpec{
 				Kind:        "GKE",
@@ -177,6 +183,9 @@ func GetDefaultPlans() []*configv1.Plan {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "eks-development",
+				Annotations: map[string]string{
+					"kore.appvia.io/readonly": "true",
+				},
 			},
 			Spec: configv1.PlanSpec{
 				Kind:        "EKS",
@@ -217,6 +226,9 @@ func GetDefaultPlans() []*configv1.Plan {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "eks-production",
+				Annotations: map[string]string{
+					"kore.appvia.io/readonly": "true",
+				},
 			},
 			Spec: configv1.PlanSpec{
 				Kind:        "EKS",

--- a/pkg/kore/setup.go
+++ b/pkg/kore/setup.go
@@ -77,14 +77,8 @@ func (h hubImpl) Setup(ctx context.Context) error {
 
 	// @step: ensure some default plans
 	for _, x := range assets.GetDefaultPlans() {
-		found, err := h.Plans().Has(ctx, x.Name)
-		if err != nil {
+		if err := h.Plans().Update(getAdminContext(ctx), x, true); err != nil {
 			return err
-		}
-		if !found {
-			if err := h.Plans().Update(getAdminContext(ctx), x, true); err != nil {
-				return err
-			}
 		}
 	}
 	for _, x := range assets.GetDefaultPlanPolicies() {

--- a/ui/lib/components/plans/PlanItem.js
+++ b/ui/lib/components/plans/PlanItem.js
@@ -1,26 +1,42 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Avatar, Icon, Typography } from 'antd'
+import { List, Avatar, Icon, Typography, Tooltip } from 'antd'
 const { Text } = Typography
 
 import IconTooltip from '../utils/IconTooltip'
+import { isReadOnlyCRD } from '../../utils/crd-helpers'
 
 class PlanItem extends React.Component {
   static propTypes = {
     plan: PropTypes.object.isRequired,
     viewPlan: PropTypes.func.isRequired,
     editPlan: PropTypes.func.isRequired,
+    deletePlan: PropTypes.func.isRequired,
     displayUnassociatedPlanWarning: PropTypes.bool.isRequired
   }
 
   actions = () => {
+    const readonly = isReadOnlyCRD(this.props.plan)
     const actions = []
     if (this.props.displayUnassociatedPlanWarning) {
       actions.push(<IconTooltip key="warning" icon="warning" color="orange" text="This plan not associated with any GCP automated projects and will not be available for teams to use. Edit this plan or go to Project automation settings to review this."/>)
     }
     actions.push(<Text key="view_plan"><a onClick={this.props.viewPlan(this.props.plan)}><Icon type="eye" theme="filled"/> View</a></Text>)
-    actions.push(<Text key="edit_plan"><a onClick={this.props.editPlan(this.props.plan)}><Icon type="edit" theme="filled"/> Edit</a></Text>,)
+    actions.push(
+      <Text key="edit_plan">
+        <Tooltip title={readonly ? 'Read-only' : 'Edit this plan'}>
+          <a onClick={readonly ? () => {} : this.props.editPlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
+        </Tooltip>
+      </Text>
+    )
+    actions.push(
+      <Text key="delete_plan">
+        <Tooltip title={readonly ? 'Read-only' : 'Delete this plan'}>
+          <a onClick={readonly ? () => {} : this.props.deletePlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
+        </Tooltip>
+      </Text>
+    )
     return actions
   }
 

--- a/ui/lib/components/plans/PlanList.js
+++ b/ui/lib/components/plans/PlanList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { List, Alert, Icon, Drawer, Typography, Button } from 'antd'
+import { List, Alert, Icon, Drawer, Typography, Button, Modal, message } from 'antd'
 const { Title, Text } = Typography
 
 import PlanItem from './PlanItem'
@@ -7,6 +7,7 @@ import ManageClusterPlanForm from './ManageClusterPlanForm'
 import ResourceList from '../resources/ResourceList'
 import PlanViewer from './PlanViewer'
 import KoreApi from '../../kore-api'
+import AllocationHelpers from '../../utils/allocation-helpers'
 
 class PlanList extends ResourceList {
 
@@ -70,6 +71,22 @@ class PlanList extends ResourceList {
     return false
   }
 
+  delete = (plan) => () => {
+    Modal.confirm({
+      title: `Are you sure you want to delete the plan ${plan.spec.description}?`,
+      content: 'This cannot be undone',
+      okText: 'Yes',
+      okType: 'danger',
+      cancelText: 'No',
+      onOk: async () => {
+        await AllocationHelpers.removeAllocation(plan)
+        await (await KoreApi.client()).RemovePlan(plan.metadata.name)
+        message.success(`Plan ${plan.spec.description} deleted`)
+        await this.refresh()
+      }
+    })
+  }
+
   render() {
     const { resources, view, edit, add } = this.state
 
@@ -87,7 +104,7 @@ class PlanList extends ResourceList {
           <>
             <List
               dataSource={resources.items}
-              renderItem={plan => <PlanItem plan={plan} viewPlan={this.view} editPlan={this.edit} displayUnassociatedPlanWarning={this.unassociatedPlanWarning(plan)} /> }
+              renderItem={plan => <PlanItem plan={plan} viewPlan={this.view} editPlan={this.edit} deletePlan={this.delete} displayUnassociatedPlanWarning={this.unassociatedPlanWarning(plan)} /> }
             >
             </List>
 

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -80,6 +80,7 @@ class KoreApiClient {
   ListPlans = (kind) => this.apis.default.ListPlans({ kind })
   UpdatePlan = (name, plan) => this.apis.default.UpdatePlan({ name, body: JSON.stringify(plan) })
   GetPlanSchema = (kind) => this.apis.default.GetPlanSchema({ kind })
+  RemovePlan = (name) => this.apis.default.RemovePlan({ name })
 
   // Services
   ListServiceProviders = () => this.apis.default.ListServiceProviders()


### PR DESCRIPTION
Few small changes:

* Built-in plans are now read-only.
* Setup.go now overwrites the default plans on startup rather than only if they don't exist, so we can update our built-in plans easily.
* UI respects the read-only flag so doesn't present editing options for uneditable plans.
* UI can now delete plans (like the CLI always could).