### PR TITLE
In-cluster services admin

### DIFF
--- a/hack/deploy-beta.sh
+++ b/hack/deploy-beta.sh
@@ -27,7 +27,7 @@ export ENVIRONMENT="${ENVIRONMENT:-"beta"}"
 export BUILD_ID=${BUILD_ID:-${VERSION}}
 
 export KORE_API_PUBLIC_URL=${KORE_API_PUBLIC_URL_BETA}
-export KORE_FEATURE_GATES="[services=true]"
+export KORE_FEATURE_GATES="[services=true,application_services=true]"
 export KORE_UI_PUBLIC_URL=${KORE_UI_PUBLIC_URL_BETA}
 export KORE_UI_SHOW_PROTOTYPES=true
 export KORE_VERBOSE=true

--- a/hack/deploy-qa.sh
+++ b/hack/deploy-qa.sh
@@ -27,7 +27,7 @@ export ENVIRONMENT="${ENVIRONMENT:-"qa"}"
 export BUILD_ID=${BUILD_ID:-${VERSION}}
 
 export KORE_API_PUBLIC_URL=${KORE_API_PUBLIC_URL_QA}
-export KORE_FEATURE_GATES="[services=true]"
+export KORE_FEATURE_GATES="[services=true,application_services=true]"
 export KORE_UI_PUBLIC_URL=${KORE_UI_PUBLIC_URL_QA}
 export KORE_UI_SHOW_PROTOTYPES=true
 export KORE_VERBOSE=true

--- a/ui/assets/styles.less
+++ b/ui/assets/styles.less
@@ -78,13 +78,20 @@
 
 .large-list-item {
 
-  .ant-list-item-meta-avatar img {
-    height: 75px
+  .ant-list-item-meta-avatar {
+    img {
+      height: 75px;
+    }
+    .ant-avatar {
+      width: 60px;
+      height: 60px;
+      img {
+        height: 60px;
+      }
+    }
   }
 
   .ant-list-item-meta-content {
-    margin-top: 15px;
-
     h4.ant-list-item-meta-title {
       font-size: 22px;
     }

--- a/ui/lib/components/layout/SiderMenu.js
+++ b/ui/lib/components/layout/SiderMenu.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import { Layout, Menu, Icon } from 'antd'
 const { Sider } = Layout
 const { SubMenu } = Menu
-import getConfig from 'next/config'
-const { publicRuntimeConfig } = getConfig()
+
+import { featureEnabled, KoreFeatures } from '../../utils/features'
 
 class SiderMenu extends React.Component {
   static propTypes = {
@@ -50,7 +50,7 @@ class SiderMenu extends React.Component {
         }
       >
         {menuItem({ key: 'configure_cloud', text: 'Cloud', href: '/configure/cloud/[[...cloud]]', link: '/configure/cloud', icon: 'cloud' })}
-        {!publicRuntimeConfig.featureGates['services'] ? null :
+        {featureEnabled(KoreFeatures.APPLICATION_SERVICES) ? null :
           menuItem({ key: 'configure_services', text: 'Services', link: '/configure/services', icon: 'cloud-server' })
         }
         {menuItem({ key: 'configure_users', text: 'Users', link: '/configure/users', icon: 'user' })}

--- a/ui/lib/components/layout/SiderMenu.js
+++ b/ui/lib/components/layout/SiderMenu.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { Layout, Menu, Icon } from 'antd'
 const { Sider } = Layout
 const { SubMenu } = Menu
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 class SiderMenu extends React.Component {
   static propTypes = {
@@ -48,12 +50,10 @@ class SiderMenu extends React.Component {
         }
       >
         {menuItem({ key: 'configure_cloud', text: 'Cloud', href: '/configure/cloud/[[...cloud]]', link: '/configure/cloud', icon: 'cloud' })}
-        {menuItem({ key: 'configure_users', text: 'Users', link: '/configure/users', icon: 'user' })}
-        {/* Removed for now - only exposing services via the cloud page at the moment
-        {!publicRuntimeConfig.featureGates['services'] ? null : 
+        {!publicRuntimeConfig.featureGates['services'] ? null :
           menuItem({ key: 'configure_services', text: 'Services', link: '/configure/services', icon: 'cloud-server' })
-        } 
-        */}
+        }
+        {menuItem({ key: 'configure_users', text: 'Users', link: '/configure/users', icon: 'user' })}
       </SubMenu>
     ) : null
 

--- a/ui/lib/components/services/ServiceKindManage.js
+++ b/ui/lib/components/services/ServiceKindManage.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import KoreApi from '../../../lib/kore-api'
-import { Card, Typography, Icon, Switch, Tooltip, List, Avatar, Button, Drawer, Modal } from 'antd'
+import { Card, Divider, Typography, Icon, Switch, Tooltip, List, Avatar, Button, Drawer, Modal } from 'antd'
 import ManageServicePlanForm from '../../../lib/components/plans/ManageServicePlanForm'
 import { isReadOnlyCRD } from '../../utils/crd-helpers'
-const { Paragraph, Text, Title } = Typography
+const { Text, Title } = Typography
 
 export default class ServiceKindManage extends React.Component {
   static propTypes = {
@@ -84,8 +84,7 @@ export default class ServiceKindManage extends React.Component {
 
     return (
       <List.Item key={plan.metadata.name} actions={actions}>
-        <List.Item.Meta 
-          avatar={<Avatar icon="build" />} 
+        <List.Item.Meta
           title={displayName} 
           description={plan.spec.description} />
       </List.Item>
@@ -148,27 +147,26 @@ export default class ServiceKindManage extends React.Component {
             />
           )}
         </Drawer>
-        <Card 
-          title={displayName} 
-          style={{ marginBottom: '30px' }}
-          extra={(
+
+        <List.Item>
+          <List.Item.Meta
+            className="large-list-item"
+            avatar={kind && kind.spec.imageURL ? <Avatar src={kind.spec.imageURL} /> : <Avatar size={60} icon="cloud-server" />}
+            title={displayName}
+            description={kind.spec.description || 'No description'}
+          />
+          <div style={{ marginLeft: '30px' }}>
             <Tooltip placement="left" title={kind.spec.enabled ? 'This is available for teams to consume' : 'Teams cannot use this cloud service'}>
               <Switch loading={loading} onChange={() => this.toggleEnabled()} checked={kind.spec.enabled} checkedChildren="Enabled" unCheckedChildren="Disabled" />
             </Tooltip>
-          )}>
-          <Paragraph className="logo">
-            { kind.spec.imageURL ? (
-              <img src={kind.spec.imageURL} height="80px" />
-            ) : (
-              <Icon type="cloud-server" style={{ fontSize: '80px' }} theme="outlined" />
-            ) }
-          </Paragraph>
-          <Paragraph className="name" strong>{displayName}</Paragraph>
-          <Paragraph type="secondary">{kind.spec.description}</Paragraph>
-        </Card>
+          </div>
+        </List.Item>
+
+        <Divider />
+
         <Card 
-          title={`Plans for ${displayName}`} 
-          extra={kind.spec.schema ? <Button type="primary" onClick={this.createPlan}>+ New</Button> : null}>
+          title={`Plans for ${displayName}`}
+          extra={kind.spec.schema ? <Button type="primary" onClick={this.createPlan}>+ New plan</Button> : null}>
           <List dataSource={plans.items} renderItem={(plan) => this.renderPlan(plan)} />
         </Card>
       </>

--- a/ui/lib/components/teams/cluster/ClustersTab.js
+++ b/ui/lib/components/teams/cluster/ClustersTab.js
@@ -4,8 +4,6 @@ import moment from 'moment'
 import Link from 'next/link'
 import { Button, Col, Divider, Icon, message, Row, Tag, Tooltip, Typography } from 'antd'
 const { Paragraph, Text } = Typography
-import getConfig from 'next/config'
-const { publicRuntimeConfig } = getConfig()
 import { get } from 'lodash'
 
 import Cluster from './Cluster'
@@ -13,6 +11,7 @@ import ClusterAccessInfo from './ClusterAccessInfo'
 import KoreApi from '../../../kore-api'
 import copy from '../../../utils/object-copy'
 import { inProgressStatusList, statusColorMap, statusIconMap } from '../../../utils/ui-helpers'
+import { featureEnabled, KoreFeatures } from '../../../utils/features'
 
 class ClustersTab extends React.Component {
 
@@ -30,8 +29,6 @@ class ClustersTab extends React.Component {
     createNamespace: false
   }
 
-  servicesEnabled = () => Boolean(publicRuntimeConfig.featureGates['services'])
-
   async fetchComponentData () {
     try {
       const team = this.props.team.metadata.name
@@ -40,7 +37,7 @@ class ClustersTab extends React.Component {
         api.ListClusters(team),
         api.ListNamespaces(team),
         api.ListPlans(),
-        this.servicesEnabled() ? api.ListServices(team) : Promise.resolve({ items: [] })
+        featureEnabled(KoreFeatures.APPLICATION_SERVICES) ? api.ListServices(team) : Promise.resolve({ items: [] })
       ])
       clusters = clusters.items
       namespaceClaims = namespaceClaims.items
@@ -176,7 +173,7 @@ class ClustersTab extends React.Component {
                     resourceApiPath={`/teams/${team.metadata.name}/clusters/${cluster.metadata.name}`}
                   />
                   {!cluster.deleted && clusterNamespaceClaims.length > 0 && this.clusterResourceList({ resources: namespaceClaims, resourceDisplayPropertyPath: 'spec.name', title: 'Namespaces' })}
-                  {!cluster.deleted && this.servicesEnabled() && clusterApplicationServices.length > 0 && this.clusterResourceList({ resources: clusterApplicationServices, resourceDisplayPropertyPath: 'metadata.name', title: 'Application services', style: { marginTop: '5px' } })}
+                  {!cluster.deleted && featureEnabled(KoreFeatures.APPLICATION_SERVICES) && clusterApplicationServices.length > 0 && this.clusterResourceList({ resources: clusterApplicationServices, resourceDisplayPropertyPath: 'metadata.name', title: 'Application services', style: { marginTop: '5px' } })}
                   {!cluster.deleted && idx < clusters.length - 1 && <Divider />}
                 </React.Fragment>
               )

--- a/ui/lib/utils/features.js
+++ b/ui/lib/utils/features.js
@@ -1,0 +1,11 @@
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
+
+export const KoreFeatures = {
+  SERVICES: 'services',
+  APPLICATION_SERVICES: 'application_services'
+}
+
+export function featureEnabled(feature) {
+  return Boolean(publicRuntimeConfig.featureGates[feature])
+}

--- a/ui/pages/configure/cloud/[[...cloud]].js
+++ b/ui/pages/configure/cloud/[[...cloud]].js
@@ -12,8 +12,7 @@ import PolicyList from '../../../lib/components/policies/PolicyList'
 import GCPProjectAutomationSettings from '../../../lib/components/setup/GCPProjectAutomationSettings'
 import CloudTabs from '../../../lib/components/common/CloudTabs'
 import CloudServiceAdmin from '../../../lib/components/services/CloudServiceAdmin'
-import getConfig from 'next/config'
-const { publicRuntimeConfig } = getConfig()
+import { featureEnabled, KoreFeatures } from '../../../lib/utils/features'
 
 export default class ConfigureCloudPage extends React.Component {
   static propTypes = {
@@ -96,7 +95,7 @@ export default class ConfigureCloudPage extends React.Component {
             <Tabs.TabPane tab="Cluster Policies" key="policies">
               <PolicyList kind="EKS" />
             </Tabs.TabPane>
-            {!publicRuntimeConfig.featureGates['services'] ? null : 
+            {!featureEnabled(KoreFeatures.SERVICES) ? null :
               <Tabs.TabPane tab="Cloud Services" key="services">
                 <CloudServiceAdmin cloud="AWS" />
               </Tabs.TabPane>

--- a/ui/pages/configure/services/[kind].js
+++ b/ui/pages/configure/services/[kind].js
@@ -27,8 +27,9 @@ export default class ServiceKindPage extends React.Component {
       <>
         <Breadcrumb
           items={[
+            { text: 'Configure' },
             { text: 'Services', href: '/configure/services', link: '/configure/services' },
-            { text: `Service: ${displayName}` }
+            { text: displayName }
           ]}
         />
         <ServiceKindManage kind={details} />

--- a/ui/pages/configure/services/index.js
+++ b/ui/pages/configure/services/index.js
@@ -1,24 +1,49 @@
 import React from 'react'
 import ServiceKindList from '../../../lib/components/services/ServiceKindList'
 import Breadcrumb from '../../../lib/components/layout/Breadcrumb'
-import { Alert } from 'antd'
+import { Alert, Card, Checkbox, Form, Input, Typography } from 'antd'
+const { Text } = Typography
+
+import { getKoreLabel } from '../../../lib/utils/crd-helpers'
 
 export default class ServiceIndexPage extends React.Component {
+  state = {
+    platformFilter: [],
+    serviceNameFilter: ''
+  }
+
+  changeFilters = (platform) => () => {
+    if (this.state.platformFilter.indexOf(platform) >= 0) {
+      this.setState({ platformFilter: this.state.platformFilter.filter(f => f !== platform) })
+    } else {
+      this.setState({ platformFilter: [ ...this.state.platformFilter, platform ] })
+    }
+  }
+
+  checkboxFilter = (name) => (
+    <Checkbox checked={this.state.platformFilter.indexOf(name) >= 0} onClick={this.changeFilters(name)}>{name}</Checkbox>
+  )
+
   render() {
     return (
       <>
-        <Breadcrumb
-          items={[
-            { text: 'Cloud Services', href: '/configure/services', link: '/configure/services' }
-          ]}
-        />
+        <Breadcrumb items={[{ text: 'Configure' }, { text: 'Services' }]}/>
         <Alert 
           type="info" 
-          message="Cloud Services"
+          message="Services"
           description="Enabling services allows teams to provision additional resources, either from cloud providers or directly into their clusters. Each service type can be enabled or disabled, and selecting 'Manage' allows control over the plans for a specific service."
           style={{ marginBottom: '20px' }}
         />
-        <ServiceKindList />
+        <Card size="small" style={{ marginBottom: '20px' }}>
+          <Form.Item labelAlign="left" labelCol={{ span: 4 }} label={<Text strong>Filter by platform</Text>} style={{ marginBottom: 0 }}>
+            {this.checkboxFilter('AWS')}{this.checkboxFilter('Kubernetes')}
+          </Form.Item>
+          <Form.Item labelAlign="left" labelCol={{ span: 4 }} wrapperCol={{ span: 6 }} label={<Text strong>Filter by service name</Text>} style={{ marginBottom: 0 }}>
+            <Input onChange={(e) => this.setState({ serviceNameFilter: e.target.value })} value={this.state.serviceNameFilter} placeholder="Filter by service name"/>
+          </Form.Item>
+          <a style={{ display: 'block', marginTop: '10px', marginBottom: '5px', textDecoration: 'underline' }} onClick={() => this.setState({ serviceNameFilter: '', platformFilter: [] })}>Clear filters</a>
+        </Card>
+        <ServiceKindList filter={ (s) => (this.state.platformFilter.length === 0 || this.state.platformFilter.includes(getKoreLabel(s, 'platform'))) && s.spec.displayName.toLowerCase().indexOf(this.state.serviceNameFilter.toLowerCase()) >= 0} />
       </>
     )
   }

--- a/ui/pages/teams/[name].js
+++ b/ui/pages/teams/[name].js
@@ -6,12 +6,11 @@ import Error from 'next/error'
 import { Typography, Button, message, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
 const { Paragraph, Text } = Typography
 const { TabPane } = Tabs
-import getConfig from 'next/config'
-const { publicRuntimeConfig } = getConfig()
 
 import Breadcrumb from '../../lib/components/layout/Breadcrumb'
 import redirect from '../../lib/utils/redirect'
 import KoreApi from '../../lib/kore-api'
+import { featureEnabled, KoreFeatures } from '../../lib/utils/features'
 import ClustersTab from '../../lib/components/teams/cluster/ClustersTab'
 import ServicesTab from '../../lib/components/teams/service/ServicesTab'
 import MembersTab from '../../lib/components/teams/members/MembersTab'
@@ -177,7 +176,7 @@ class TeamDashboard extends React.Component {
             <ClustersTab user={this.props.user} team={this.props.team} getClusterCount={(count) => this.setState({ clusterCount: count })} />
           </TabPane>
 
-          {!publicRuntimeConfig.featureGates['services'] ? null : (
+          {!featureEnabled(KoreFeatures.SERVICES) ? null : (
             <TabPane key="services" tab={this.getTabTitle({ title: 'Cloud services', count: this.state.serviceCount })} forceRender={true}>
               <ServicesTab user={this.props.user} team={this.props.team} getServiceCount={(count) => this.setState({ serviceCount: count })} />
             </TabPane>

--- a/ui/pages/teams/[name]/clusters/[cluster].js
+++ b/ui/pages/teams/[name]/clusters/[cluster].js
@@ -345,7 +345,7 @@ class ClusterPage extends React.Component {
               <List.Item.Meta
                 className="large-list-item"
                 avatar={<img src={clusterProviderIconSrcMap[cluster.spec.kind]} />}
-                title={cluster.metadata.name}
+                title={<Text style={{ marginTop: '15px', display: 'block' }}>{cluster.metadata.name}</Text>}
                 description={
                   <div>
                     <Text type='secondary'>Created {created}</Text>

--- a/ui/pages/teams/[name]/clusters/[cluster].js
+++ b/ui/pages/teams/[name]/clusters/[cluster].js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import moment from 'moment'
 import { Divider, Typography, Collapse, Icon, Row, Col, List, Button, Form, Card, Badge, message, Drawer, Tooltip } from 'antd'
 const { Paragraph, Text } = Typography
-import getConfig from 'next/config'
-const { publicRuntimeConfig } = getConfig()
 
 import KoreApi from '../../../../lib/kore-api'
 import Breadcrumb from '../../../../lib/components/layout/Breadcrumb'
@@ -13,6 +11,7 @@ import ComponentStatusTree from '../../../../lib/components/common/ComponentStat
 import ResourceStatusTag from '../../../../lib/components/resources/ResourceStatusTag'
 import { clusterProviderIconSrcMap } from '../../../../lib/utils/ui-helpers'
 import copy from '../../../../lib/utils/object-copy'
+import { featureEnabled, KoreFeatures } from '../../../../lib/utils/features'
 import FormErrorMessage from '../../../../lib/components/forms/FormErrorMessage'
 import { inProgressStatusList } from '../../../../lib/utils/ui-helpers'
 import apiPaths from '../../../../lib/utils/api-paths'
@@ -66,10 +65,8 @@ class ClusterPage extends React.Component {
     return { team, cluster }
   }
 
-  servicesEnabled = () => Boolean(publicRuntimeConfig.featureGates['services'])
-
   fetchCommonData = async () => {
-    if (this.servicesEnabled()) {
+    if (featureEnabled(KoreFeatures.SERVICES)) {
       const serviceKinds = await (await KoreApi.client()).ListServiceKinds()
       return { serviceKinds: serviceKinds.items }
     }
@@ -81,13 +78,13 @@ class ClusterPage extends React.Component {
     const api = await KoreApi.client()
     let [ namespaceClaims, serviceCredentials ] = await Promise.all([
       api.ListNamespaces(team),
-      this.servicesEnabled() ? api.ListServiceCredentials(team, this.state.cluster.metadata.name) : Promise.resolve({ items: [] }),
+      featureEnabled(KoreFeatures.SERVICES) ? api.ListServiceCredentials(team, this.state.cluster.metadata.name) : Promise.resolve({ items: [] }),
     ])
     namespaceClaims = namespaceClaims.items.filter(ns => ns.spec.cluster.name === this.props.cluster.metadata.name)
     serviceCredentials = serviceCredentials.items
 
     const revealBindings = {}
-    this.servicesEnabled() && namespaceClaims.filter(nc => serviceCredentials.filter(sc => sc.spec.clusterNamespace === nc.spec.name).length > 0).forEach(nc => revealBindings[nc.spec.name] = true)
+    featureEnabled(KoreFeatures.SERVICES) && namespaceClaims.filter(nc => serviceCredentials.filter(sc => sc.spec.clusterNamespace === nc.spec.name).length > 0).forEach(nc => revealBindings[nc.spec.name] = true)
 
     return { namespaceClaims, serviceCredentials, revealBindings }
   }
@@ -106,7 +103,7 @@ class ClusterPage extends React.Component {
     this.fetchCommonData().then(data => {
       this.setState({ ...data })
       this.fetchNamespacesData().then(data => this.setState({ ...data }))
-      if (this.servicesEnabled()) {
+      if (featureEnabled(KoreFeatures.APPLICATION_SERVICES)) {
         this.fetchApplicationServicesData().then(data => this.setState({ ...data }))
       }
     })
@@ -392,7 +389,7 @@ class ClusterPage extends React.Component {
                   propsResourceDataKey="namespaceClaim"
                   resourceApiPath={`/teams/${team.metadata.name}/namespaceclaims/${namespaceClaim.metadata.name}`}
                 />
-                {!namespaceClaim.deleted && this.servicesEnabled() && (
+                {!namespaceClaim.deleted && featureEnabled(KoreFeatures.SERVICES) && (
                   <>
                     <Collapse onChange={this.revealBindings(namespaceClaim.spec.name)} activeKey={this.state.revealBindings[namespaceClaim.spec.name] ? ['bindings'] : []}>
                       <Collapse.Panel
@@ -452,7 +449,7 @@ class ClusterPage extends React.Component {
             <NamespaceClaimForm team={team.metadata.name} cluster={cluster} handleSubmit={this.handleNamespaceCreated} handleCancel={this.createNamespace(false)}/>
           </Drawer>
 
-          {this.servicesEnabled() && (
+          {featureEnabled(KoreFeatures.SERVICES) && (
             <Drawer
               title="Create service access"
               placement="right"
@@ -476,7 +473,7 @@ class ClusterPage extends React.Component {
 
         </Card>
 
-        {this.servicesEnabled() && (
+        {featureEnabled(KoreFeatures.APPLICATION_SERVICES) && (
           <>
             <Card
               title={this.getCardTitle('Application services', applicationServices)}

--- a/ui/scripts/run-with-env.sh
+++ b/ui/scripts/run-with-env.sh
@@ -8,7 +8,7 @@ done
 
 export KORE_API_TOKEN=$(kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_TOKEN" | base64 --decode)
 
-export KORE_FEATURE_GATES="services=true"
+export KORE_FEATURE_GATES="services=true,application_services=true"
 export KORE_UI_SHOW_PROTOTYPES=true
 
 exec "$@"


### PR DESCRIPTION
* adding left-side menu button for "Services"
* both in-cluster and cloud services can be managed via this page
* filter the services on this page by platform and service name
* enabled/disabled now shown side-by-side
* some minor cosmetic changes to service admin in general

<img width="1150" alt="Screen Shot 2020-06-08 at 16 56 39" src="https://user-images.githubusercontent.com/1334068/84052984-31e6d500-a9a9-11ea-830d-64087bf8c132.png">

<img width="1161" alt="Screen Shot 2020-06-08 at 16 58 13" src="https://user-images.githubusercontent.com/1334068/84053008-3a3f1000-a9a9-11ea-804b-6d4ce77ba451.png">

Closes #850 