### PR TITLE
Improve UI E2E Workflow and plan default values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ jobs:
               libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
               libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
               libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-              fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+              fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm1
             curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
             sudo apt install nodejs
             node --version

--- a/pkg/kore/assets/plan_schema_eks.go
+++ b/pkg/kore/assets/plan_schema_eks.go
@@ -42,7 +42,8 @@ const EKSPlanSchema = `
 			"items": {
 				"type": "string",
 				"format": "1.2.3.4/16"
-			}
+			},
+			"default": [ "0.0.0.0/0" ]
 		},
 		"authProxyAllowedIPs": {
 			"title": "Auth Proxy Allowed IP Ranges",
@@ -52,7 +53,8 @@ const EKSPlanSchema = `
 				"type": "string",
 				"format": "1.2.3.4/16"
 			},
-			"minItems": 1
+			"minItems": 1,
+			"default": [ "0.0.0.0/0" ]
 		},
 		"clusterUsers": {
 			"type": "array",
@@ -84,7 +86,8 @@ const EKSPlanSchema = `
 		"defaultTeamRole": {
 			"type": "string",
 			"description": "The default role that team members have on this cluster.",
-			"enum": [ "view", "edit", "admin", "cluster-admin" ]
+			"enum": [ "view", "edit", "admin", "cluster-admin" ],
+			"default": "view"
 		},
 		"description": {
 			"type": "string",
@@ -94,13 +97,16 @@ const EKSPlanSchema = `
 		"domain": {
 			"type": "string",
 			"description": "The domain for this cluster.",
-			"minLength": 1
+			"minLength": 1,
+			"default": "default"
 		},
 		"enableDefaultTrafficBlock": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": false
 		},
 		"inheritTeamMembers": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": true
 		},
 		"nodeGroups": {
 			"type": "array",
@@ -209,7 +215,8 @@ const EKSPlanSchema = `
 			"type": "string",
 			"description": "The range of IPv4 addresses for your EKS cluster in CIDR block format",
 			"format": "1.2.3.4/16",
-			"immutable": true
+			"immutable": true,
+			"default": "10.0.0.0/16"
 		},
 		"region": {
 			"type": "string",

--- a/pkg/kore/assets/plan_schema_gke.go
+++ b/pkg/kore/assets/plan_schema_gke.go
@@ -65,7 +65,10 @@ const GKEPlanSchema = `
 					}
 				}
 			},
-			"minItems": 1
+			"minItems": 1,
+			"default": [
+				{ "name": "default", "cidr": "0.0.0.0/0" }
+			]
 		},
 		"authProxyAllowedIPs": {
 			"title": "Auth Proxy Allowed IP Ranges",
@@ -75,7 +78,8 @@ const GKEPlanSchema = `
 				"type": "string",
 				"format": "1.2.3.4/16"
 			},
-			"minItems": 1
+			"minItems": 1,
+			"default": [ "0.0.0.0/0" ]
 		},
 		"clusterUsers": {
 			"type": "array",
@@ -107,7 +111,8 @@ const GKEPlanSchema = `
 		"defaultTeamRole": {
 			"type": "string",
 			"description": "The default role that team members have on this cluster.",
-			"enum": [ "view", "edit", "admin", "cluster-admin" ]
+			"enum": [ "view", "edit", "admin", "cluster-admin" ],
+			"default": "view"
 		},
 		"description": {
 			"type": "string",
@@ -118,51 +123,62 @@ const GKEPlanSchema = `
 			"type": "string",
 			"description": "The domain for this cluster.",
 			"minLength": 1,
-			"immutable": true
+			"default": "default"
 		},
 		"enableDefaultTrafficBlock": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": false
 		},
 		"enableHTTPLoadBalancer": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": true
 		},
 		"enableHorizontalPodAutoscaler": {
 			"type": "boolean",
-			"immutable": true
+			"immutable": true,
+			"default": true
 		},
 		"enableIstio": {
 			"type": "boolean",
-			"immutable": true
+			"immutable": true,
+			"default": false
 		},
 		"enablePrivateEndpoint": {
 			"type": "boolean",
-			"immutable": true
+			"immutable": true,
+			"default": false
 		},
 		"enablePrivateNetwork": {
 			"type": "boolean",
-			"immutable": true
+			"immutable": true,
+			"default": false
 		},
 		"enableShieldedNodes": {
 			"type": "boolean",
 			"description": "Shielded nodes provide additional verifications of the node OS and VM, with enhanced rootkit and bootkit protection applied",
-			"immutable": true
+			"immutable": true,
+			"default": true
 		},
 		"enableStackDriverLogging": {
 			"type": "boolean",
-			"immutable": true
+			"immutable": true,
+			"default": true
 		},
 		"enableStackDriverMetrics": {
 			"type": "boolean",
-			"immutable": true
+			"immutable": true,
+			"default": true
 		},
 		"inheritTeamMembers": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": true
 		},
 		"maintenanceWindow": {
 			"type": "string",
 			"description": "Time of day to allow maintenance operations to be performed by the cloud provider on this cluster.",
 			"format": "hh:mm",
-			"immutable": true
+			"immutable": true,
+			"default": "03:00"
 		},
 		"nodePools": {
 			"type": "array",
@@ -316,7 +332,8 @@ const GKEPlanSchema = `
 		"releaseChannel": {
 			"type": "string",
 			"description": "Follow a GKE release channel to control the auto-upgrade of your cluster - if set, auto-upgrade will be true on all node groups",
-			"enum": ["REGULAR", "STABLE", "RAPID", ""]
+			"enum": ["REGULAR", "STABLE", "RAPID", ""],
+			"default": "REGULAR"
 		},
 		"version": {
 			"type": "string",
@@ -324,7 +341,8 @@ const GKEPlanSchema = `
 			"pattern": "^($|-|latest|[0-9]+\\.[0-9]+($|\\.[0-9]+($|\\-gke\\.[0-9]+)))$",
 			"examples": [
 				"- (GKE default)", "1.15 (latest 1.15.x)", "1.15.1", "1.15.1-gke.6 (exact GKE patch version, not recommended)", "latest"
-			]
+			],
+			"default": ""
 		},
 
 		"diskSize": {

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -16,6 +16,20 @@ test:
 	npm run lint
 	npm test
 
+test-e2e:
+	@echo "--> Running E2E Tests (headless)"
+	npm run test-e2e
+
+test-e2e-debug:
+	@echo "--> Running E2E Tests (non-headless)"
+	@export SHOW_BROWSER=true && npm run test-e2e
+
+kind-e2e:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e
+
+kind-e2e-debug:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-debug
+
 update-swagger:
 	@echo "--> Updating unit test / auto-gen swagger (requires API to be running locally)"
 	@curl --retry 5 --retry-delay 5 --retry-connrefused -sSL http://127.0.0.1:10080/swagger.json | jq > ./kore-api-swagger.json

--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -39,7 +39,7 @@ describe('Configure Cloud - GCP', () => {
 
     it('adds a new project credential', async () => {
       await gkeProjCredsPage.add()
-      await gkeProjCredsPage.populateNew(testCred)
+      await gkeProjCredsPage.populate(testCred)
       await gkeProjCredsPage.save()
       await expect(page).toMatch('GCP project credentials created successfully')
     })
@@ -50,14 +50,14 @@ describe('Configure Cloud - GCP', () => {
 
     it('edits a project credential with a new description', async () => {
       await gkeProjCredsPage.edit(testCred.name, testCred.project)
-      await gkeProjCredsPage.populateEdit({ summary: 'summary2' })
+      await gkeProjCredsPage.populate({ summary: 'summary2' })
       await gkeProjCredsPage.save()
       await expect(page).toMatch('GCP project credentials updated successfully')
     })
 
     it('edits a project credential with a new key', async () => {
       await gkeProjCredsPage.edit(testCred.name, testCred.project)
-      await gkeProjCredsPage.populateEdit({ json: 'sheep' })
+      await gkeProjCredsPage.replaceKey('sheep')
       await gkeProjCredsPage.save()
       await expect(page).toMatch('GCP project credentials updated successfully')
     })

--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -85,8 +85,7 @@ describe('Configure Cloud - GCP', () => {
       await cloudPage.closeAllNotifications()
       await waitForDrawerOpenClose(page)
       await gkeClusterPlansPage.openTab()
-      // Wait for plans to load
-      await page.waitForSelector('#gkeplans_list', { timeout: 1000 })
+      await gkeClusterPlansPage.listLoaded()
     })
 
     beforeEach(async () => {
@@ -116,6 +115,7 @@ describe('Configure Cloud - GCP', () => {
 
     it('creates a new plan using default values', async () => {
       await gkeClusterPlansPage.new()
+      await expect(page).toMatch('New GKE plan')
       await gkeClusterPlansPage.populatePlan(testPlan)
       await gkeClusterPlansPage.addNodePool()
       await gkeClusterPlansPage.populateNodePool({ name: 'compute' })

--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -1,0 +1,161 @@
+const { ConfigureCloudPage } = require('./page-objects/configure/cloud/configure-cloud')
+const { ConfigureCloudGCPProjects } = require('./page-objects/configure/cloud/GCP/projects')
+const { ConfigureCloudGCPClusterPlans } = require('./page-objects/configure/cloud/GCP/cluster-plans')
+const { waitForDrawerOpenClose } = require('./page-objects/utils')
+
+const page = global.page
+
+// This test assumes it runs after a test which performs a login as local admin (e.g. 01-first-time-setup.test.js)
+describe('Configure Cloud - GCP', () => {
+  const cloudPage = new ConfigureCloudPage(page)
+
+  beforeAll(async () => {
+    await cloudPage.visitPage()
+    cloudPage.verifyPageURL()
+    await cloudPage.selectCloud('gcp')
+  })
+
+  describe('Project Credentials', () => {
+    const gkeProjCredsPage = new ConfigureCloudGCPProjects(page)
+    const testCred = {
+      // Randomise name of test cred.
+      name: `testproj-${Math.random().toString(36).substr(2, 5)}`,
+      summary: 'a summary',
+      project: 'project001',
+      json: 'horse'
+    }
+
+    beforeAll(async () => {
+      await gkeProjCredsPage.openTab()
+    })
+
+    beforeEach(async () => {
+      await gkeProjCredsPage.closeAllNotifications()
+    })
+
+    it('has the correct URL', () => {
+      gkeProjCredsPage.verifyPageURL()
+    })
+
+    it('adds a new project credential', async () => {
+      await gkeProjCredsPage.add()
+      await gkeProjCredsPage.populateNew(testCred)
+      await gkeProjCredsPage.save()
+      await expect(page).toMatch('GCP project credentials created successfully')
+    })
+
+    it('shows project credentials', async () => {
+      await gkeProjCredsPage.checkCredentialListed(testCred.name)
+    })
+
+    it('edits a project credential with a new description', async () => {
+      await gkeProjCredsPage.edit(testCred.name, testCred.project)
+      await gkeProjCredsPage.populateEdit({ summary: 'summary2' })
+      await gkeProjCredsPage.save()
+      await expect(page).toMatch('GCP project credentials updated successfully')
+    })
+
+    it('edits a project credential with a new key', async () => {
+      await gkeProjCredsPage.edit(testCred.name, testCred.project)
+      await gkeProjCredsPage.populateEdit({ json: 'sheep' })
+      await gkeProjCredsPage.save()
+      await expect(page).toMatch('GCP project credentials updated successfully')
+    })
+
+    it('allows credentials to be deleted', async () => {
+      await gkeProjCredsPage.delete(testCred.name)
+      await gkeProjCredsPage.confirmDelete()
+      await expect(page).toMatch('GCP project credentials deleted successfully')
+    })
+
+  })
+
+  describe('Cluster Plans', () => {
+    const gkeClusterPlansPage = new ConfigureCloudGCPClusterPlans(page)
+
+    const testPlan = {
+      name: `testplan-${Math.random().toString(36).substr(2, 5)}`,
+      description: 'Test plan for testing',
+      planDescription: 'A plan description',
+      region: 'europe-west2'
+    }
+
+    beforeAll(async () => {
+      // In case of gruff from previous tests, wait a beat before starting.
+      await cloudPage.closeAllNotifications()
+      await waitForDrawerOpenClose(page)
+      await gkeClusterPlansPage.openTab()
+      // Wait for plans to load
+      await page.waitForSelector('#gkeplans_list', { timeout: 1000 })
+    })
+
+    beforeEach(async () => {
+      await gkeClusterPlansPage.closeAllNotifications()
+    })
+
+    it('has the correct URL', () => {
+      gkeClusterPlansPage.verifyPageURL()
+    })
+
+    it('views an existing plan', async () => {
+      await gkeClusterPlansPage.view('gke-development')
+      // Check a random thing to ensure the plan is being displayed.
+      await expect(page).toMatch('Authorized Master Networks')
+      await gkeClusterPlansPage.closeDrawer()
+    })
+
+    it('does not allow editing of a read-only plan', async () => {
+      await gkeClusterPlansPage.edit('gke-development')
+      await expect(page).toMatch('This plan is read-only')
+    })
+
+    it('does not allow deleting of a read-only plan', async () => {
+      await gkeClusterPlansPage.delete('gke-development')
+      await expect(page).toMatch('This plan is read-only and cannot be deleted')
+    })
+
+    it('creates a new plan using default values', async () => {
+      await gkeClusterPlansPage.new()
+      await gkeClusterPlansPage.populatePlan(testPlan)
+      await gkeClusterPlansPage.addNodePool()
+      await gkeClusterPlansPage.populateNodePool({ name: 'compute' })
+      await gkeClusterPlansPage.closeNodePool()
+      await gkeClusterPlansPage.save()
+      await expect(page).toMatch('GKE plan created successfully')
+    })
+
+    it('edits an existing plan', async () => {
+      await gkeClusterPlansPage.edit(testPlan.name)
+      await gkeClusterPlansPage.populatePlan({ region: 'europe-west1' })
+      await gkeClusterPlansPage.addNodePool()
+      // No node pool name, close should be disabled:
+      expect(await gkeClusterPlansPage.closeNodePoolDisabled()).toBeTruthy()
+      await gkeClusterPlansPage.populateNodePool({ name: 'compute' })
+      // Node pool name clashes with existing name, close should be disabled:
+      expect(await gkeClusterPlansPage.closeNodePoolDisabled()).toBeTruthy()
+      await gkeClusterPlansPage.populateNodePool({ name: 'compute2' })
+      // Button should now be enabled:
+      expect(await gkeClusterPlansPage.closeNodePoolDisabled()).not.toBeTruthy()
+      await gkeClusterPlansPage.closeNodePool()
+      await gkeClusterPlansPage.save()
+      await expect(page).toMatch('GKE plan updated successfully')
+    })
+
+    it('edits an existing node pool', async () => {
+      await gkeClusterPlansPage.edit(testPlan.name)
+      await gkeClusterPlansPage.viewEditNodePool(1)
+      await gkeClusterPlansPage.populateNodePool({ enableAutoscaler: false, size: 10 })
+      await gkeClusterPlansPage.closeNodePool()
+      await gkeClusterPlansPage.save()
+      await expect(page).toMatch('GKE plan updated successfully')
+    })
+
+    it('allows deleting of a non-read-only plan', async () => {
+      await gkeClusterPlansPage.delete(testPlan.name)
+      await gkeClusterPlansPage.confirmDelete()
+      await expect(page).toMatch(`${testPlan.name} plan deleted`)
+    })
+
+  })
+
+})

--- a/ui/__tests__/e2e/03-configure-cloud-aws.test.js
+++ b/ui/__tests__/e2e/03-configure-cloud-aws.test.js
@@ -1,0 +1,73 @@
+const { ConfigureCloudPage } = require('./page-objects/configure/cloud/configure-cloud')
+const { ConfigureCloudAWSAccounts } = require('./page-objects/configure/cloud/AWS/accounts')
+
+const page = global.page
+
+// This test assumes it runs after a test which performs a login as local admin (e.g. 01-first-time-setup.test.js)
+describe('Configure Cloud - AWS', () => {
+  const cloudPage = new ConfigureCloudPage(page)
+
+  beforeAll(async () => {
+    await cloudPage.visitPage()
+    cloudPage.verifyPageURL()
+    await cloudPage.selectCloud('aws')
+  })
+
+  describe('Account Credentials', () => {
+    const awsAccountsPage = new ConfigureCloudAWSAccounts(page)
+    const testCred = {
+      // Randomise name of test cred.
+      name: `testproj-${Math.random().toString(36).substr(2, 5)}`,
+      summary: 'a summary',
+      accountID: '123456',
+      accessKeyID: 'abcdef',
+      secretAccessKey: 'pqrstuvwx'
+    }
+
+    beforeAll(async () => {
+      await awsAccountsPage.openTab()
+    })
+
+    beforeEach(async () => {
+      await awsAccountsPage.closeAllNotifications()
+    })
+
+    it('has the correct URL', () => {
+      awsAccountsPage.verifyPageURL()
+    })
+
+    it('adds a new account credential', async () => {
+      await awsAccountsPage.add()
+      await expect(page).toMatch('New AWS account')
+      await awsAccountsPage.populate(testCred)
+      expect(await awsAccountsPage.saveButtonDisabled()).not.toBeTruthy()
+      await awsAccountsPage.save()
+    })
+
+    it('shows account credentials', async () => {
+      await awsAccountsPage.checkAccountListed(testCred.name)
+    })
+
+    it('edits a credential with a new description', async () => {
+      await awsAccountsPage.edit(testCred.name, testCred.accountID)
+      await awsAccountsPage.populate({ summary: 'summary2' })
+      await awsAccountsPage.save()
+      await expect(page).toMatch('AWS account credentials updated successfully')
+    })
+
+    it('edits a credential with a new key', async () => {
+      await awsAccountsPage.edit(testCred.name, testCred.accountID)
+      await awsAccountsPage.replaceKey('abcdefAB', 'pqrstuvwxAB')
+      await awsAccountsPage.save()
+      await expect(page).toMatch('AWS account credentials updated successfully')
+    })
+
+    // Re-instate this once deleting EKS credentials implemented:
+    // it('allows credentials to be deleted', async () => {
+    //   await awsAccountsPage.delete(testCred.name)
+    //   await awsAccountsPage.confirmDelete()
+    //   await expect(page).toMatch('AWS account credentials deleted successfully')
+    // })
+  })
+
+})

--- a/ui/__tests__/e2e/03-configure-cloud-aws.test.js
+++ b/ui/__tests__/e2e/03-configure-cloud-aws.test.js
@@ -1,5 +1,7 @@
 const { ConfigureCloudPage } = require('./page-objects/configure/cloud/configure-cloud')
 const { ConfigureCloudAWSAccounts } = require('./page-objects/configure/cloud/AWS/accounts')
+const { ConfigureCloudAWSClusterPlans } = require('./page-objects/configure/cloud/AWS/cluster-plans')
+const { waitForDrawerOpenClose } = require('./page-objects/utils')
 
 const page = global.page
 
@@ -62,12 +64,99 @@ describe('Configure Cloud - AWS', () => {
       await expect(page).toMatch('AWS account credentials updated successfully')
     })
 
-    // Re-instate this once deleting EKS credentials implemented:
-    // it('allows credentials to be deleted', async () => {
-    //   await awsAccountsPage.delete(testCred.name)
-    //   await awsAccountsPage.confirmDelete()
-    //   await expect(page).toMatch('AWS account credentials deleted successfully')
-    // })
+    it('allows credentials to be deleted', async () => {
+      await awsAccountsPage.delete(testCred.name)
+      await awsAccountsPage.confirmDelete()
+      await expect(page).toMatch('AWS account credentials deleted successfully')
+    })
+
   })
 
+  describe('Cluster Plans', () => {
+    const awsClusterPlansPage = new ConfigureCloudAWSClusterPlans(page)
+
+    const testPlan = {
+      name: `testplan-${Math.random().toString(36).substr(2, 5)}`,
+      description: 'Test plan for testing',
+      planDescription: 'A plan description',
+      region: 'eu-west-2',
+      version: '1.15'
+    }
+
+    beforeAll(async () => {
+      // In case of gruff from previous tests, wait a beat before starting.
+      await cloudPage.closeAllNotifications()
+      await waitForDrawerOpenClose(page)
+      await awsClusterPlansPage.openTab()
+      await awsClusterPlansPage.listLoaded()
+    })
+
+    beforeEach(async () => {
+      await awsClusterPlansPage.closeAllNotifications()
+    })
+
+    it('has the correct URL', () => {
+      awsClusterPlansPage.verifyPageURL()
+    })
+
+    it('views an existing plan', async () => {
+      await awsClusterPlansPage.view('eks-development')
+      // Check a random thing to ensure the plan is being displayed.
+      await expect(page).toMatch('Default Team Role')
+      await awsClusterPlansPage.closeDrawer()
+    })
+
+    it('does not allow editing of a read-only plan', async () => {
+      await awsClusterPlansPage.edit('eks-development')
+      await expect(page).toMatch('This plan is read-only')
+    })
+
+    it('does not allow deleting of a read-only plan', async () => {
+      await awsClusterPlansPage.delete('eks-development')
+      await expect(page).toMatch('This plan is read-only and cannot be deleted')
+    })
+
+    it('creates a new plan using default values', async () => {
+      await awsClusterPlansPage.new()
+      await expect(page).toMatch('New EKS plan')
+      await awsClusterPlansPage.populatePlan(testPlan)
+      await awsClusterPlansPage.addNodeGroup()
+      await awsClusterPlansPage.populateNodeGroup({ name: 'default' })
+      await awsClusterPlansPage.closeNodeGroup()
+      await awsClusterPlansPage.save()
+      await expect(page).toMatch('EKS plan created successfully')
+    })
+
+    it('edits an existing plan', async () => {
+      await awsClusterPlansPage.edit(testPlan.name)
+      await awsClusterPlansPage.populatePlan({ region: 'eu-west-1' })
+      await awsClusterPlansPage.addNodeGroup()
+      // No name, close should be disabled:
+      expect(await awsClusterPlansPage.closeNodeGroupDisabled()).toBeTruthy()
+      await awsClusterPlansPage.populateNodeGroup({ name: 'default' })
+      // Name clashes with existing name, close should be disabled:
+      expect(await awsClusterPlansPage.closeNodeGroupDisabled()).toBeTruthy()
+      await awsClusterPlansPage.populateNodeGroup({ name: 'default2' })
+      // Button should now be enabled:
+      expect(await awsClusterPlansPage.closeNodeGroupDisabled()).not.toBeTruthy()
+      await awsClusterPlansPage.closeNodeGroup()
+      await awsClusterPlansPage.save()
+      await expect(page).toMatch('EKS plan updated successfully')
+    })
+
+    it('edits an existing node group', async () => {
+      await awsClusterPlansPage.edit(testPlan.name)
+      await awsClusterPlansPage.viewEditNodeGroup(1)
+      await awsClusterPlansPage.populateNodeGroup({ minSize: 2, desiredSize: 5, maxSize: 7 })
+      await awsClusterPlansPage.closeNodeGroup()
+      await awsClusterPlansPage.save()
+      await expect(page).toMatch('EKS plan updated successfully')
+    })
+
+    it('allows deleting of a non-read-only plan', async () => {
+      await awsClusterPlansPage.delete(testPlan.name)
+      await awsClusterPlansPage.confirmDelete()
+      await expect(page).toMatch(`${testPlan.name} plan deleted`)
+    })
+  })
 })

--- a/ui/__tests__/e2e/README.md
+++ b/ui/__tests__/e2e/README.md
@@ -1,0 +1,13 @@
+Kore UI E2E Testing
+===================
+
+To run locally, run kore-in-kind (`make kind-dev` in the top level) and run the UI (`make run-prod` or `make run` in 
+the UI folder) then run the tests.
+
+To run tests with the browser visible and slow-mo on so you can inspect what is happening, run `make kind-e2e-debug`.
+
+To run the tests headless (as per CI), run `make kind-e2e`. **Always run `make kind-e2e` after adjusting tests** as
+often subtle timing issues occur when running headlessly (e.g. trying to click on things before animations finish).
+
+The test files are executed alphabetically, e.g. 01-first-time-setup will run before 02-configure-cloud-gcp. Therefore
+it is safe to depend on data created by earlier tests, but for sanity, it is best to ensure the tests are re-runnable.

--- a/ui/__tests__/e2e/config.js
+++ b/ui/__tests__/e2e/config.js
@@ -1,3 +1,8 @@
 module.exports = {
-  testUrl: process.env.KORE_UI_TEST_URL || 'http://localhost:3000'
+  testUrl: process.env.KORE_UI_TEST_URL || 'http://localhost:3000',
+  adminPass: process.env.KORE_ADMIN_PASS || 'password',
+  // Use longer timeout if we're showing the browser:
+  timeout: process.env.SHOW_BROWSER !== 'true' ? 15000 : 60000,
+  expectTimeout: 1000,
+  drawerOpenClosePause: 500
 }

--- a/ui/__tests__/e2e/page-objects/base.js
+++ b/ui/__tests__/e2e/page-objects/base.js
@@ -38,6 +38,7 @@ export class BasePage {
     await Promise.all(notifs.map(async (n) => {
       try {
         await n.click()
+        await waitForDrawerOpenClose(this.p)
       } catch (err) {
         // Sometimes these randomly go out of scope while we're clicking, ignore errors
         // in that case.
@@ -55,7 +56,6 @@ export class BasePage {
 
   async visitPage(query = '') {
     try {
-      console.log(`goto [${testUrl}${this.pagePath}${query}]`)
       await this.p.goto(`${testUrl}${this.pagePath}${query}`)
       await this.p.waitForSelector('body')
     } catch (error) {

--- a/ui/__tests__/e2e/page-objects/base.js
+++ b/ui/__tests__/e2e/page-objects/base.js
@@ -1,9 +1,13 @@
-const { testUrl } = require('../config')
+const { testUrl, timeout, expectTimeout } = require('../config')
+import { setDefaultOptions } from 'expect-puppeteer'
+import { waitForDrawerOpenClose } from './utils'
+
+setDefaultOptions({ timeout: expectTimeout })
+jest.setTimeout(timeout)
 
 export class BasePage {
-
-  constructor(page) {
-    this.page = page
+  constructor(p) {
+    this.p = p
   }
 
   getFileName() {
@@ -14,21 +18,46 @@ export class BasePage {
   }
 
   async screenshot(filename) {
-    await this.page.screenshot({
+    await this.p.screenshot({
       fullPage: true,
       path: `__tests__/e2e/screenshots/${filename}.png`
     })
   }
 
-  verifyPage() {
-    expect(this.page.url()).toBe(`${testUrl}${this.pagePath}`)
+  verifyPageURL() {
+    expect(this.p.url()).toBe(`${testUrl}${this.pagePath}`)
+  }
+
+  /**
+   * Close any open notifications/messages (e.g. success / error messages from saving resources).
+   * 
+   * Useful to call from beforeEach.
+   */
+  async closeAllNotifications() {
+    const notifs = await this.p.$$('a.ant-notification-notice-close')
+    await Promise.all(notifs.map(async (n) => {
+      try {
+        await n.click()
+      } catch (err) {
+        // Sometimes these randomly go out of scope while we're clicking, ignore errors
+        // in that case.
+      }
+    }))
+  }
+
+  /**
+   * Close any open drawer.
+   */
+  async closeDrawer() {
+    await this.p.click('button.ant-drawer-close')
+    await waitForDrawerOpenClose(this.p)
   }
 
   async visitPage(query = '') {
     try {
       console.log(`goto [${testUrl}${this.pagePath}${query}]`)
-      await this.page.goto(`${testUrl}${this.pagePath}${query}`)
-      await this.page.waitForSelector('body')
+      await this.p.goto(`${testUrl}${this.pagePath}${query}`)
+      await this.p.waitForSelector('body')
     } catch (error) {
       const filename = this.getFileName()
       console.log(`Exception caught in visitPage, taking screenshot ${filename}.png. Error is: ${error}`)
@@ -38,10 +67,10 @@ export class BasePage {
 
   async getHeading() {
     try {
-      return await this.page.$eval('h1', el => el.innerHTML)
+      return await this.p.$eval('h1', el => el.innerHTML)
     } catch (error) {
       const filename = `failed-getHeading-${this.getFileName()}`
-      console.log(`Exception caught in getHeading on ${this.page.url()}, taking screenshot ${filename}.png. Error is: ${error}`)
+      console.log(`Exception caught in getHeading on ${this.p.url()}, taking screenshot ${filename}.png. Error is: ${error}`)
       await this.screenshot(filename)
     }
   }
@@ -50,12 +79,11 @@ export class BasePage {
     options = options || { waitForNav: true }
     if (options.waitForNav) {
       await Promise.all([
-        this.page.waitForNavigation(),
-        this.page.click('.ant-btn-primary')
+        this.p.waitForNavigation(),
+        this.p.click('.ant-btn-primary')
       ])
     } else {
-      await this.page.click('.ant-btn-primary')
+      await this.p.click('.ant-btn-primary')
     }
   }
-
 }

--- a/ui/__tests__/e2e/page-objects/configure/cloud/AWS/accounts.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/AWS/accounts.js
@@ -1,0 +1,55 @@
+import { ConfigureCloudPage } from '../configure-cloud'
+import { waitForDrawerOpenClose, clearFillTextInput } from '../../../utils'
+
+export class ConfigureCloudAWSAccounts extends ConfigureCloudPage {
+  constructor(p) {
+    super(p)
+    this.pagePath = '/configure/cloud/AWS/accounts'
+  }
+
+  async openTab() {
+    await this.selectCloud('aws')
+    await this.selectSubTab('Account credentials', 'AWS/accounts')
+  }
+
+  async checkAccountListed(name) {
+    await expect(this.p).toMatchElement(`#ekscreds_${name}`)
+  }
+
+  async add() {
+    await this.p.click('button#add')
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async edit(name, accountID) {
+    await this.p.click(`a#ekscreds_edit_${name}`)
+    await waitForDrawerOpenClose(this.p)
+    await expect(this.p).toMatch(`AWS account: ${accountID}`)
+  }
+
+  async populate({ accountID, accessKeyID, secretAccessKey, name, summary }) {
+    await clearFillTextInput(this.p, 'eks_credentials_accountID', accountID)
+    await clearFillTextInput(this.p, 'eks_credentials_accessKeyID', accessKeyID)
+    await clearFillTextInput(this.p, 'eks_credentials_secretAccessKey', secretAccessKey)
+    await clearFillTextInput(this.p, 'eks_credentials_name', name)
+    await clearFillTextInput(this.p, 'eks_credentials_summary', summary)
+  }
+
+  async replaceKey(accessKeyID, secretAccessKey) {
+    await this.p.type('input#eks_credentials_replace_key',' ')
+    // Wait for service account text field to be shown:
+    await expect(this.p).toMatch('Access key ID')
+    await clearFillTextInput(this.p, 'eks_credentials_accessKeyID', accessKeyID)
+    await clearFillTextInput(this.p, 'eks_credentials_secretAccessKey', secretAccessKey)
+  }
+
+  async saveButtonDisabled() {
+    return (await this.p.$('button#save[disabled]')) !== null
+  }
+
+  async save() {
+    await this.p.click('button#save')
+    await waitForDrawerOpenClose(this.p)
+  }
+
+}

--- a/ui/__tests__/e2e/page-objects/configure/cloud/AWS/accounts.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/AWS/accounts.js
@@ -1,5 +1,5 @@
 import { ConfigureCloudPage } from '../configure-cloud'
-import { waitForDrawerOpenClose, clearFillTextInput } from '../../../utils'
+import { waitForDrawerOpenClose, clearFillTextInput, modalYes } from '../../../utils'
 
 export class ConfigureCloudAWSAccounts extends ConfigureCloudPage {
   constructor(p) {
@@ -52,4 +52,11 @@ export class ConfigureCloudAWSAccounts extends ConfigureCloudPage {
     await waitForDrawerOpenClose(this.p)
   }
 
+  async delete(name) {
+    await this.p.click(`a#ekscreds_del_${name}`)
+  }
+
+  async confirmDelete() {
+    await modalYes(this.p, 'Are you sure you want to delete the credentials')
+  }
 }

--- a/ui/__tests__/e2e/page-objects/configure/cloud/AWS/cluster-plans.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/AWS/cluster-plans.js
@@ -1,15 +1,15 @@
 import { ConfigureCloudPage } from '../configure-cloud'
-import { clearFillTextInput, modalYes, waitForDrawerOpenClose, setSwitch } from '../../../utils'
+import { clearFillTextInput, modalYes, waitForDrawerOpenClose } from '../../../utils'
 
-export class ConfigureCloudGCPClusterPlans extends ConfigureCloudPage {
+export class ConfigureCloudAWSClusterPlans extends ConfigureCloudPage {
   constructor(p) {
     super(p)
-    this.pagePath = '/configure/cloud/GCP/plans'
+    this.pagePath = '/configure/cloud/AWS/plans'
   }
 
   async openTab() {
-    await this.selectCloud('gcp')
-    await this.selectSubTab('Cluster Plans', 'GCP/plans')
+    await this.selectCloud('aws')
+    await this.selectSubTab('Cluster Plans', 'AWS/plans')
   }
 
   async listLoaded() {
@@ -39,37 +39,37 @@ export class ConfigureCloudGCPClusterPlans extends ConfigureCloudPage {
     await waitForDrawerOpenClose(this.p)
   }
 
-  async populatePlan({ description, name, planDescription, region }) {
+  async populatePlan({ description, name, planDescription, region, version }) {
     await clearFillTextInput(this.p, 'plan_summary', description)
     await clearFillTextInput(this.p, 'plan_description', name)
     await clearFillTextInput(this.p, 'plan_input_description', planDescription)
     await clearFillTextInput(this.p, 'plan_input_region', region)
+    await clearFillTextInput(this.p, 'plan_input_version', version)
   }
 
-  async addNodePool() {
-    await this.p.click('button#plan_nodepool_add')
+  async addNodeGroup() {
+    await this.p.click('button#plan_nodegroup_add')
     await waitForDrawerOpenClose(this.p)
   }
 
-  async viewEditNodePool(idx) {
-    await this.p.click(`a#plan_nodepool_${idx}_viewedit`)
+  async viewEditNodeGroup(idx) {
+    await this.p.click(`a#plan_nodegroup_${idx}_viewedit`)
     await waitForDrawerOpenClose(this.p)
   }
 
-  async populateNodePool({ name, enableAutoscaler, minSize, size, maxSize }) {
-    await clearFillTextInput(this.p, 'plan_nodepool_name', name)
-    await setSwitch(this.p, 'plan_nodepool_enableAutoscaler', enableAutoscaler)
-    await clearFillTextInput(this.p, 'plan_nodepool_minSize', minSize)
-    await clearFillTextInput(this.p, 'plan_nodepool_size', size)
-    await clearFillTextInput(this.p, 'plan_nodepool_maxSize', maxSize)
+  async populateNodeGroup({ name, minSize, desiredSize, maxSize }) {
+    await clearFillTextInput(this.p, 'plan_nodegroup_name', name)
+    await clearFillTextInput(this.p, 'plan_nodegroup_minSize', minSize)
+    await clearFillTextInput(this.p, 'plan_nodegroup_desiredSize', desiredSize)
+    await clearFillTextInput(this.p, 'plan_nodegroup_maxSize', maxSize)
   }
 
-  async closeNodePoolDisabled() {
-    return (await this.p.$('button#plan_nodepool_close[disabled]')) !== null
+  async closeNodeGroupDisabled() {
+    return (await this.p.$('button#plan_nodegroup_close[disabled]')) !== null
   }
 
-  async closeNodePool() {
-    await this.p.click('button#plan_nodepool_close')
+  async closeNodeGroup() {
+    await this.p.click('button#plan_nodegroup_close')
     await waitForDrawerOpenClose(this.p)
   }
 

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-plans.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-plans.js
@@ -9,7 +9,7 @@ export class ConfigureCloudGCPClusterPlans extends ConfigureCloudPage {
 
   async openTab() {
     await this.selectCloud('gcp')
-    await this.selectSubTab('Cluster Plans')
+    await this.selectSubTab('Cluster Plans', 'GCP/plans')
   }
 
   async view(name) {

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-plans.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-plans.js
@@ -1,0 +1,77 @@
+import { ConfigureCloudPage } from '../configure-cloud'
+import { clearFillTextInput, modalYes, waitForDrawerOpenClose, setSwitch } from '../../../utils'
+
+export class ConfigureCloudGCPClusterPlans extends ConfigureCloudPage {
+  constructor(p) {
+    super(p)
+    this.pagePath = '/configure/cloud/GCP/plans'
+  }
+
+  async openTab() {
+    await this.selectCloud('gcp')
+    await this.selectSubTab('Cluster Plans')
+  }
+
+  async view(name) {
+    await this.p.click(`a#gkeplans_view_${name}`)
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async edit(name) {
+    await this.p.click(`a#gkeplans_edit_${name}`)
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async delete(name) {
+    await this.p.click(`a#gkeplans_delete_${name}`)
+  }
+
+  async confirmDelete() {
+    await modalYes(this.p, 'Are you sure you want to delete the plan')
+  }
+
+  async new() {
+    await expect(this.p).toClick('button', { text: '+ New' })
+    await waitForDrawerOpenClose(this.p)
+    await expect(this.p).toMatch('New GKE plan')
+  }
+
+  async populatePlan({ description, name, planDescription, region }) {
+    await clearFillTextInput(this.p, 'plan_summary', description)
+    await clearFillTextInput(this.p, 'plan_description', name)
+    await clearFillTextInput(this.p, 'plan_input_description', planDescription)
+    await clearFillTextInput(this.p, 'plan_input_region', region)
+  }
+
+  async addNodePool() {
+    await this.p.click('button#plan_nodepool_add')
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async viewEditNodePool(idx) {
+    await this.p.click(`a#plan_nodepool_${idx}_viewedit`)
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async populateNodePool({ name, enableAutoscaler, minSize, size, maxSize }) {
+    await clearFillTextInput(this.p, 'plan_nodepool_name', name)
+    await setSwitch(this.p, 'plan_nodepool_enableAutoscaler', enableAutoscaler)
+    await clearFillTextInput(this.p, 'plan_nodepool_minSize', minSize)
+    await clearFillTextInput(this.p, 'plan_nodepool_size', size)
+    await clearFillTextInput(this.p, 'plan_nodepool_maxSize', maxSize)
+  }
+
+  async closeNodePoolDisabled() {
+    return (await this.p.$('button#plan_nodepool_close[disabled]')) !== null
+  }
+
+  async closeNodePool() {
+    await this.p.click('button#plan_nodepool_close')
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async save() {
+    await this.p.click('button#plan_save')
+    await waitForDrawerOpenClose(this.p)
+  }
+}

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/projects.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/projects.js
@@ -9,7 +9,7 @@ export class ConfigureCloudGCPProjects extends ConfigureCloudPage {
 
   async openTab() {
     await this.selectCloud('gcp')
-    await this.selectSubTab('Project credentials')
+    await this.selectSubTab('Project credentials', 'GCP/projects')
   }
 
   /**
@@ -31,24 +31,20 @@ export class ConfigureCloudGCPProjects extends ConfigureCloudPage {
     await expect(this.p).toMatch(`GCP project: ${project}`)
   }
 
-  async populateNew({ name, summary, project, json }) {
-    await this.p.type('input#gke_credentials_name', name)
-    await this.p.type('input#gke_credentials_summary', summary)
-    await this.p.type('input#gke_credentials_project', project)
-    await this.p.type('textarea#gke_credentials_account', json)
-  }
-
-  async populateEdit({ name, summary, project, json }) {
-    clearFillTextInput(this.p, 'gke_credentials_project', project)
-    clearFillTextInput(this.p, 'gke_credentials_name', name)
-    clearFillTextInput(this.p, 'gke_credentials_summary', summary)
-
-    if (json) {
-      await this.p.type('input#gke_credentials_replace_key',' ')
-      // Wait for service account text field to be shown:
-      await expect(this.p).toMatch('Service Account JSON')
+  async populate({ name, summary, project, json }) {
+    await clearFillTextInput(this.p, 'gke_credentials_name', name)
+    await clearFillTextInput(this.p, 'gke_credentials_summary', summary)
+    await clearFillTextInput(this.p, 'gke_credentials_project', project)
+    if (json !== undefined) {
       await this.p.type('textarea#gke_credentials_account', json)
     }
+  }
+
+  async replaceKey(json) {
+    await this.p.type('input#gke_credentials_replace_key',' ')
+    // Wait for service account text field to be shown:
+    await expect(this.p).toMatch('Service Account JSON')
+    await this.p.type('textarea#gke_credentials_account', json)
   }
 
   async save() {

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/projects.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/projects.js
@@ -1,0 +1,66 @@
+import { ConfigureCloudPage } from '../configure-cloud'
+import { clearFillTextInput, modalYes, waitForDrawerOpenClose } from '../../../utils'
+
+export class ConfigureCloudGCPProjects extends ConfigureCloudPage {
+  constructor(p) {
+    super(p)
+    this.pagePath = '/configure/cloud/GCP/projects'
+  }
+
+  async openTab() {
+    await this.selectCloud('gcp')
+    await this.selectSubTab('Project credentials')
+  }
+
+  /**
+   * Checks credential for project listed in list of credentials
+   */
+  async checkCredentialListed(name) {
+    await expect(this.p).toMatchElement(`#gkecreds_${name}`)
+  }
+
+  async add() {
+    await expect(this.p).toClick('button', { text: '+ New' })
+    await waitForDrawerOpenClose(this.p)
+    await expect(this.p).toMatch('New GCP project')
+  }
+
+  async edit(name, project) {
+    await this.p.click(`a#gkecreds_edit_${name}`)
+    await waitForDrawerOpenClose(this.p)
+    await expect(this.p).toMatch(`GCP project: ${project}`)
+  }
+
+  async populateNew({ name, summary, project, json }) {
+    await this.p.type('input#gke_credentials_name', name)
+    await this.p.type('input#gke_credentials_summary', summary)
+    await this.p.type('input#gke_credentials_project', project)
+    await this.p.type('textarea#gke_credentials_account', json)
+  }
+
+  async populateEdit({ name, summary, project, json }) {
+    clearFillTextInput(this.p, 'gke_credentials_project', project)
+    clearFillTextInput(this.p, 'gke_credentials_name', name)
+    clearFillTextInput(this.p, 'gke_credentials_summary', summary)
+
+    if (json) {
+      await this.p.type('input#gke_credentials_replace_key',' ')
+      // Wait for service account text field to be shown:
+      await expect(this.p).toMatch('Service Account JSON')
+      await this.p.type('textarea#gke_credentials_account', json)
+    }
+  }
+
+  async save() {
+    await this.p.click('button#save')
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async delete(name) {
+    await this.p.click(`a#gkecreds_del_${name}`)
+  }
+
+  async confirmDelete() {
+    await modalYes(this.p, 'Are you sure you want to delete the credentials')
+  }
+}

--- a/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
@@ -7,13 +7,26 @@ export class ConfigureCloudPage extends BasePage {
   }
 
   async selectCloud(name) {
-    await this.p.click(`#tab-${name}`)
+    // Check if we're already on the right page (or the default page is what we want)
+    const currUrl = await this.p.url()
+    if (currUrl.toLowerCase().indexOf(`/configure/cloud/${name.toLowerCase()}/`) > -1 || (name.toLowerCase() === 'gcp' && currUrl.endsWith('/configure/cloud'))) {
+      return
+    }
+    await Promise.all([
+      this.p.waitForNavigation(),
+      this.p.click(`#tab-${name}`)
+    ])
   }
 
-  async selectSubTab(name) {
+  async selectSubTab(name, urlName) {
     const subTab = await this.p.$x(`//div[@id='cloud_subtabs']//div[@role='tab' and text()='${name}']`)
     if (subTab.length === 0) {
       throw new Error(`No sub-tab exists with name ${name}`)
+    }
+    // Check if we're already on the right page/tab (or the default page/tab is what we want)
+    const currUrl = await this.p.url()
+    if (currUrl.endsWith(`/configure/cloud/${urlName}`) || (urlName === 'GCP/orgs' && currUrl.endsWith('/configure/cloud/'))) {
+      return
     }
     await Promise.all([
       this.p.waitForNavigation(),

--- a/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
@@ -1,0 +1,23 @@
+const { BasePage } = require('../../base')
+
+export class ConfigureCloudPage extends BasePage {
+  constructor(p) {
+    super(p)
+    this.pagePath = '/configure/cloud'
+  }
+
+  async selectCloud(name) {
+    await this.p.click(`#tab-${name}`)
+  }
+
+  async selectSubTab(name) {
+    const subTab = await this.p.$x(`//div[@id='cloud_subtabs']//div[@role='tab' and text()='${name}']`)
+    if (subTab.length === 0) {
+      throw new Error(`No sub-tab exists with name ${name}`)
+    }
+    await Promise.all([
+      this.p.waitForNavigation(),
+      subTab[0].click()
+    ])
+  }
+}

--- a/ui/__tests__/e2e/page-objects/index.js
+++ b/ui/__tests__/e2e/page-objects/index.js
@@ -1,8 +1,8 @@
 const { BasePage } = require('./base')
 
 export class IndexPage extends BasePage {
-  constructor(page) {
-    super(page)
+  constructor(p) {
+    super(p)
     this.pagePath = '/'
   }
 }

--- a/ui/__tests__/e2e/page-objects/login.js
+++ b/ui/__tests__/e2e/page-objects/login.js
@@ -1,20 +1,20 @@
 const { BasePage } = require('./base')
+const config = require('../config')
 
 export class LoginPage extends BasePage {
-
-  constructor(page) {
-    super(page)
+  constructor(p) {
+    super(p)
     this.pagePath = '/login'
   }
 
   async localUserLogin() {
-    await this.page.click('#local-user-login')
-    await this.page.waitFor('#login-form')
-    await this.page.type('#login_login', 'admin')
-    await this.page.type('#login_password', 'password')
+    await this.p.click('#local-user-login')
+    await this.p.waitFor('#login-form')
+    await this.p.type('#login_login', 'admin')
+    await this.p.type('#login_password', config.adminPass)
     const [response] = await Promise.all([
-      this.page.waitForNavigation(),
-      this.page.click('#submit'),
+      this.p.waitForNavigation(),
+      this.p.click('#submit'),
     ])
     expect(response.ok()).toBeTruthy()
   }

--- a/ui/__tests__/e2e/page-objects/setup-kore-cloud-access.js
+++ b/ui/__tests__/e2e/page-objects/setup-kore-cloud-access.js
@@ -1,65 +1,65 @@
 const { BasePage } = require('./base')
 
 export class SetupKoreCloudAccessPage extends BasePage {
-  constructor(page) {
-    super(page)
+  constructor(p) {
+    super(p)
     this.pagePath = '/setup/kore/cloud-access'
   }
 
   async selectCloud(name) {
-    await this.page.click(`#${name}`)
+    await this.p.click(`#${name}`)
   }
 
   async selectKoreManagedGcpProjects() {
-    await this.page.click('.use-kore-managed-projects')
+    await this.p.click('.use-kore-managed-projects')
   }
 
   async selectKoreManagedProjects(type) {
     // cluster or custom
-    await this.page.click(`.automated-projects-${type}`)
+    await this.p.click(`.automated-projects-${type}`)
   }
 
   async addGcpOrganization() {
-    await this.page.waitFor('.new-gcp-organization')
-    await this.page.click('.new-gcp-organization')
-    await this.page.waitFor('#gcp_organization_parentID')
-    await this.page.type('#gcp_organization_parentID', 'test-org')
-    await this.page.type('#gcp_organization_billingAccount', 'BILL-1234')
-    await this.page.type('#gcp_organization_account', 'invalid service account JSON')
-    await this.page.type('#gcp_organization_name', 'Test org')
-    await this.page.type('#gcp_organization_summary', 'Org used by automated test')
+    await this.p.waitFor('.new-gcp-organization')
+    await this.p.click('.new-gcp-organization')
+    await this.p.waitFor('#gcp_organization_parentID')
+    await this.p.type('#gcp_organization_parentID', 'test-org')
+    await this.p.type('#gcp_organization_billingAccount', 'BILL-1234')
+    await this.p.type('#gcp_organization_account', 'invalid service account JSON')
+    await this.p.type('#gcp_organization_name', 'Test org')
+    await this.p.type('#gcp_organization_summary', 'Org used by automated test')
     await Promise.all([
-      this.page.waitFor('#gcp_organization_parentID', { hidden: true }),
-      this.page.click('#save')
+      this.p.waitFor('#gcp_organization_parentID', { hidden: true }),
+      this.p.click('#save')
     ])
   }
 
   async nextStep() {
-    await this.page.click('.steps-action .ant-btn-primary')
+    await this.p.click('.steps-action .ant-btn-primary')
   }
 
   async save() {
-    await this.page.click('.steps-action .ant-btn-primary')
-    await this.page.waitFor('.kore-managed-setup-complete')
+    await this.p.click('.steps-action .ant-btn-primary')
+    await this.p.waitFor('.kore-managed-setup-complete')
   }
 
   async setAutomatedProjectDefaults() {
-    await this.page.waitFor('.set-kore-defaults')
-    await this.page.click('.set-kore-defaults')
+    await this.p.waitFor('.set-kore-defaults')
+    await this.p.click('.set-kore-defaults')
   }
 
   async enterGkeCredentials() {
-    await this.page.type('#gke_credentials_project', 'test-project')
-    await this.page.type('#gke_credentials_account', 'invalid service account JSON')
-    await this.page.type('#gke_credentials_name', 'Test project')
-    await this.page.type('#gke_credentials_summary', 'Project used by automated test')
+    await this.p.type('#gke_credentials_project', 'test-project')
+    await this.p.type('#gke_credentials_account', 'invalid service account JSON')
+    await this.p.type('#gke_credentials_name', 'Test project')
+    await this.p.type('#gke_credentials_summary', 'Project used by automated test')
   }
 
   async continueWithoutVerification() {
-    await this.page.waitFor('#continue-without-verification')
+    await this.p.waitFor('#continue-without-verification')
     await Promise.all([
-      this.page.waitForNavigation(),
-      await this.page.click('#continue-without-verification')
+      this.p.waitForNavigation(),
+      await this.p.click('#continue-without-verification')
     ])
   }
 }

--- a/ui/__tests__/e2e/page-objects/setup-kore-complete.js
+++ b/ui/__tests__/e2e/page-objects/setup-kore-complete.js
@@ -1,8 +1,8 @@
 const { BasePage } = require('./base')
 
 export class SetupKoreCompletePage extends BasePage {
-  constructor(page) {
-    super(page)
+  constructor(p) {
+    super(p)
     this.pagePath = '/setup/kore/complete'
   }
 }

--- a/ui/__tests__/e2e/page-objects/setup-kore.js
+++ b/ui/__tests__/e2e/page-objects/setup-kore.js
@@ -1,8 +1,8 @@
 const { BasePage } = require('./base')
 
 export class SetupKorePage extends BasePage {
-  constructor(page) {
-    super(page)
+  constructor(p) {
+    super(p)
     this.pagePath = '/setup/kore'
   }
 }

--- a/ui/__tests__/e2e/page-objects/utils.js
+++ b/ui/__tests__/e2e/page-objects/utils.js
@@ -1,0 +1,42 @@
+import { drawerOpenClosePause } from '../config'
+
+export async function clearFillTextInput(pg, id, value) {
+  if (value === undefined) {
+    return
+  }
+  const input = await pg.$(`input#${id}`)
+  await input.click({ clickCount: 3 })
+  await input.type(value.toString())
+}
+
+export async function setSwitch(pg, id, setOn) {
+  if (setOn === undefined) {
+    return
+  }
+  const switchButtonsCheck = await pg.$$(`button#${id}[aria-checked='${setOn ? 'false' : 'true'}']`)
+  if (switchButtonsCheck.length === 0) {
+    // Already set as desired.
+    return
+  }
+  await switchButtonsCheck[0].click()
+}
+
+export async function modalYes(pg, textToCheck) {
+  if (textToCheck) {
+    await expect(pg).toMatch(textToCheck)
+  }
+  await pg.waitForSelector('button.ant-btn-danger', { visible: true })
+  await pg.click('button.ant-btn-danger')
+  // The modal takes a beat to disappear, need to wait for the animation
+  // else we can be in trouble.
+  await waitForDrawerOpenClose(pg)
+}
+
+/**
+ * The drawer open/close animation can take a short while before elements are clickable. 
+ * Call this to wait for the drawer to complete opening/closing.
+ * @param {Page} pg 
+ */
+export async function waitForDrawerOpenClose(pg) {
+  await pg.waitFor(drawerOpenClosePause)
+}

--- a/ui/__tests__/e2e/sequencer.js
+++ b/ui/__tests__/e2e/sequencer.js
@@ -1,0 +1,10 @@
+const Sequencer = require('@jest/test-sequencer').default
+
+class AlphaNumericSequencer extends Sequencer {
+  sort(tests) {
+    const copyTests = Array.from(tests)
+    return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1))
+  }
+}
+
+module.exports = AlphaNumericSequencer

--- a/ui/__tests__/unit/lib/components/plans/ManageClusterPlanForm.test.js
+++ b/ui/__tests__/unit/lib/components/plans/ManageClusterPlanForm.test.js
@@ -50,32 +50,6 @@ describe('ManageClusterPlanForm', () => {
     })
   })
 
-  describe('#generatePlanConfiguration', () => {
-    test('sets default false for boolean properties', () => {
-      const config = form.generatePlanConfiguration()
-      expect(config).toEqual({ bool1: false, bool2: false })
-    })
-
-    test('includes user configured values', () => {
-      form.state.planValues = {
-        string1: 'hello',
-        number1: 123
-      }
-      const config = form.generatePlanConfiguration()
-      expect(config).toEqual({ bool1: false, bool2: false, string1: 'hello', number1: 123 })
-    })
-
-    test('user configured values override default boolean values', () => {
-      form.state.planValues = {
-        bool1: true,
-        string1: 'hello',
-        number1: 123
-      }
-      const config = form.generatePlanConfiguration()
-      expect(config).toEqual({ bool1: true, bool2: false, string1: 'hello', number1: 123 })
-    })
-  })
-
   describe('#handleSubmit', () => {
     let event
     beforeEach(() => {

--- a/ui/jest-puppeteer.config.js
+++ b/ui/jest-puppeteer.config.js
@@ -2,10 +2,10 @@ module.exports = {
   launch: {
     headless: process.env.SHOW_BROWSER !== 'true',
     slowMo: process.env.SHOW_BROWSER !== 'true' ? undefined : 15,
-    args: ['--no-sandbox', '--start-maximized', '--window-size=1900,1000'],
+    args: ['--no-sandbox', '--start-maximized', '--window-size=1550,950'],
     defaultViewport: {
-      width: 1800,
-      height: 900
+      width: 1525,
+      height: 800
     }
   }
 }

--- a/ui/jest-puppeteer.config.js
+++ b/ui/jest-puppeteer.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  launch: {
+    headless: process.env.SHOW_BROWSER !== 'true',
+    slowMo: process.env.SHOW_BROWSER !== 'true' ? undefined : 15,
+    args: ['--no-sandbox', '--start-maximized', '--window-size=1900,1000'],
+    defaultViewport: {
+      width: 1800,
+      height: 900
+    }
+  }
+}

--- a/ui/lib/components/common/CloudTabs.js
+++ b/ui/lib/components/common/CloudTabs.js
@@ -14,19 +14,19 @@ class CloudTabs extends React.Component {
     return (
       <Tabs activeKey={selectedKey} onChange={handleSelectCloud}>
         <Tabs.TabPane tab={
-          <span>
+          <span id="tab-gcp">
             <img src="/static/images/GCP.png" height="40px" style={{ marginRight: '10px' }}/>
             Google Cloud Platform
           </span>
         } key="GCP" />
         <Tabs.TabPane tab={
-          <span>
+          <span id="tab-aws">
             <img src="/static/images/AWS.png" height="40px" style={{ marginRight: '15px' }} />
             Amazon Web Services
           </span>
         } key="AWS" />
         <Tabs.TabPane tab={
-          <span>
+          <span id="tab-azure">
             <img src="/static/images/Azure.svg" height="25px" style={{ marginRight: '15px' }} />
             Microsoft Azure (coming soon)
           </span>

--- a/ui/lib/components/credentials/EKSCredentials.js
+++ b/ui/lib/components/credentials/EKSCredentials.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Avatar, Icon, Typography, message, Tooltip } from 'antd'
+import { List, Avatar, Icon, Typography, Tooltip } from 'antd'
 const { Text } = Typography
 
 import ResourceVerificationStatus from '../resources/ResourceVerificationStatus'
 import AutoRefreshComponent from '../teams/AutoRefreshComponent'
+import { successMessage, errorMessage } from '../../utils/message'
 
 class EKSCredentials extends AutoRefreshComponent {
   static propTypes = {
@@ -25,10 +26,10 @@ class EKSCredentials extends AutoRefreshComponent {
     const { eksCredentials } = this.props
     const { status } = eksCredentials
     if (status.status === 'Success') {
-      return message.success(`AWS credentials for account "${eksCredentials.spec.accountID}" verified successfully`)
+      return successMessage(`AWS credentials for account "${eksCredentials.spec.accountID}" verified successfully`)
     }
     if (status.status === 'Failure') {
-      return message.error(`AWS credentials for account "${eksCredentials.spec.accountID}" could not be verified`)
+      return errorMessage(`AWS credentials for account "${eksCredentials.spec.accountID}" could not be verified`)
     }
   }
 

--- a/ui/lib/components/credentials/EKSCredentials.js
+++ b/ui/lib/components/credentials/EKSCredentials.js
@@ -11,7 +11,8 @@ class EKSCredentials extends AutoRefreshComponent {
   static propTypes = {
     eksCredentials: PropTypes.object.isRequired,
     allTeams: PropTypes.array.isRequired,
-    editEKSCredentials: PropTypes.func.isRequired
+    editEKSCredentials: PropTypes.func.isRequired,
+    deleteEKSCredentials: PropTypes.func.isRequired
   }
 
   componentDidUpdate(prevProps) {
@@ -34,7 +35,7 @@ class EKSCredentials extends AutoRefreshComponent {
   }
 
   render() {
-    const { eksCredentials, editEKSCredentials, allTeams } = this.props
+    const { eksCredentials, editEKSCredentials, deleteEKSCredentials, allTeams } = this.props
     const created = moment(eksCredentials.metadata.creationTimestamp).fromNow()
 
     const displayAllocations = () => {
@@ -48,6 +49,7 @@ class EKSCredentials extends AutoRefreshComponent {
     return (
       <List.Item id={`ekscreds_${eksCredentials.metadata.name}`} key={eksCredentials.metadata.name} actions={[
         <ResourceVerificationStatus key="verification_status" resourceStatus={eksCredentials.status} />,
+        <Text key="delete_creds"><a id={`ekscreds_del_${eksCredentials.metadata.name}`} onClick={deleteEKSCredentials(eksCredentials)}><Icon type="delete" theme="filled"/> Delete</a></Text>,
         <Text key="show_creds"><a id={`ekscreds_edit_${eksCredentials.metadata.name}`} onClick={editEKSCredentials(eksCredentials)}><Icon type="edit" theme="filled"/> Edit</a></Text>
       ]}>
         <List.Item.Meta
@@ -55,8 +57,8 @@ class EKSCredentials extends AutoRefreshComponent {
           title={
             <>
               <Text style={{ display: 'inline', marginRight: '15px', fontSize: '20px', fontWeight: '600' }}>{eksCredentials.spec.accountID}</Text>
-              <Text style={{ marginRight: '5px' }}>{eksCredentials.allocation.spec.name}</Text>
-              <Tooltip title={eksCredentials.allocation.spec.summary}>
+              <Text style={{ marginRight: '5px' }}>{eksCredentials.allocation ? eksCredentials.allocation.spec.name : null}</Text>
+              <Tooltip title={eksCredentials.allocation ? eksCredentials.allocation.spec.summary : null}>
                 <Icon type="info-circle" theme="twoTone" />
               </Tooltip>
             </>

--- a/ui/lib/components/credentials/EKSCredentials.js
+++ b/ui/lib/components/credentials/EKSCredentials.js
@@ -46,9 +46,9 @@ class EKSCredentials extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item key={eksCredentials.metadata.name} actions={[
+      <List.Item id={`ekscreds_${eksCredentials.metadata.name}`} key={eksCredentials.metadata.name} actions={[
         <ResourceVerificationStatus key="verification_status" resourceStatus={eksCredentials.status} />,
-        <Text key="show_creds"><a onClick={editEKSCredentials(eksCredentials)}><Icon type="edit" theme="filled"/> Edit</a></Text>
+        <Text key="show_creds"><a id={`ekscreds_edit_${eksCredentials.metadata.name}`} onClick={editEKSCredentials(eksCredentials)}><Icon type="edit" theme="filled"/> Edit</a></Text>
       ]}>
         <List.Item.Meta
           avatar={<Avatar icon="amazon" />}

--- a/ui/lib/components/credentials/EKSCredentialsForm.js
+++ b/ui/lib/components/credentials/EKSCredentialsForm.js
@@ -124,7 +124,7 @@ class EKSCredentialsForm extends VerifiedAllocatedResourceForm {
               style={{ marginTop: '10px' }}
             />
             <Form.Item label="Replace access key">
-              <Checkbox onChange={(e) => this.setState({ replaceKey: e.target.checked })}></Checkbox>
+              <Checkbox id="eks_credentials_replace_key" onChange={(e) => this.setState({ replaceKey: e.target.checked })}></Checkbox>
             </Form.Item>
           </>
         ) : null}

--- a/ui/lib/components/credentials/EKSCredentialsList.js
+++ b/ui/lib/components/credentials/EKSCredentialsList.js
@@ -18,6 +18,7 @@ class EKSCredentialsList extends ResourceList {
 
   createdMessage = 'AWS account credentials created successfully'
   updatedMessage = 'AWS account credentials updated successfully'
+  deletedMessage = 'AWS account credentials deleted successfully'
 
   async fetchComponentData() {
     const api = await KoreApi.client()
@@ -45,7 +46,7 @@ class EKSCredentialsList extends ResourceList {
           showIcon
           style={{ marginBottom: '20px' }}
         />
-        <Button type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
+        <Button id="add" type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
         {!resources ? <Icon type="loading" /> : (
           <>
             <List

--- a/ui/lib/components/credentials/EKSCredentialsList.js
+++ b/ui/lib/components/credentials/EKSCredentialsList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { Typography, List, Button, Drawer, Alert, Icon } from 'antd'
+import { Typography, List, Button, Drawer, Alert, Icon, Modal } from 'antd'
 const { Title } = Typography
 import getConfig from 'next/config'
 const { publicRuntimeConfig } = getConfig()
@@ -9,6 +9,7 @@ import EKSCredentialsForm from './EKSCredentialsForm'
 import EKSCredentials from './EKSCredentials'
 import KoreApi from '../../kore-api'
 import AllocationHelpers from '../../utils/allocation-helpers'
+import { loadingMessage, successMessage, errorMessage } from '../../utils/message'
 
 class EKSCredentialsList extends ResourceList {
 
@@ -19,6 +20,7 @@ class EKSCredentialsList extends ResourceList {
   createdMessage = 'AWS account credentials created successfully'
   updatedMessage = 'AWS account credentials updated successfully'
   deletedMessage = 'AWS account credentials deleted successfully'
+  deleteFailedMessage = 'Error deleting AWS account credentials'
 
   async fetchComponentData() {
     const api = await KoreApi.client()
@@ -32,6 +34,29 @@ class EKSCredentialsList extends ResourceList {
       eks.allocation = AllocationHelpers.findAllocationForResource(allAllocations, eks)
     })
     return { resources: eksCredentials, allTeams }
+  }
+
+  delete = (cred) => () => {
+    Modal.confirm({
+      title: `Are you sure you want to delete the credentials ${cred.spec.accountID}?`,
+      content: 'This cannot be undone',
+      okText: 'Yes',
+      okType: 'danger',
+      cancelText: 'No',
+      onOk: async () => {
+        const key = loadingMessage('Deleting allocations for credential', { duration: 0 })
+        try {
+          await AllocationHelpers.removeAllocation(cred)
+          loadingMessage('Deleting credential', { key, duration: 0 })
+          await (await KoreApi.client()).DeleteEKSCredentials(publicRuntimeConfig.koreAdminTeamName, cred.metadata.name)
+          successMessage(this.deletedMessage, { key })
+        } catch (err) {
+          console.error(err)
+          errorMessage(this.deleteFailedMessage, { key })
+        }
+        await this.refresh()
+      }
+    })
   }
 
   render() {
@@ -56,7 +81,9 @@ class EKSCredentialsList extends ResourceList {
                   eksCredentials={eks}
                   allTeams={allTeams.items}
                   editEKSCredentials={this.edit}
+                  deleteEKSCredentials={this.delete}
                   handleUpdate={this.handleStatusUpdated}
+                  handleDelete={() => {}}
                   refreshMs={2000}
                   propsResourceDataKey="eksCredentials"
                   resourceApiPath={`/teams/${publicRuntimeConfig.koreAdminTeamName}/ekscredentials/${eks.metadata.name}`}

--- a/ui/lib/components/credentials/GCPOrganization.js
+++ b/ui/lib/components/credentials/GCPOrganization.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Avatar, Icon, Typography, message, Tooltip } from 'antd'
+import { List, Avatar, Icon, Typography, Tooltip } from 'antd'
 const { Text } = Typography
 
 import ResourceVerificationStatus from '../resources/ResourceVerificationStatus'
 import AutoRefreshComponent from '../teams/AutoRefreshComponent'
+import { successMessage, errorMessage } from '../../utils/message'
 
 class GCPOrganization extends AutoRefreshComponent {
   static propTypes = {
@@ -25,10 +26,10 @@ class GCPOrganization extends AutoRefreshComponent {
     const { organization } = this.props
     const { allocation, status } = organization
     if (status.status === 'Success') {
-      return message.success(`GCP organization "${allocation.spec.name}" created successfully`)
+      return successMessage(`GCP organization "${allocation.spec.name}" created successfully`)
     }
     if (status.status === 'Failure') {
-      return message.error(`GCP organization "${allocation.spec.name}" failed to be created`)
+      return errorMessage(`GCP organization "${allocation.spec.name}" failed to be created`)
     }
   }
 

--- a/ui/lib/components/credentials/GKECredentials.js
+++ b/ui/lib/components/credentials/GKECredentials.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Avatar, Icon, Typography, message, Tooltip } from 'antd'
+import { List, Avatar, Icon, Typography, Tooltip } from 'antd'
 const { Text } = Typography
 
 import ResourceVerificationStatus from '../resources/ResourceVerificationStatus'
 import AutoRefreshComponent from '../teams/AutoRefreshComponent'
+import { successMessage, errorMessage } from '../../utils/message'
 
 class GKECredentials extends AutoRefreshComponent {
   static propTypes = {
@@ -25,15 +26,15 @@ class GKECredentials extends AutoRefreshComponent {
     const { gkeCredentials } = this.props
     const { status } = gkeCredentials
     if (status.status === 'Success') {
-      return message.success(`GCP credentials for project "${gkeCredentials.spec.project}" verified successfully`)
+      return successMessage(`GCP credentials for project "${gkeCredentials.spec.project}" verified successfully`)
     }
     if (status.status === 'Failure') {
-      return message.error(`GCP credentials for project "${gkeCredentials.spec.project}" could not be verified`)
+      return errorMessage(`GCP credentials for project "${gkeCredentials.spec.project}" could not be verified`)
     }
   }
 
   render() {
-    const { gkeCredentials, editGKECredential, allTeams } = this.props
+    const { gkeCredentials, editGKECredential, deleteGKECredential, allTeams } = this.props
     const created = moment(gkeCredentials.metadata.creationTimestamp).fromNow()
 
     const displayAllocations = () => {
@@ -45,9 +46,10 @@ class GKECredentials extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item key={gkeCredentials.metadata.name} actions={[
+      <List.Item id={`gkecreds_${gkeCredentials.metadata.name}`} key={gkeCredentials.metadata.name} actions={[
         <ResourceVerificationStatus key="verification_status" resourceStatus={gkeCredentials.status} />,
-        <Text key="show_creds"><a onClick={editGKECredential(gkeCredentials)}><Icon type="edit" theme="filled"/> Edit</a></Text>
+        <Text key="delete_creds"><a id={`gkecreds_del_${gkeCredentials.metadata.name}`} onClick={deleteGKECredential(gkeCredentials)}><Icon type="delete" theme="filled"/> Delete</a></Text>,
+        <Text key="show_creds"><a id={`gkecreds_edit_${gkeCredentials.metadata.name}`} onClick={editGKECredential(gkeCredentials)}><Icon type="edit" theme="filled"/> Edit</a></Text>
       ]}>
         <List.Item.Meta
           avatar={<Avatar icon="project" />}

--- a/ui/lib/components/credentials/GKECredentialsForm.js
+++ b/ui/lib/components/credentials/GKECredentialsForm.js
@@ -109,7 +109,7 @@ class GKECredentialsForm extends VerifiedAllocatedResourceForm {
             rules: [{ required: true, message: 'Please enter your project name!' }],
             initialValue: data && data.spec.project
           })(
-            <Input placeholder="Project" />,
+            <Input placeholder="Project" name="project" />,
           )}
         </Form.Item>
 
@@ -121,7 +121,7 @@ class GKECredentialsForm extends VerifiedAllocatedResourceForm {
               style={{ marginTop: '10px' }}
             />
             <Form.Item label="Replace key">
-              <Checkbox onChange={(e) => this.setState({ replaceKey: e.target.checked })}></Checkbox>
+              <Checkbox id="gke_credentials_replace_key" onChange={(e) => this.setState({ replaceKey: e.target.checked })}></Checkbox>
             </Form.Item>
           </>
         ) : null}
@@ -132,7 +132,7 @@ class GKECredentialsForm extends VerifiedAllocatedResourceForm {
               {form.getFieldDecorator('account', {
                 rules: [{ required: true, message: 'Please enter your Service Account key!' }]
               })(
-                <Input.TextArea autoSize={{ minRows: 4, maxRows: 10  }} placeholder="Service Account JSON" />,
+                <Input.TextArea name="service_account_json" autoSize={{ minRows: 4, maxRows: 10  }} placeholder="Service Account JSON" />,
               )}
             </Form.Item>
           </>

--- a/ui/lib/components/credentials/GKECredentialsList.js
+++ b/ui/lib/components/credentials/GKECredentialsList.js
@@ -44,8 +44,8 @@ class GKECredentialsList extends ResourceList {
       okType: 'danger',
       cancelText: 'No',
       onOk: async () => {
+        const key = loadingMessage('Deleting allocations for credential', { duration: 0 })
         try {
-          const key = loadingMessage('Deleting allocations for credential', { duration: 0 })
           await AllocationHelpers.removeAllocation(cred)
           loadingMessage('Deleting credential', { key, duration: 0 })
           await (await KoreApi.client()).RemoveGKECredential(publicRuntimeConfig.koreAdminTeamName, cred.metadata.name)

--- a/ui/lib/components/credentials/GKECredentialsList.js
+++ b/ui/lib/components/credentials/GKECredentialsList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { Typography, List, Button, Drawer, Alert, Icon } from 'antd'
+import { Typography, List, Button, Drawer, Alert, Icon, Modal } from 'antd'
 const { Title } = Typography
 import getConfig from 'next/config'
 const { publicRuntimeConfig } = getConfig()
@@ -9,6 +9,7 @@ import ResourceList from '../resources/ResourceList'
 import GKECredentialsForm from './GKECredentialsForm'
 import KoreApi from '../../kore-api'
 import AllocationHelpers from '../../utils/allocation-helpers'
+import { errorMessage, successMessage, loadingMessage } from '../../utils/message'
 
 class GKECredentialsList extends ResourceList {
 
@@ -18,6 +19,8 @@ class GKECredentialsList extends ResourceList {
 
   createdMessage = 'GCP project credentials created successfully'
   updatedMessage = 'GCP project credentials updated successfully'
+  deletedMessage = 'GCP project credentials deleted successfully'
+  deleteFailedMessage = 'Error deleting GCP project credentials'
 
   async fetchComponentData() {
     const api = await KoreApi.client()
@@ -31,6 +34,29 @@ class GKECredentialsList extends ResourceList {
       gke.allocation = AllocationHelpers.findAllocationForResource(allAllocations, gke)
     })
     return { resources: gkeCredentials, allTeams }
+  }
+
+  delete = (cred) => () => {
+    Modal.confirm({
+      title: `Are you sure you want to delete the credentials ${cred.spec.project}?`,
+      content: 'This cannot be undone',
+      okText: 'Yes',
+      okType: 'danger',
+      cancelText: 'No',
+      onOk: async () => {
+        try {
+          const key = loadingMessage('Deleting allocations for credential', { duration: 0 })
+          await AllocationHelpers.removeAllocation(cred)
+          loadingMessage('Deleting credential', { key, duration: 0 })
+          await (await KoreApi.client()).RemoveGKECredential(publicRuntimeConfig.koreAdminTeamName, cred.metadata.name)
+          successMessage(this.deletedMessage, { key })
+        } catch (err) {
+          console.error(err)
+          errorMessage(this.deleteFailedMessage, { key })
+        }
+        await this.refresh()
+      }
+    })
   }
 
   render() {
@@ -49,12 +75,14 @@ class GKECredentialsList extends ResourceList {
         {!resources ? <Icon type="loading" /> : (
           <>
             <List
+              id="gkecreds_list"
               dataSource={resources.items}
               renderItem={gke =>
                 <GKECredentials
                   gkeCredentials={gke}
                   allTeams={allTeams.items}
                   editGKECredential={this.edit}
+                  deleteGKECredential={this.delete}
                   handleUpdate={this.handleStatusUpdated}
                   refreshMs={2000}
                   propsResourceDataKey="gkeCredentials"

--- a/ui/lib/components/credentials/GKECredentialsList.js
+++ b/ui/lib/components/credentials/GKECredentialsList.js
@@ -84,6 +84,7 @@ class GKECredentialsList extends ResourceList {
                   editGKECredential={this.edit}
                   deleteGKECredential={this.delete}
                   handleUpdate={this.handleStatusUpdated}
+                  handleDelete={() => {}}
                   refreshMs={2000}
                   propsResourceDataKey="gkeCredentials"
                   resourceApiPath={`/teams/${publicRuntimeConfig.koreAdminTeamName}/gkecredentials/${gke.metadata.name}`}

--- a/ui/lib/components/forms/NewTeamForm.js
+++ b/ui/lib/components/forms/NewTeamForm.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types'
 import canonical from '../../utils/canonical'
 import copy from '../../utils/object-copy'
 import Team from '../../crd/Team'
-import { Button, Form, Input, Alert, message, Typography } from 'antd'
+import { Button, Form, Input, Alert, Typography } from 'antd'
 import KoreApi from '../../kore-api'
+import { successMessage } from '../../utils/message'
 
 const { Paragraph, Text } = Typography
 
@@ -68,7 +69,7 @@ class NewTeamForm extends React.Component {
           const state = copy(this.state)
           state.submitting = false
           this.setState(state)
-          message.success('Team created')
+          successMessage('Team created')
         } else {
           const state = copy(this.state)
           state.submitting = false

--- a/ui/lib/components/plans/ManageClusterPlanForm.js
+++ b/ui/lib/components/plans/ManageClusterPlanForm.js
@@ -56,13 +56,6 @@ class ManageClusterPlanForm extends ManagePlanForm {
     return planResource
   }
 
-  generatePlanConfiguration = () => {
-    const properties = this.state.schema.properties
-    const defaultConfiguration = {}
-    Object.keys(properties).forEach(p => properties[p].type === 'boolean' ? defaultConfiguration[p] = false : null)
-    return { ...defaultConfiguration, ...this.state.planValues }
-  }
-
   process = async (err, values) => {
     if (err) {
       this.setFormSubmitting(false, 'Validation failed')
@@ -71,7 +64,7 @@ class ManageClusterPlanForm extends ManagePlanForm {
     try {
       const api = await KoreApi.client()
       const metadataName = this.getMetadataName(values)
-      const planResult = await api.UpdatePlan(metadataName, this.generatePlanResource({ ...values, configuration: this.generatePlanConfiguration() }))
+      const planResult = await api.UpdatePlan(metadataName, this.generatePlanResource({ ...values, configuration: { ...this.state.planValues } }))
 
       if (this.accountManagementRulesEnabled()) {
         const accountMgtResource = copy(this.state.accountManagement)

--- a/ui/lib/components/plans/ManagePlanForm.js
+++ b/ui/lib/components/plans/ManagePlanForm.js
@@ -34,6 +34,19 @@ export default class ManagePlanForm extends React.Component {
   componentDidMountComplete = null
   componentDidMount() {
     this.componentDidMountComplete = this.fetchComponentData().then(() => {
+      if (this.props.mode === 'create' && !this.props.data) {
+        // Copy default values into the plan values as a starting point.
+        const planValues = {}
+        console.log(this.state.schema)
+        const schemaProps = this.state.schema.properties
+        Object.keys(schemaProps).forEach((prop) => {
+          if (schemaProps[prop].default !== undefined) {
+            console.log('defaulting property', prop, schemaProps[prop].default)
+            planValues[prop] = schemaProps[prop].default
+          }
+        })
+        this.setState({ planValues })
+      }
       // To disabled submit button at the beginning.
       this.props.form.validateFields()
     })

--- a/ui/lib/components/plans/ManagePlanForm.js
+++ b/ui/lib/components/plans/ManagePlanForm.js
@@ -37,11 +37,9 @@ export default class ManagePlanForm extends React.Component {
       if (this.props.mode === 'create' && !this.props.data) {
         // Copy default values into the plan values as a starting point.
         const planValues = {}
-        console.log(this.state.schema)
         const schemaProps = this.state.schema.properties
         Object.keys(schemaProps).forEach((prop) => {
           if (schemaProps[prop].default !== undefined) {
-            console.log('defaulting property', prop, schemaProps[prop].default)
             planValues[prop] = schemaProps[prop].default
           }
         })
@@ -220,7 +218,7 @@ export default class ManagePlanForm extends React.Component {
           <>
             <FormErrorMessage message={formErrorMessage} />
             <Form.Item>
-              <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
+              <Button id="plan_save" type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
             </Form.Item>
           </>
         }

--- a/ui/lib/components/plans/PlanItem.js
+++ b/ui/lib/components/plans/PlanItem.js
@@ -23,18 +23,18 @@ class PlanItem extends React.Component {
     if (this.props.displayUnassociatedPlanWarning) {
       actions.push(<IconTooltip key="warning" icon="warning" color="orange" text="This plan not associated with any GCP automated projects and will not be available for teams to use. Edit this plan or go to Project automation settings to review this."/>)
     }
-    actions.push(<Text key="view_plan"><a id={`gkeplans_view_${this.props.plan.metadata.name}`} onClick={this.props.viewPlan(this.props.plan)}><Icon type="eye" theme="filled"/> View</a></Text>)
+    actions.push(<Text key="view_plan"><a id={`plans_view_${this.props.plan.metadata.name}`} onClick={this.props.viewPlan(this.props.plan)}><Icon type="eye" theme="filled"/> View</a></Text>)
     actions.push(
       <Text key="edit_plan">
         <Tooltip title="Edit this plan">
-          <a id={`gkeplans_edit_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only. Create a new plan if this built-in plan does not meet your needs.' }) : this.props.editPlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
+          <a id={`plans_edit_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only. Create a new plan if this built-in plan does not meet your needs.' }) : this.props.editPlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
         </Tooltip>
       </Text>
     )
     actions.push(
       <Text key="delete_plan">
         <Tooltip title="Delete this plan">
-          <a id={`gkeplans_delete_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only and cannot be deleted. To prevent teams using this plan, remove the allocation.' }) : this.props.deletePlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
+          <a id={`plans_delete_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only and cannot be deleted. To prevent teams using this plan, remove the allocation.' }) : this.props.deletePlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
         </Tooltip>
       </Text>
     )

--- a/ui/lib/components/plans/PlanItem.js
+++ b/ui/lib/components/plans/PlanItem.js
@@ -6,6 +6,7 @@ const { Text } = Typography
 
 import IconTooltip from '../utils/IconTooltip'
 import { isReadOnlyCRD } from '../../utils/crd-helpers'
+import { warningMessage } from '../../utils/message'
 
 class PlanItem extends React.Component {
   static propTypes = {
@@ -22,18 +23,18 @@ class PlanItem extends React.Component {
     if (this.props.displayUnassociatedPlanWarning) {
       actions.push(<IconTooltip key="warning" icon="warning" color="orange" text="This plan not associated with any GCP automated projects and will not be available for teams to use. Edit this plan or go to Project automation settings to review this."/>)
     }
-    actions.push(<Text key="view_plan"><a onClick={this.props.viewPlan(this.props.plan)}><Icon type="eye" theme="filled"/> View</a></Text>)
+    actions.push(<Text key="view_plan"><a id={`gkeplans_view_${this.props.plan.metadata.name}`} onClick={this.props.viewPlan(this.props.plan)}><Icon type="eye" theme="filled"/> View</a></Text>)
     actions.push(
       <Text key="edit_plan">
-        <Tooltip title={readonly ? 'Read-only' : 'Edit this plan'}>
-          <a onClick={readonly ? () => {} : this.props.editPlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
+        <Tooltip title="Edit this plan">
+          <a id={`gkeplans_edit_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only. Create a new plan if this built-in plan does not meet your needs.' }) : this.props.editPlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
         </Tooltip>
       </Text>
     )
     actions.push(
       <Text key="delete_plan">
-        <Tooltip title={readonly ? 'Read-only' : 'Delete this plan'}>
-          <a onClick={readonly ? () => {} : this.props.deletePlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
+        <Tooltip title="Delete this plan">
+          <a id={`gkeplans_delete_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only and cannot be deleted. To prevent teams using this plan, remove the allocation.' }) : this.props.deletePlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
         </Tooltip>
       </Text>
     )

--- a/ui/lib/components/plans/PlanList.js
+++ b/ui/lib/components/plans/PlanList.js
@@ -120,7 +120,7 @@ class PlanList extends ResourceList {
           showIcon
           style={{ marginBottom: '20px' }}
         />
-        <Button type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
+        <Button id="add" type="primary" onClick={this.add(true)} style={{ display: 'block', marginBottom: '20px' }}>+ New</Button>
 
         <Drawer
           title={drawerTitle}
@@ -155,7 +155,7 @@ class PlanList extends ResourceList {
         {!resources ? <Icon type="loading" /> : (
           <>
             <List
-              id="gkeplans_list"
+              id="plans_list"
               dataSource={resources.items}
               renderItem={plan => <PlanItem plan={plan} viewPlan={this.view} editPlan={this.edit} deletePlan={this.delete} displayUnassociatedPlanWarning={this.unassociatedPlanWarning(plan)} /> }
             >

--- a/ui/lib/components/plans/PlanOption.js
+++ b/ui/lib/components/plans/PlanOption.js
@@ -62,6 +62,8 @@ export default class PlanOption extends PlanOptionBase {
       )
     }
 
+    const id = this.props.id || `plan_input_${name}`
+
     // Special handling for 'key map' object types, represented in json schema as having no properties list and additionalProperties of type string
     if (property.type === 'object' && property.additionalProperties && property.additionalProperties.type === 'string') {
       return (
@@ -78,26 +80,26 @@ export default class PlanOption extends PlanOptionBase {
           switch(property.type) {
           case 'string': {
             if (property.format === 'multiline') {
-              return <TextArea value={valueOrDefault} readOnly={!editable} onChange={(e) => onChange(name, e.target.value)} rows='20' />
+              return <TextArea id={id} value={valueOrDefault} readOnly={!editable} onChange={(e) => onChange(name, e.target.value)} rows='20' />
             } else if (property.enum) {
-              return <ConstrainedDropdown readOnly={!editable} value={valueOrDefault} allowedValues={property.enum} onChange={(e) => onChange(name, e)} />
+              return <ConstrainedDropdown id={id} readOnly={!editable} value={valueOrDefault} allowedValues={property.enum} onChange={(e) => onChange(name, e)} />
             } else {
-              return <Input value={valueOrDefault} readOnly={!editable} pattern={property.pattern} onChange={(e) => onChange(name, e.target.value)} />
+              return <Input id={id} value={valueOrDefault} readOnly={!editable} pattern={property.pattern} onChange={(e) => onChange(name, e.target.value)} />
             }
           }
           case 'boolean': {
-            return <Switch checked={valueOrDefault} disabled={!editable} onChange={(v) => onChange(name, v)} checkedChildren={<Icon type="check" />} unCheckedChildren={<Icon type="close" />} />
+            return <Switch id={id} checked={valueOrDefault} disabled={!editable} onChange={(v) => onChange(name, v)} checkedChildren={<Icon type="check" />} unCheckedChildren={<Icon type="close" />} />
           }
           case 'number': {
-            return <InputNumber value={valueOrDefault} readOnly={!editable} onChange={(v) => onChange(name, v)} />
+            return <InputNumber id={id} value={valueOrDefault} readOnly={!editable} onChange={(v) => onChange(name, v)} />
           }
           case 'integer': {
-            return <InputNumber value={valueOrDefault} readOnly={!editable} onChange={(v) => onChange(name, v)} />
+            return <InputNumber id={id} value={valueOrDefault} readOnly={!editable} onChange={(v) => onChange(name, v)} />
           }
           case 'array': {
             const values = valueOrDefault ? valueOrDefault : []
             if (property.items.type !== 'array' && property.items.type !== 'object') {
-              return <Select mode="tags" tokenSeparators={[',']} value={values} disabled={!editable} onChange={(v) => onChange(name, v)} />
+              return <Select id={id} mode="tags" tokenSeparators={[',']} value={values} disabled={!editable} onChange={(v) => onChange(name, v)} />
             } else {
               return (
                 <>
@@ -118,7 +120,7 @@ export default class PlanOption extends PlanOptionBase {
                   {(values.length === 0) ?
                     <Alert type="info" message={`No ${displayName} currently defined.`}/>
                     : null}
-                  <Button disabled={!editable} icon="plus" title={`Add new ${displayName}`} onClick={() => onChange(name, this.addComplexItemToArray(property, values))}>
+                  <Button id={`${id}_add`} disabled={!editable} icon="plus" title={`Add new ${displayName}`} onClick={() => onChange(name, this.addComplexItemToArray(property, values))}>
                     {`Add new ${displayName}`}
                   </Button>
                 </>
@@ -135,7 +137,7 @@ export default class PlanOption extends PlanOptionBase {
           <Alert 
             message={(
               <>
-                This property is deprecated. See below for instructions. <Button onClick={() => onChange(name, undefined)}>Unset &amp; hide</Button>
+                This property is deprecated. See below for instructions. <Button id={`${id}_removedeprecated`} onClick={() => onChange(name, undefined)}>Unset &amp; hide</Button>
               </>
             )}
             type="warning"

--- a/ui/lib/components/plans/PlanOptionBase.js
+++ b/ui/lib/components/plans/PlanOptionBase.js
@@ -18,6 +18,7 @@ export default class PlanOptionBase extends React.Component {
     manage: PropTypes.bool, // manage means we're editing a PLAN, false/unspecified means we're USING a plan e.g. to make/edit a cluster
     mode: PropTypes.oneOf(['create','view','edit']),
     team: PropTypes.object, // may be optionally used by custom plan option components to give richer interface when manage=false.
+    id: PropTypes.string,
   }
 
   describe = (property) => {

--- a/ui/lib/components/plans/custom/ConstrainedDropdown.js
+++ b/ui/lib/components/plans/custom/ConstrainedDropdown.js
@@ -8,10 +8,11 @@ export default class ConstrainedDropdown extends React.Component {
     value: PropTypes.string,
     allowedValues: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
+    id: PropTypes.string
   }
 
   render() {
-    const { value, readOnly } = this.props
+    const { value, readOnly, id } = this.props
     let { allowedValues } = this.props
     // Support a list of strings or a list of { value: 'x', display: 'y' } objects:
     if (allowedValues.length > 0 && (typeof allowedValues[0])==='string') {
@@ -19,7 +20,7 @@ export default class ConstrainedDropdown extends React.Component {
     }
 
     return (
-      <Select value={value} disabled={readOnly} defaultValue={null} onChange={this.props.onChange} style={{ width: '100%' }}>
+      <Select id={id} value={value} disabled={readOnly} defaultValue={null} onChange={this.props.onChange} style={{ width: '100%' }}>
         {allowedValues.map((allowedValue) => <Select.Option key={allowedValue.value} value={allowedValue.value}>{allowedValue.display ? allowedValue.display : allowedValue.value}</Select.Option>)}
       </Select>
     )

--- a/ui/lib/components/plans/custom/PlanOptionClusterUsers.js
+++ b/ui/lib/components/plans/custom/PlanOptionClusterUsers.js
@@ -119,7 +119,7 @@ export default class PlanOptionClusterUsers extends PlanOptionBase {
       { title: 'User', dataIndex: 'username', key: 'username', width: '45%' },
       { title: 'Roles', dataIndex: 'roles', key: 'tags', width: '45%', render: function renderRoles(userRoles, r) { 
         return (
-          <Select mode="multiple" value={userRoles}  onChange={(selectedRoles) => this.setUserRoles(r.username, selectedRoles)}>
+          <Select id={`plan_input_${name}_${r.username}_roles`} mode="multiple" value={userRoles}  onChange={(selectedRoles) => this.setUserRoles(r.username, selectedRoles)}>
             {!editable ? null : roles.map((role) => userRoles.indexOf(role) === -1 ? <Select.Option key={role} value={role}>{role}</Select.Option> : null)}
           </Select>
         )
@@ -128,7 +128,7 @@ export default class PlanOptionClusterUsers extends PlanOptionBase {
         if (!editable) {
           return null
         }
-        return <><div style={{ textAlign: 'right' }}><a onClick={() => this.removeUser(r.username)}><Icon type="delete" title="Delete" /></a></div></>
+        return <><div style={{ textAlign: 'right' }}><a id={`plan_input_${name}_${r.username}_remove`} onClick={() => this.removeUser(r.username)}><Icon type="delete" title="Delete" /></a></div></>
       }.bind(this) },
     ]
 
@@ -142,6 +142,7 @@ export default class PlanOptionClusterUsers extends PlanOptionBase {
           rowKey={r => r.username}
           footer={!editable ? null : () => (
             <Select
+              id={`plan_input_${name}_adduser`} 
               mode="single" showSearch={true}
               placeholder="Start typing username to find users to add"
               onSearch={this.searchUsers}

--- a/ui/lib/components/policies/PolicyList.js
+++ b/ui/lib/components/policies/PolicyList.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { message, Avatar, List, Alert, Icon, Drawer, Typography, Button, Tooltip, Modal } from 'antd'
+import { Avatar, List, Alert, Icon, Drawer, Typography, Button, Tooltip, Modal } from 'antd'
 const { Title, Text, Paragraph } = Typography
 import getConfig from 'next/config'
 const { publicRuntimeConfig } = getConfig()
@@ -11,6 +11,7 @@ import Policy from './Policy'
 import PolicyForm from './PolicyForm'
 import AllocationHelpers from '../../utils/allocation-helpers'
 import { isReadOnlyCRD } from '../../utils/crd-helpers'
+import { successMessage } from '../../utils/message'
 
 class PolicyList extends ResourceList {
   static propTypes = {
@@ -40,7 +41,7 @@ class PolicyList extends ResourceList {
       onOk: async () => {
         await AllocationHelpers.removeAllocation(policy)
         await (await KoreApi.client()).RemovePlanPolicy(policy.metadata.name)
-        message.success(`Policy ${policy.spec.description} deleted`)
+        successMessage(`Policy ${policy.spec.description} deleted`)
         await this.refresh()
       }
     })

--- a/ui/lib/components/resources/ResourceList.js
+++ b/ui/lib/components/resources/ResourceList.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { message } from 'antd'
+import { successMessage } from '../../utils/message'
 
 class ResourceList extends React.Component {
 
@@ -43,12 +43,12 @@ class ResourceList extends React.Component {
 
   handleStatusUpdated = (updatedResource, done) => {
     this.setState((state) => {
-      this.setState({
+      return {
         resources: {
           ...state.resources,
           items: state.resources.items.map((r) => r.metadata.name !== updatedResource.metadata.name ? r : { ...r, status: updatedResource.status })
         }
-      })
+      }
     }, done)
   }
 
@@ -58,39 +58,40 @@ class ResourceList extends React.Component {
 
   handleEditSave = (updated) => {
     const editedName = this.state.edit.metadata.name
-    this.setState({
-      ...this.state,
-      edit: false,
-      resources: {
-        items: this.state.resources.items.map(resource => {
-          if (resource.metadata.name === editedName) {
-            return {
-              ...resource,
-              spec: updated.spec,
-              allocation: updated.allocation,
-              status: {
-                ...resource.status, status: 'Pending'
-              },
-              ...updated.append
+    this.setState((state) => {
+      return {
+        edit: false,
+        resources: {
+          items: state.resources.items.map(resource => {
+            if (resource.metadata.name === editedName) {
+              return {
+                ...resource,
+                spec: updated.spec,
+                allocation: updated.allocation,
+                status: {
+                  ...resource.status, status: 'Pending'
+                },
+                ...updated.append
+              }
             }
-          }
-          return resource
-        })
+            return resource
+          })
+        }
       }
     })
-    message.success(this.updatedMessage)
+    successMessage(this.updatedMessage)
   }
 
   handleAddSave = async (created) => {
+    const newItems = this.state.resources.items.concat([ created ])
     this.setState({
-      ...this.state,
       add: false,
       resources: {
-        items: this.state.resources.items.concat([ created ])
+        items: newItems
       }
     })
-    this.props.getResourceItemList && this.props.getResourceItemList(this.state.resources.items)
-    message.success(this.createdMessage)
+    this.props.getResourceItemList && this.props.getResourceItemList(newItems)
+    successMessage(this.createdMessage)
   }
 }
 

--- a/ui/lib/components/resources/VerifiedAllocatedResourceForm.js
+++ b/ui/lib/components/resources/VerifiedAllocatedResourceForm.js
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import { message, Typography, Form, Card, Alert, Button, Input, Select } from 'antd'
+import { Typography, Form, Card, Alert, Button, Input, Select } from 'antd'
 const { Paragraph, Text } = Typography
 
 import canonical from '../../utils/canonical'
 import ResourceVerificationStatus from './ResourceVerificationStatus'
 import FormErrorMessage from '../forms/FormErrorMessage'
 import AllocationHelpers from '../../utils/allocation-helpers'
+import { successMessage, loadingMessage, errorMessage } from '../../utils/message'
 
 class VerifiedAllocatedResourceForm extends React.Component {
   static propTypes = {
@@ -65,10 +66,10 @@ class VerifiedAllocatedResourceForm extends React.Component {
     const messageKey = 'verify'
     tryCount = tryCount || 0
     if (tryCount === 0) {
-      message.loading({ content: 'Verifying credentials', key: messageKey, duration: 0 })
+      loadingMessage('Verifying credentials', { key: messageKey, duration: 0 })
     }
     if (tryCount === 3) {
-      message.error({ content: 'Credentials verification failed', key: messageKey })
+      errorMessage('Credentials verification failed', { key: messageKey })
       this.setState({
         ...this.state,
         inlineVerificationFailed: true,
@@ -90,7 +91,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
       setTimeout(async () => {
         const resourceResult = await this.getResource(resource.metadata.name)
         if (resourceResult.status.status === 'Success') {
-          message.success({ content: 'Credentials verification successful', key: messageKey })
+          successMessage({ content: 'Credentials verification successful', key: messageKey })
           return await this.props.handleSubmit(resourceResult)
         }
         return await this.verify(resourceResult, tryCount + 1)
@@ -198,7 +199,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
           />
         ) : null}
 
-        <Form {...formConfig} onSubmit={this.handleSubmit}>
+        <Form {...formConfig} name="resource_form" onSubmit={this.handleSubmit}>
           <FormErrorMessage message={formErrorMessage} />
 
           {this.resourceFormFields()}
@@ -215,7 +216,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
                 rules: [{ required: true, message: 'Please enter the name!' }],
                 initialValue: data && data.allocation && data.allocation.spec.name
               })(
-                <Input placeholder="Name" />,
+                <Input name="name" placeholder="Name" />,
               )}
             </Form.Item>
             <Form.Item label="Description" validateStatus={this.fieldError('summary') ? 'error' : ''} help={this.fieldError('summary') || nameSection.descriptionHelp}>
@@ -223,7 +224,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
                 rules: [{ required: true, message: 'Please enter the description!' }],
                 initialValue: data && data.allocation && data.allocation.spec.summary
               })(
-                <Input placeholder="Description" />,
+                <Input name="description" placeholder="Description" />,
               )}
             </Form.Item>
           </Card>
@@ -252,6 +253,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
                       style={{ width: '100%' }}
                       placeholder={noAllocation ? 'No teams' : 'All teams'}
                       onChange={this.onAllocationsChange}
+                      name="allocation"
                     >
                       {allTeams.items.map(t => (
                         <Select.Option key={t.metadata.name} value={t.metadata.name}>{t.spec.summary}</Select.Option>

--- a/ui/lib/components/resources/VerifiedAllocatedResourceForm.js
+++ b/ui/lib/components/resources/VerifiedAllocatedResourceForm.js
@@ -91,7 +91,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
       setTimeout(async () => {
         const resourceResult = await this.getResource(resource.metadata.name)
         if (resourceResult.status.status === 'Success') {
-          successMessage({ content: 'Credentials verification successful', key: messageKey })
+          successMessage('Credentials verification successful', { key: messageKey })
           return await this.props.handleSubmit(resourceResult)
         }
         return await this.verify(resourceResult, tryCount + 1)

--- a/ui/lib/components/security/SecurityScanResult.js
+++ b/ui/lib/components/security/SecurityScanResult.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Card, Descriptions, List, Tooltip, Icon, Button, Collapse, message, Drawer } from 'antd'
+import { Card, Descriptions, List, Tooltip, Icon, Button, Collapse, Drawer } from 'antd'
 import moment from 'moment'
 import Link from 'next/link'
 import getConfig from 'next/config'
@@ -9,6 +9,7 @@ const { publicRuntimeConfig } = getConfig()
 import SecurityStatusIcon from './SecurityStatusIcon'
 import KoreApi from '../../kore-api'
 import SecurityRule from './SecurityRule'
+import { errorMessage } from '../../utils/message'
 
 export default class SecurityScanResult extends React.Component {
   static propTypes = {
@@ -35,12 +36,12 @@ export default class SecurityScanResult extends React.Component {
         ruleDetails: rule
       })
       if (!rule) {
-        message.error(`Rule ${ruleCode} not found, cannot show details`)
+        errorMessage(`Rule ${ruleCode} not found, cannot show details`)
       }
     } catch (err) {
       this.setState({ loadingRule: false })
       console.error(`Failed to load details of rule ${ruleCode}`, err)
-      message.error(`Failed to load details of rule ${ruleCode}`)
+      errorMessage(`Failed to load details of rule ${ruleCode}`)
     }
   }
 

--- a/ui/lib/components/services/ServiceKindList.js
+++ b/ui/lib/components/services/ServiceKindList.js
@@ -4,7 +4,7 @@ import { sortBy } from 'lodash'
 import KoreApi from '../../kore-api'
 import { Alert, Avatar, Col, Icon, List, Row, Switch, Tooltip, Typography } from 'antd'
 import Link from 'next/link'
-import { successMessage } from '../../utils/message'
+import { successMessage, errorMessage } from '../../utils/message'
 const { Text, Title } = Typography
 import { featureEnabled, KoreFeatures } from '../../utils/features'
 import { isReadOnlyCRD } from '../../utils/crd-helpers'

--- a/ui/lib/components/services/ServiceKindList.js
+++ b/ui/lib/components/services/ServiceKindList.js
@@ -2,8 +2,9 @@ import * as React from 'react'
 import PropTypes from 'prop-types'
 import { sortBy } from 'lodash'
 import KoreApi from '../../kore-api'
-import { Alert, Avatar, Col, Icon, List, message, Row, Switch, Tooltip, Typography } from 'antd'
+import { Alert, Avatar, Col, Icon, List, Row, Switch, Tooltip, Typography } from 'antd'
 import Link from 'next/link'
+import { successMessage } from '../../utils/message'
 const { Text, Title } = Typography
 import { featureEnabled, KoreFeatures } from '../../utils/features'
 import { isReadOnlyCRD } from '../../utils/crd-helpers'
@@ -50,9 +51,9 @@ export default class ServiceKindList extends React.Component {
       this.setState({
         kinds: sortBy(this.state.kinds.filter(k => k.metadata.name !== kind.metadata.name).concat([ serviceKindResult ]), k => k.spec.displayName.toLowerCase())
       })
-      message.success(`${enabled ? 'Enabled' : 'Disabled'} service "${kind.spec.displayName}"`)
+      successMessage(`${enabled ? 'Enabled' : 'Disabled'} service "${kind.spec.displayName}"`)
     } catch (error) {
-      message.error(`Failed to ${enabled ? 'enable' : 'disable'} service "${kind.spec.displayName}", please try again.`)
+      errorMessage(`Failed to ${enabled ? 'enable' : 'disable'} service "${kind.spec.displayName}", please try again.`)
     }
   }
 

--- a/ui/lib/components/setup/GCPAutomatedProjectList.js
+++ b/ui/lib/components/setup/GCPAutomatedProjectList.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Alert, Button, Card, Col, Icon, List, message, Modal, Popover, Row, Typography } from 'antd'
+import { Alert, Button, Card, Col, Icon, List, Modal, Popover, Row, Typography } from 'antd'
 const { Paragraph, Text, Title } = Typography
 
 import PlanViewer from '../plans/PlanViewer'
 import IconTooltip from '../utils/IconTooltip'
 import DataField from '../utils/DataField'
+import { successMessage } from '../../utils/message'
 
 class GCPAutomatedProjectList extends React.Component {
 
@@ -36,7 +37,7 @@ class GCPAutomatedProjectList extends React.Component {
     const project = this.props.automatedProjectList.find(p => p.code === projectCode)
     project.plans.push(plan)
     this.props.handleChange(projectCode, 'plans')(project.plans)
-    message.success('Plan associated')
+    successMessage('Plan associated')
   }
 
   closeAssociatePlans = () => this.setState({ associatePlanVisible: false })
@@ -69,7 +70,7 @@ class GCPAutomatedProjectList extends React.Component {
     const project = this.props.automatedProjectList.find(p => p.code === projectCode)
     const updatedPlans = project.plans.filter(p => p !== plan)
     this.props.handleChange(projectCode, 'plans')(updatedPlans)
-    message.success('Plan unassociated')
+    successMessage('Plan unassociated')
   }
 
   automatedProjectContent = ({ project }) => (

--- a/ui/lib/components/setup/GCPKoreManagedProjects.js
+++ b/ui/lib/components/setup/GCPKoreManagedProjects.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
-import { Alert, Button, Card, Divider, Icon, message, Radio, Result, Steps, Typography } from 'antd'
+import { Alert, Button, Card, Divider, Icon, Radio, Result, Steps, Typography } from 'antd'
 const { Paragraph, Text } = Typography
 const { Step } = Steps
 
@@ -18,6 +18,7 @@ import V1ObjectMeta from '../../kore-api/model/V1ObjectMeta'
 import V1Ownership from '../../kore-api/model/V1Ownership'
 import V1beta1AccountsRule from '../../kore-api/model/V1beta1AccountsRule'
 import AllocationHelpers from '../../utils/allocation-helpers'
+import { successMessage } from '../../utils/message'
 
 class GCPKoreManagedProjects extends React.Component {
 
@@ -73,7 +74,7 @@ class GCPKoreManagedProjects extends React.Component {
     this.setState({
       gcpProjectList: this.state.gcpProjectList.concat([{ code, plans: [], ...project }]),
     })
-    message.success('GCP automated project added')
+    successMessage('GCP automated project added')
   }
 
   handleGcpProjectDeleted = (code) => {
@@ -81,7 +82,7 @@ class GCPKoreManagedProjects extends React.Component {
       this.setState({
         gcpProjectList: this.state.gcpProjectList.filter(p => p.code !== code)
       })
-      message.success('GCP automated project removed')
+      successMessage('GCP automated project removed')
     }
   }
 

--- a/ui/lib/components/setup/GCPProjectAutomationSettings.js
+++ b/ui/lib/components/setup/GCPProjectAutomationSettings.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Alert, Button, Icon, message, Modal, Radio, Typography } from 'antd'
+import { Alert, Button, Icon, Modal, Radio, Typography } from 'antd'
 const { Paragraph, Text } = Typography
 import getConfig from 'next/config'
 const { publicRuntimeConfig } = getConfig()
@@ -18,6 +18,7 @@ import KoreApi from '../../kore-api'
 import canonical from '../../utils/canonical'
 import copy from '../../utils/object-copy'
 import asyncForEach from '../../utils/async-foreach'
+import { successMessage } from '../../utils/message'
 
 class GCPProjectAutomationSettings extends React.Component {
   state = {
@@ -133,16 +134,16 @@ class GCPProjectAutomationSettings extends React.Component {
             accountManagement: false,
             gcpProjectList: []
           })
-          message.success('Project automation settings saved')
+          successMessage('Project automation settings saved')
         } catch (err) {
           console.error('Error saving project automation settings', err)
-          message.success('Failed to save project automation settings')
+          successMessage('Failed to save project automation settings')
           this.setState({ submitting: false, errorMessage: 'A problem occurred trying to save, please try again later.' })
         }
         return
       } else {
         this.setState({ submitting: false })
-        message.success('Project automation settings saved')
+        successMessage('Project automation settings saved')
         return
       }
     }
@@ -157,10 +158,10 @@ class GCPProjectAutomationSettings extends React.Component {
         await AllocationHelpers.storeAllocation({ resourceToAllocate: accountMgtResource })
         this.setState({ submitting: false, accountManagement: accountMgtResource })
       })
-      message.success('Project automation settings saved')
+      successMessage('Project automation settings saved')
     } catch (error) {
       console.error('Error saving project automation settings', error)
-      message.success('Failed to save project automation settings')
+      successMessage('Failed to save project automation settings')
       this.setState({ submitting: false, errorMessage: 'A problem occurred trying to save, please try again later.' })
     }
   }
@@ -172,7 +173,7 @@ class GCPProjectAutomationSettings extends React.Component {
     this.setState({
       gcpProjectList: this.state.gcpProjectList.concat([{ code, plans: [], ...project }]),
     })
-    message.success('GCP automated project added')
+    successMessage('GCP automated project added')
   }
 
   handleGcpProjectDeleted = (code) => {
@@ -180,7 +181,7 @@ class GCPProjectAutomationSettings extends React.Component {
       this.setState({
         gcpProjectList: this.state.gcpProjectList.filter(p => p.code !== code)
       })
-      message.success('GCP automated project removed')
+      successMessage('GCP automated project removed')
     }
   }
 

--- a/ui/lib/components/teams/cluster/Cluster.js
+++ b/ui/lib/components/teams/cluster/Cluster.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import Link from 'next/link'
-import { List, Icon, Typography, Modal, Popconfirm, message, Tag, Tooltip } from 'antd'
+import { List, Icon, Typography, Modal, Popconfirm, Tag, Tooltip } from 'antd'
 const { Text, Paragraph } = Typography
 
 import { clusterProviderIconSrcMap, inProgressStatusList } from '../../../utils/ui-helpers'
 import ResourceStatusTag from '../../resources/ResourceStatusTag'
 import AutoRefreshComponent from '../AutoRefreshComponent'
 import { isReadOnlyCRD } from '../../../utils/crd-helpers'
+import { successMessage } from '../../../utils/message'
 
 class Cluster extends AutoRefreshComponent {
   static propTypes = {
@@ -22,13 +23,13 @@ class Cluster extends AutoRefreshComponent {
     const { cluster } = this.props
     const { status, deleted } = cluster
     if (deleted) {
-      return message.success(`Cluster successfully deleted: ${cluster.metadata.name}`)
+      return successMessage(`Cluster successfully deleted: ${cluster.metadata.name}`)
     }
     if (status.status === 'Success') {
-      return message.success(`Cluster successfully created: ${cluster.metadata.name}`)
+      return successMessage(`Cluster successfully created: ${cluster.metadata.name}`)
     }
     if (status.status === 'Failure') {
-      return message.error(`Cluster failed to create: ${cluster.metadata.name}`)
+      return errorMessage(`Cluster failed to create: ${cluster.metadata.name}`)
     }
   }
 

--- a/ui/lib/components/teams/cluster/Cluster.js
+++ b/ui/lib/components/teams/cluster/Cluster.js
@@ -8,7 +8,7 @@ import { clusterProviderIconSrcMap, inProgressStatusList } from '../../../utils/
 import ResourceStatusTag from '../../resources/ResourceStatusTag'
 import AutoRefreshComponent from '../AutoRefreshComponent'
 import { isReadOnlyCRD } from '../../../utils/crd-helpers'
-import { successMessage } from '../../../utils/message'
+import { successMessage, errorMessage } from '../../../utils/message'
 
 class Cluster extends AutoRefreshComponent {
   static propTypes = {

--- a/ui/lib/components/teams/cluster/ClusterBuildForm.js
+++ b/ui/lib/components/teams/cluster/ClusterBuildForm.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
-import { Button, Form, message } from 'antd'
+import { Button, Form } from 'antd'
 
 import redirect from '../../../utils/redirect'
 import CloudSelector from '../../common/CloudSelector'
@@ -13,6 +13,7 @@ import V1ClusterSpec from '../../../kore-api/model/V1ClusterSpec'
 import V1Cluster from '../../../kore-api/model/V1Cluster'
 import V1ObjectMeta from '../../../kore-api/model/V1ObjectMeta'
 import getConfig from 'next/config'
+import { loadingMessage } from '../../../utils/message'
 const { publicRuntimeConfig } = getConfig()
 
 class ClusterBuildForm extends React.Component {
@@ -132,7 +133,7 @@ class ClusterBuildForm extends React.Component {
           values.clusterName,
           this.getClusterResource(values)
         )
-        message.loading('Cluster build requested...')
+        loadingMessage('Cluster build requested...')
         return redirect({
           router: Router,
           path: `/teams/${this.props.team.metadata.name}/clusters/${values.clusterName}`

--- a/ui/lib/components/teams/cluster/ClustersTab.js
+++ b/ui/lib/components/teams/cluster/ClustersTab.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import Link from 'next/link'
-import { Button, Col, Divider, Icon, message, Row, Tag, Tooltip, Typography } from 'antd'
+import { Button, Col, Divider, Icon, Row, Tag, Tooltip, Typography } from 'antd'
 const { Paragraph, Text } = Typography
 import { get } from 'lodash'
 
@@ -11,6 +11,7 @@ import ClusterAccessInfo from './ClusterAccessInfo'
 import KoreApi from '../../../kore-api'
 import copy from '../../../utils/object-copy'
 import { inProgressStatusList, statusColorMap, statusIconMap } from '../../../utils/ui-helpers'
+import { errorMessage, loadingMessage } from '../../../utils/message'
 
 class ClustersTab extends React.Component {
 
@@ -100,10 +101,10 @@ class ClustersTab extends React.Component {
       cluster.status.status = 'Deleting'
       cluster.metadata.deletionTimestamp = new Date()
       this.setState({ clusters }, done)
-      message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
+      loadingMessage(`Cluster deletion requested: ${cluster.metadata.name}`)
     } catch (err) {
       console.error('Error deleting cluster', err)
-      message.error('Error deleting cluster, please try again.')
+      errorMessage('Error deleting cluster, please try again.')
     }
   }
 

--- a/ui/lib/components/teams/members/MembersTab.js
+++ b/ui/lib/components/teams/members/MembersTab.js
@@ -8,7 +8,7 @@ import KoreApi from '../../../kore-api'
 import copy from '../../../utils/object-copy'
 import asyncForEach from '../../../utils/async-foreach'
 import InviteLink from '../InviteLink'
-import { successMessage } from '../../../utils/message'
+import { successMessage, errorMessage } from '../../../utils/message'
 
 class MembersTab extends React.Component {
 

--- a/ui/lib/components/teams/members/MembersTab.js
+++ b/ui/lib/components/teams/members/MembersTab.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Avatar, Button, Col, Divider, Icon, List, message, Popconfirm, Row, Select, Tag, Typography } from 'antd'
+import { Avatar, Button, Col, Divider, Icon, List, Popconfirm, Row, Select, Tag, Typography } from 'antd'
 const { Text } = Typography
 const { Option } = Select
 
@@ -8,6 +8,7 @@ import KoreApi from '../../../kore-api'
 import copy from '../../../utils/object-copy'
 import asyncForEach from '../../../utils/async-foreach'
 import InviteLink from '../InviteLink'
+import { successMessage } from '../../../utils/message'
 
 class MembersTab extends React.Component {
 
@@ -65,13 +66,13 @@ class MembersTab extends React.Component {
       await asyncForEach(this.state.membersToAdd, async member => {
         await api.AddTeamMember(this.props.team.metadata.name, member)
         members.push(member)
-        message.success(`Team member added: ${member}`)
+        successMessage(`Team member added: ${member}`)
       })
       this.props.getMemberCount && this.props.getMemberCount(members.length)
       this.setState({ members, membersToAdd: [] })
     } catch (err) {
       console.error('Error adding team member', err)
-      message.error('Error adding team members, please try again.')
+      errorMessage('Error adding team members, please try again.')
     }
   }
 
@@ -84,10 +85,10 @@ class MembersTab extends React.Component {
         members = members.filter(m => m !== member)
         this.props.getMemberCount && this.props.getMemberCount(members.length)
         this.setState({ members })
-        message.success(`Team member removed: ${member}`)
+        successMessage(`Team member removed: ${member}`)
       } catch (err) {
         console.error('Error removing team member', err)
-        message.error('Error removing team member, please try again.')
+        errorMessage('Error removing team member, please try again.')
       }
     }
   }

--- a/ui/lib/components/teams/namespace/NamespaceClaim.js
+++ b/ui/lib/components/teams/namespace/NamespaceClaim.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Icon, Typography, Popconfirm, message } from 'antd'
+import { List, Icon, Typography, Popconfirm } from 'antd'
 const { Text } = Typography
 
 import ResourceStatusTag from '../../resources/ResourceStatusTag'
 import AutoRefreshComponent from '../AutoRefreshComponent'
+import { successMessage, errorMessage } from '../../../utils/message'
 
 class NamespaceClaim extends AutoRefreshComponent {
   static propTypes = {
@@ -17,13 +18,13 @@ class NamespaceClaim extends AutoRefreshComponent {
     const { namespaceClaim } = this.props
     const { spec, status, deleted } = namespaceClaim
     if (deleted) {
-      return message.success(`Namespace "${spec.name}" successfully deleted`)
+      return successMessage(`Namespace "${spec.name}" successfully deleted`)
     }
     if (status.status === 'Success') {
-      return message.success(`Namespace "${spec.name}" created on cluster "${spec.cluster.name}"`)
+      return successMessage(`Namespace "${spec.name}" created on cluster "${spec.cluster.name}"`)
     }
     if (status.status === 'Failure') {
-      return message.error(`Namespace "${spec.name}" failed to create on cluster "${spec.cluster.name}"`)
+      return errorMessage(`Namespace "${spec.name}" failed to create on cluster "${spec.cluster.name}"`)
     }
   }
 

--- a/ui/lib/components/teams/namespace/NamespacesTab.js
+++ b/ui/lib/components/teams/namespace/NamespacesTab.js
@@ -8,7 +8,6 @@ import {
   Drawer,
   Icon,
   List,
-  message,
   Modal,
   Row,
   Tooltip,

--- a/ui/lib/components/teams/namespace/NamespacesTab.js
+++ b/ui/lib/components/teams/namespace/NamespacesTab.js
@@ -28,6 +28,7 @@ import ServiceCredential from '../service/ServiceCredential'
 import apiPaths from '../../../utils/api-paths'
 import NamespaceClaimForm from './NamespaceClaimForm'
 import ServiceCredentialForm from '../../../../lib/components/teams/service/ServiceCredentialForm'
+import { loadingMessage, errorMessage } from '../../../utils/message'
 
 class NamespacesTab extends React.Component {
 
@@ -130,13 +131,13 @@ class NamespacesTab extends React.Component {
         revealBindings
       }
     })
-    message.loading(`Service access with secret name "${serviceCredential.spec.secretName}" requested`)
+    loadingMessage(`Service access with secret name "${serviceCredential.spec.secretName}" requested`)
   }
 
   deleteNamespace = async (name, done) => {
     const team = this.props.team.metadata.name
     try {
-      message.loading(`Namespace deletion requested: ${name}`)
+      loadingMessage(`Namespace deletion requested: ${name}`)
       await (await KoreApi.client()).RemoveNamespace(team, name)
       this.setState((state) => {
         const namespaceClaims = copy(state.namespaceClaims)
@@ -147,7 +148,7 @@ class NamespacesTab extends React.Component {
       }, done)
     } catch (err) {
       console.error('Error deleting namespace', err)
-      message.error('Error deleting namespace, please try again.')
+      errorMessage('Error deleting namespace, please try again.')
     }
   }
 
@@ -186,10 +187,10 @@ class NamespacesTab extends React.Component {
         }
       }, done)
 
-      message.loading('Deletion of service access requested')
+      loadingMessage('Deletion of service access requested')
     } catch (err) {
       console.error('Error deleting service access', err)
-      message.error('Error deleting service access, please try again.')
+      errorMessage('Error deleting service access, please try again.')
     }
   }
 

--- a/ui/lib/components/teams/service/ApplicationServiceForm.js
+++ b/ui/lib/components/teams/service/ApplicationServiceForm.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import { Alert, Button, Card, Checkbox, Form, Icon, Input, message, Select } from 'antd'
+import { Alert, Button, Card, Checkbox, Form, Icon, Input, Select } from 'antd'
 
 import ServiceOptionsForm from '../../services/ServiceOptionsForm'
 import FormErrorMessage from '../../forms/FormErrorMessage'
@@ -9,6 +9,7 @@ import V1ServiceSpec from '../../../kore-api/model/V1ServiceSpec'
 import V1Service from '../../../kore-api/model/V1Service'
 import { NewV1ObjectMeta, NewV1Ownership } from '../../../utils/model'
 import { getKoreLabel } from '../../../utils/crd-helpers'
+import { errorMessage, loadingMessage } from '../../../../utils/message'
 
 class ApplicationServiceForm extends React.Component {
   static propTypes = {
@@ -107,14 +108,14 @@ class ApplicationServiceForm extends React.Component {
 
     this.validatedFormsFields(async (err, values) => {
       if (err) {
-        message.error('Validation failed')
+        errorMessage('Validation failed')
         this.setState({ submitting: false, formErrorMessage: 'Validation failed' })
         return
       }
       try {
         const existing = await (await KoreApi.client()).GetService(this.props.team.metadata.name, values.serviceName)
         if (existing) {
-          message.error('Validation failed')
+          errorMessage('Validation failed')
           return this.setState({
             submitting: false,
             formErrorMessage: `A service with the name "${values.serviceName}" already exists in this team.`
@@ -122,12 +123,12 @@ class ApplicationServiceForm extends React.Component {
         }
 
         const service = await (await KoreApi.client()).UpdateService(this.props.team.metadata.name, values.serviceName, this.generateServiceResource(values))
-        message.loading('Application service requested...')
+        loadingMessage('Application service requested...')
 
         return this.props.handleSubmit(service)
       } catch (err) {
         console.error('Error saving application service', err)
-        message.error('Error requesting application service, please try again.')
+        errorMessage('Error requesting application service, please try again.')
         this.setState({
           submitting: false,
           formErrorMessage: (err.fieldErrors && err.message) ? err.message : 'An error occurred requesting the application service, please try again',

--- a/ui/lib/components/teams/service/ApplicationServiceForm.js
+++ b/ui/lib/components/teams/service/ApplicationServiceForm.js
@@ -9,7 +9,7 @@ import V1ServiceSpec from '../../../kore-api/model/V1ServiceSpec'
 import V1Service from '../../../kore-api/model/V1Service'
 import { NewV1ObjectMeta, NewV1Ownership } from '../../../utils/model'
 import { getKoreLabel } from '../../../utils/crd-helpers'
-import { errorMessage, loadingMessage } from '../../../../utils/message'
+import { errorMessage, loadingMessage } from '../../../utils/message'
 
 class ApplicationServiceForm extends React.Component {
   static propTypes = {

--- a/ui/lib/components/teams/service/Service.js
+++ b/ui/lib/components/teams/service/Service.js
@@ -8,7 +8,7 @@ import ResourceStatusTag from '../../resources/ResourceStatusTag'
 import AutoRefreshComponent from '../AutoRefreshComponent'
 import Link from 'next/link'
 import { getKoreLabel, isReadOnlyCRD } from '../../../utils/crd-helpers'
-import { successMessage } from '../../../utils/message'
+import { successMessage, errorMessage } from '../../../utils/message'
 
 class Service extends AutoRefreshComponent {
   static propTypes = {

--- a/ui/lib/components/teams/service/Service.js
+++ b/ui/lib/components/teams/service/Service.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Icon, Typography, Popconfirm, message, Tooltip, Avatar, Tag } from 'antd'
+import { List, Icon, Typography, Popconfirm, Tooltip, Avatar, Tag } from 'antd'
 const { Text } = Typography
 
 import { inProgressStatusList } from '../../../utils/ui-helpers'
@@ -8,6 +8,7 @@ import ResourceStatusTag from '../../resources/ResourceStatusTag'
 import AutoRefreshComponent from '../AutoRefreshComponent'
 import Link from 'next/link'
 import { getKoreLabel, isReadOnlyCRD } from '../../../utils/crd-helpers'
+import { successMessage } from '../../../utils/message'
 
 class Service extends AutoRefreshComponent {
   static propTypes = {
@@ -23,13 +24,13 @@ class Service extends AutoRefreshComponent {
     const { service } = this.props
     const { status, deleted } = service
     if (deleted) {
-      return message.success(`Service successfully deleted: ${service.metadata.name}`)
+      return successMessage(`Service successfully deleted: ${service.metadata.name}`)
     }
     if (status.status === 'Success') {
-      return message.success(`Service successfully created: ${service.metadata.name}`)
+      return successMessage(`Service successfully created: ${service.metadata.name}`)
     }
     if (status.status === 'Failure') {
-      return message.error(`Service failed to create: ${service.metadata.name}`)
+      return errorMessage(`Service failed to create: ${service.metadata.name}`)
     }
   }
 

--- a/ui/lib/components/teams/service/ServiceBuildForm.js
+++ b/ui/lib/components/teams/service/ServiceBuildForm.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import { Alert, Button, Card, Checkbox, Col, Collapse, Form, Icon, Input, message, Row, Typography, Select } from 'antd'
+import { Alert, Button, Card, Checkbox, Col, Collapse, Form, Icon, Input, Row, Typography, Select } from 'antd'
 const { Paragraph, Text } = Typography
 const { Panel } = Collapse
 
@@ -16,6 +16,7 @@ import V1ServiceCredentials from '../../../kore-api/model/V1ServiceCredentials'
 import V1ServiceCredentialsSpec from '../../../kore-api/model/V1ServiceCredentialsSpec'
 import { NewV1ObjectMeta, NewV1Ownership } from '../../../utils/model'
 import { getKoreLabel } from '../../../utils/crd-helpers'
+import { errorMessage, loadingMessage } from '../../../utils/message'
 
 class ServiceBuildForm extends React.Component {
   static propTypes = {
@@ -199,7 +200,7 @@ class ServiceBuildForm extends React.Component {
       try {
         const api = await KoreApi.client()
         const service = await api.UpdateService(this.props.team.metadata.name, values.serviceName, this.getServiceResource(values))
-        message.loading('Service build requested...')
+        loadingMessage('Service build requested...')
 
         if (this.state.bindingsToCreate.length > 0) {
           await asyncForEach(this.state.bindingsToCreate, async (bindingNamespace) => {
@@ -210,10 +211,10 @@ class ServiceBuildForm extends React.Component {
               const credentialName = `${cluster.metadata.name}-${namespaceClaim.spec.name}-${secretName}`
               const resource = this.getServiceCredentialsResource(credentialName, secretName, service, cluster, namespaceClaim)
               await api.UpdateServiceCredentials(this.props.team.metadata.name, credentialName, resource)
-              message.loading(`Service access for namespace "${namespaceClaim.spec.name}" requested...`)
+              loadingMessage(`Service access for namespace "${namespaceClaim.spec.name}" requested...`)
             } catch (error) {
               console.error('Error creating service binding', error)
-              message.error(`Failed to create service access for namespace "${namespaceClaim.spec.name}"`)
+              errorMessage(`Failed to create service access for namespace "${namespaceClaim.spec.name}"`)
             }
           })
         }

--- a/ui/lib/components/teams/service/ServiceCredential.js
+++ b/ui/lib/components/teams/service/ServiceCredential.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import moment from 'moment'
-import { Divider, List, Icon, Typography, Popconfirm, message, Tooltip, Tag } from 'antd'
+import { Divider, List, Icon, Typography, Popconfirm, Tooltip, Tag } from 'antd'
 const { Text } = Typography
 
 import ServiceCredentialSnippet from './ServiceCredentialSnippet'
 import { inProgressStatusList } from '../../../utils/ui-helpers'
 import ResourceStatusTag from '../../resources/ResourceStatusTag'
 import AutoRefreshComponent from '../AutoRefreshComponent'
+import { successMessage, errorMessage } from '../../../utils/message'
 
 class ServiceCredential extends AutoRefreshComponent {
   static propTypes = {
@@ -23,13 +24,13 @@ class ServiceCredential extends AutoRefreshComponent {
     const { serviceCredential } = this.props
     const { status, deleted } = serviceCredential
     if (deleted) {
-      return message.success(`Service access successfully deleted for service "${serviceCredential.spec.service.name}"`)
+      return successMessage(`Service access successfully deleted for service "${serviceCredential.spec.service.name}"`)
     }
     if (status.status === 'Success') {
-      return message.success(`Service access successfully created for service "${serviceCredential.spec.service.name}"`)
+      return successMessage(`Service access successfully created for service "${serviceCredential.spec.service.name}"`)
     }
     if (status.status === 'Failure') {
-      return message.error(`Service access failed to create for service "${serviceCredential.spec.service.name}"`)
+      return errorMessage(`Service access failed to create for service "${serviceCredential.spec.service.name}"`)
     }
   }
 

--- a/ui/lib/components/teams/service/ServicesTab.js
+++ b/ui/lib/components/teams/service/ServicesTab.js
@@ -10,7 +10,7 @@ import Service from './Service'
 import ServiceBuildForm from './ServiceBuildForm'
 import ApplicationServiceForm from './ApplicationServiceForm'
 import { inProgressStatusList, statusColorMap, statusIconMap } from '../../../utils/ui-helpers'
-import { loadingMessage } from '../../../utils/message'
+import { loadingMessage, errorMessage } from '../../../utils/message'
 
 class ServicesTab extends React.Component {
 

--- a/ui/lib/components/teams/service/ServicesTab.js
+++ b/ui/lib/components/teams/service/ServicesTab.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import moment from 'moment'
 import PropTypes from 'prop-types'
-import { Button, Col, Divider, Drawer, Icon, List, message, Modal, Row, Tooltip, Tag, Typography } from 'antd'
+import { Button, Col, Divider, Drawer, Icon, List, Modal, Row, Tooltip, Tag, Typography } from 'antd'
 const { Paragraph, Text } = Typography
 
 import KoreApi from '../../../kore-api'
@@ -10,6 +10,7 @@ import Service from './Service'
 import ServiceBuildForm from './ServiceBuildForm'
 import ApplicationServiceForm from './ApplicationServiceForm'
 import { inProgressStatusList, statusColorMap, statusIconMap } from '../../../utils/ui-helpers'
+import { loadingMessage } from '../../../utils/message'
 
 class ServicesTab extends React.Component {
 
@@ -113,10 +114,10 @@ class ServicesTab extends React.Component {
       service.status.status = 'Deleting'
       service.metadata.deletionTimestamp = new Date()
       this.setState({ services }, done)
-      message.loading(`Service deletion requested: ${service.metadata.name}`)
+      loadingMessage(`Service deletion requested: ${service.metadata.name}`)
     } catch (err) {
       console.error('Error deleting service', err)
-      message.error('Error deleting service, please try again.')
+      errorMessage('Error deleting service, please try again.')
     }
   }
 

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -122,6 +122,7 @@ class KoreApiClient {
   ListGKECredentials = (team) => this.apis.default.ListGKECredentials({ team })
   GetGKECredential = (team, name) => this.apis.default.GetGKECredential({ team, name })
   UpdateGKECredential = (team, name, resource) => this.apis.default.UpdateGKECredential({ team, name, body: JSON.stringify(resource) })
+  RemoveGKECredential = (team, name) => this.apis.default.RemoveGKECredential({ team, name })
   ListGCPOrganizations = (team) => this.apis.default.ListGCPOrganizations({ team })
   GetGCPOrganization = (team, name) => this.apis.default.GetGCPOrganization({ team, name })
   UpdateGCPOrganization = (team, name, org) => this.apis.default.UpdateGCPOrganization({ team, name, body: JSON.stringify(org) })

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -129,6 +129,7 @@ class KoreApiClient {
   ListEKSCredentials = (team) => this.apis.default.ListEKSCredentials({ team })
   GetEKSCredentials = (team, name) => this.apis.default.GetEKSCredentials({ team, name })
   UpdateEKSCredentials = (team, name, resource) => this.apis.default.UpdateEKSCredentials({ team, name, body: JSON.stringify(resource) })
+  DeleteEKSCredentials = (team, name) => this.apis.default.DeleteEKSCredentials({ team, name })
 
   // Teams
   GetTeam = (team) => this.apis.default.GetTeam({ team })

--- a/ui/lib/prototype/components/configure/ProjectAutomationSettings.js
+++ b/ui/lib/prototype/components/configure/ProjectAutomationSettings.js
@@ -9,6 +9,7 @@ import PlanViewer from '../../../components/plans/PlanViewer'
 
 // prototype components
 import AutomatedProjectForm from './AutomatedProjectForm'
+import { successMessage } from '../../../utils/message'
 
 class ProjectAutomationSettings extends React.Component {
 

--- a/ui/lib/prototype/components/configure/ProjectAutomationSettings.js
+++ b/ui/lib/prototype/components/configure/ProjectAutomationSettings.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Alert, Card, Typography, Tooltip, Icon, Row, Col, Button, Form, Input, Radio, List, Drawer, Popover, Modal, message } from 'antd'
+import { Alert, Card, Typography, Tooltip, Icon, Row, Col, Button, Form, Input, Radio, List, Drawer, Popover, Modal } from 'antd'
 const { Title, Text, Paragraph } = Typography
 
 import KoreApi from '../../../kore-api'
@@ -56,7 +56,7 @@ class ProjectAutomationSettings extends React.Component {
       this.setState({
         gcpProjectList: this.state.gcpProjectList.filter(p => p.code !== code)
       })
-      message.success('GCP automated project removed')
+      successMessage('GCP automated project removed')
     }
   }
 
@@ -88,7 +88,7 @@ class ProjectAutomationSettings extends React.Component {
       const gcpProjectList = copy(this.state.gcpProjectList)
       gcpProjectList.find(p => p.code === projectCode).plans.push(plan)
       this.setState({ gcpProjectList })
-      message.success('Plan associated')
+      successMessage('Plan associated')
     }
   }
 
@@ -124,7 +124,7 @@ class ProjectAutomationSettings extends React.Component {
       const project = gcpProjectList.find(p => p.code === projectCode)
       project.plans = project.plans.filter(p => p !== plan)
       this.setState({ gcpProjectList })
-      message.success('Plan unassociated')
+      successMessage('Plan unassociated')
     }
   }
 
@@ -138,7 +138,7 @@ class ProjectAutomationSettings extends React.Component {
       gcpProjectList: this.state.gcpProjectList.concat([{ code, plans: [], ...project }]),
       addProject: false
     })
-    message.success('GCP automated project added')
+    successMessage('GCP automated project added')
   }
 
   infoModal = ({ title, content }) => {

--- a/ui/lib/prototype/components/credentials/GCPOrganization.js
+++ b/ui/lib/prototype/components/credentials/GCPOrganization.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Avatar, Icon, Typography, message, Tooltip } from 'antd'
+import { List, Avatar, Icon, Typography, Tooltip } from 'antd'
 const { Text } = Typography
 
 import ResourceVerificationStatus from '../../../components/resources/ResourceVerificationStatus'
 import AutoRefreshComponent from '../../../components/teams/AutoRefreshComponent'
+import { successMessage, errorMessage } from '../../../utils/message'
 
 class GCPOrganization extends AutoRefreshComponent {
   static propTypes = {
@@ -25,10 +26,10 @@ class GCPOrganization extends AutoRefreshComponent {
     const { organization } = this.props
     const { allocation, status } = organization
     if (status.status === 'Success') {
-      return message.success(`GCP organization "${allocation.spec.name}" created successfully`)
+      return successMessage(`GCP organization "${allocation.spec.name}" created successfully`)
     }
     if (status.status === 'Failure') {
-      return message.error(`GCP organization "${allocation.spec.name}" failed to be created`)
+      return errorMessage(`GCP organization "${allocation.spec.name}" failed to be created`)
     }
   }
 

--- a/ui/lib/prototype/components/forms/VerifiedAllocatedResourceForm.js
+++ b/ui/lib/prototype/components/forms/VerifiedAllocatedResourceForm.js
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import { message, Typography, Form, Card, Alert, Button, Input } from 'antd'
+import { Typography, Form, Card, Alert, Button, Input } from 'antd'
 const { Paragraph, Text } = Typography
 
 import canonical from '../../../utils/canonical'
 import ResourceVerificationStatus from '../../../components/resources/ResourceVerificationStatus'
 import FormErrorMessage from '../../../components/forms/FormErrorMessage'
 import AllocationHelpers from '../../../utils/allocation-helpers'
+import { successMessage, loadingMessage, errorMessage } from '../../../utils/message'
 
 class VerifiedAllocatedResourceForm extends React.Component {
   static propTypes = {
@@ -64,10 +65,10 @@ class VerifiedAllocatedResourceForm extends React.Component {
     const messageKey = 'verify'
     tryCount = tryCount || 0
     if (tryCount === 0) {
-      message.loading({ content: 'Verifying credentials', key: messageKey, duration: 0 })
+      loadingMessage('Verifying credentials', { key: messageKey, duration: 0 })
     }
     if (tryCount === 3) {
-      message.error({ content: 'Credentials verification failed', key: messageKey })
+      errorMessage('Credentials verification failed', { key: messageKey })
       this.setState({
         ...this.state,
         inlineVerificationFailed: true,
@@ -89,7 +90,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
       setTimeout(async () => {
         const resourceResult = await this.getResource(resource.metadata.name)
         if (resourceResult.status.status === 'Success') {
-          message.success({ content: 'Credentials verification successful', key: messageKey })
+          successMessage({ content: 'Credentials verification successful', key: messageKey })
           return await this.props.handleSubmit(resourceResult)
         }
         return await this.verify(resourceResult, tryCount + 1)

--- a/ui/lib/prototype/components/forms/VerifiedAllocatedResourceForm.js
+++ b/ui/lib/prototype/components/forms/VerifiedAllocatedResourceForm.js
@@ -90,7 +90,7 @@ class VerifiedAllocatedResourceForm extends React.Component {
       setTimeout(async () => {
         const resourceResult = await this.getResource(resource.metadata.name)
         if (resourceResult.status.status === 'Success') {
-          successMessage({ content: 'Credentials verification successful', key: messageKey })
+          successMessage('Credentials verification successful', { key: messageKey })
           return await this.props.handleSubmit(resourceResult)
         }
         return await this.verify(resourceResult, tryCount + 1)

--- a/ui/lib/prototype/components/teams/cluster/Cluster.js
+++ b/ui/lib/prototype/components/teams/cluster/Cluster.js
@@ -7,7 +7,7 @@ import { inProgressStatusList } from '../../../../utils/ui-helpers'
 import ResourceStatusTag from '../../../../components/resources/ResourceStatusTag'
 import AutoRefreshComponent from '../../../../components/teams/AutoRefreshComponent'
 import Link from 'next/link'
-import { successMessage } from '../../../../utils/message'
+import { successMessage, errorMessage } from '../../../../utils/message'
 
 const clusterProviderIconSrcMap = {
   'GKE': '/static/images/GKE.png',

--- a/ui/lib/prototype/components/teams/cluster/Cluster.js
+++ b/ui/lib/prototype/components/teams/cluster/Cluster.js
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Icon, Typography, Modal, Popconfirm, message, Tooltip } from 'antd'
+import { List, Icon, Typography, Modal, Popconfirm, Tooltip } from 'antd'
 const { Text, Paragraph } = Typography
 
 import { inProgressStatusList } from '../../../../utils/ui-helpers'
 import ResourceStatusTag from '../../../../components/resources/ResourceStatusTag'
 import AutoRefreshComponent from '../../../../components/teams/AutoRefreshComponent'
 import Link from 'next/link'
+import { successMessage } from '../../../../utils/message'
 
 const clusterProviderIconSrcMap = {
   'GKE': '/static/images/GKE.png',
@@ -25,13 +26,13 @@ class Cluster extends AutoRefreshComponent {
     const { cluster } = this.props
     const { status, deleted } = cluster
     if (deleted) {
-      return message.success(`Cluster successfully deleted: ${cluster.metadata.name}`)
+      return successMessage(`Cluster successfully deleted: ${cluster.metadata.name}`)
     }
     if (status.status === 'Success') {
-      return message.success(`Cluster successfully created: ${cluster.metadata.name}`)
+      return successMessage(`Cluster successfully created: ${cluster.metadata.name}`)
     }
     if (status.status === 'Failure') {
-      return message.error(`Cluster failed to create: ${cluster.metadata.name}`)
+      return errorMessage(`Cluster failed to create: ${cluster.metadata.name}`)
     }
   }
 

--- a/ui/lib/prototype/components/teams/cluster/ClustersTab.js
+++ b/ui/lib/prototype/components/teams/cluster/ClustersTab.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import Link from 'next/link'
-import { Button, Col, Divider, Icon, message, Row, Tag, Tooltip, Typography } from 'antd'
+import { Button, Col, Divider, Icon, Row, Tag, Tooltip, Typography } from 'antd'
 const { Paragraph, Text } = Typography
 import { get } from 'lodash'
 
@@ -12,6 +12,7 @@ import KoreApi from '../../../../kore-api'
 import copy from '../../../../utils/object-copy'
 import { inProgressStatusList, statusColorMap, statusIconMap } from '../../../../utils/ui-helpers'
 import { featureEnabled, KoreFeatures } from '../../../../utils/features'
+import { errorMessage, loadingMessage } from '../../../../utils/message'
 
 // prototype imports
 import TeamData from '../../../utils/dummy-team-data'
@@ -105,10 +106,10 @@ class ClustersTab extends React.Component {
       cluster.status.status = 'Deleting'
       cluster.metadata.deletionTimestamp = new Date()
       this.setState({ clusters }, done)
-      message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
+      loadingMessage(`Cluster deletion requested: ${cluster.metadata.name}`)
     } catch (err) {
       console.error('Error deleting cluster', err)
-      message.error('Error deleting cluster, please try again.')
+      errorMessage('Error deleting cluster, please try again.')
     }
   }
 

--- a/ui/lib/prototype/components/teams/namespace/NamespaceClaim.js
+++ b/ui/lib/prototype/components/teams/namespace/NamespaceClaim.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { List, Avatar, Icon, Typography, Popconfirm, message } from 'antd'
+import { List, Avatar, Icon, Typography, Popconfirm } from 'antd'
 const { Text } = Typography
 
 import ResourceStatusTag from '../../../../components/resources/ResourceStatusTag'
 import AutoRefreshComponent from '../../../../components/teams/AutoRefreshComponent'
+import { successMessage, errorMessage } from '../../../../utils/message'
 
 class NamespaceClaim extends AutoRefreshComponent {
   static propTypes = {
@@ -17,13 +18,13 @@ class NamespaceClaim extends AutoRefreshComponent {
     const { namespaceClaim } = this.props
     const { spec, status, deleted } = namespaceClaim
     if (deleted) {
-      return message.success(`Namespace "${spec.name}" successfully deleted`)
+      return successMessage(`Namespace "${spec.name}" successfully deleted`)
     }
     if (status.status === 'Success') {
-      return message.success(`Namespace "${spec.name}" created on cluster "${spec.cluster.name}"`)
+      return successMessage(`Namespace "${spec.name}" created on cluster "${spec.cluster.name}"`)
     }
     if (status.status === 'Failure') {
-      return message.error(`Namespace "${spec.name}" failed to create on cluster "${spec.cluster.name}"`)
+      return errorMessage(`Namespace "${spec.name}" failed to create on cluster "${spec.cluster.name}"`)
     }
   }
 

--- a/ui/lib/utils/message.js
+++ b/ui/lib/utils/message.js
@@ -1,0 +1,74 @@
+import { notification, Icon } from 'antd'
+
+/**
+ * Shows a message to indicate the successful completion of an operation.
+ * @param {string} message 
+ * @param {messageOpts} opts 
+ * @returns {string} key which can be used to update message, e.g. warningMessage('warning!!', { key })
+ */
+export function successMessage(message, opts) {
+  return showMessage('success', message, null, opts)
+}
+
+/**
+ * Shows a message to indicate an operation is ongoing.
+ * @param {string} message 
+ * @param {messageOpts} opts 
+ * @returns {string} key which can be used to update message, e.g. successMessage('completed!!', { key })
+ */
+export function loadingMessage(message, opts) {
+  return showMessage('open', message, <Icon type="loading" />, opts)
+}
+
+/**
+ * Shows a message to indicate the failure of an operation.
+ * @param {string} message 
+ * @param {messageOpts} opts 
+ * @returns {string} key which can be used to update message, e.g. successMessage('completed!!', { key })
+ */
+export function errorMessage(message, opts) {
+  return showMessage('error', message, null, opts)
+}
+
+/**
+ * Shows a message to warn the user of something.
+ * @param {string} message 
+ * @param {messageOpts} opts 
+ * @returns {string} key which can be used to update message, e.g. successMessage('completed!!', { key })
+ */
+export function warningMessage(message, opts) {
+  return showMessage('warning', message, null, opts)
+}
+
+class messageOpts {
+  /**
+   * Duration to show the message in seconds, 0 for indefinite.
+   */
+  duration
+  /**
+   * Key to identify message - use the same key on multiple messages
+   * to update a message.
+   */
+  key
+  /**
+   * Extended description for the message.
+   */
+  description
+}
+
+function showMessage(type, message, icon, opts) {
+  if (!opts) {
+    opts = {}
+  }
+  const key = opts.key || Math.random().toString(36).substr(2, 5)
+  const duration = opts.duration || 2.5
+  notification[type]({
+    icon,
+    message,
+    duration,
+    key,
+    placement: 'bottomRight',
+    description: opts.description
+  })
+  return key
+}

--- a/ui/lib/utils/message.js
+++ b/ui/lib/utils/message.js
@@ -40,7 +40,7 @@ export function warningMessage(message, opts) {
   return showMessage('warning', message, null, opts)
 }
 
-class messageOpts {
+export class messageOpts {
   /**
    * Duration to show the message in seconds, 0 for indefinite.
    */

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2978,6 +2978,45 @@
         "minimist": "^1.2.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "dev": true
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
+    "@hapi/hoek": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "dev": true
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -3423,12 +3462,6 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
     },
-    "@types/mime-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
-      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
-      "dev": true
-    },
     "@types/node": {
       "version": "12.12.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
@@ -3486,6 +3519,16 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/experimental-utils": {
       "version": "2.12.0",
@@ -4609,6 +4652,40 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -5996,6 +6073,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
       "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
     },
+    "cwd": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+      "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
+      "dev": true,
+      "requires": {
+        "find-pkg": "^0.1.2",
+        "fs-exists-sync": "^0.1.0"
+      }
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -7017,6 +7104,15 @@
         }
       }
     },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.1"
+      }
+    },
     "expect": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
@@ -7030,6 +7126,12 @@
         "jest-message-util": "^24.9.0",
         "jest-regex-util": "^24.9.0"
       }
+    },
+    "expect-puppeteer": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz",
+      "integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
+      "dev": true
     },
     "express": {
       "version": "4.17.1",
@@ -7253,46 +7355,25 @@
       }
     },
     "extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
+      "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "pump": "^3.0.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -7472,6 +7553,53 @@
         }
       }
     },
+    "find-file-up": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "^0.1.0",
+        "resolve-dir": "^0.1.0"
+      }
+    },
+    "find-pkg": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+      "dev": true,
+      "requires": {
+        "find-file-up": "^0.1.2"
+      }
+    },
+    "find-process": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.3.tgz",
+      "integrity": "sha512-+IA+AUsQCf3uucawyTwMWcY+2M3FXq3BRvw3S+j5Jvydjk31f/+NPWpYZOJs+JUs2GvxH4Yfr6Wham0ZtRLlPA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "commander": "^2.11.0",
+        "debug": "^2.6.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -7544,6 +7672,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -7691,6 +7828,18 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+      "dev": true
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -8296,6 +8445,44 @@
         "ini": "^1.3.4"
       }
     },
+    "global-modules": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+          "dev": true
+        }
+      }
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+          "dev": true
+        }
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -8479,6 +8666,15 @@
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
       "requires": {
         "react-is": "^16.7.0"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -9581,6 +9777,73 @@
         "realpath-native": "^1.1.0"
       }
     },
+    "jest-dev-server": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.4.0.tgz",
+      "integrity": "sha512-STEHJ3iPSC8HbrQ3TME0ozGX2KT28lbT4XopPxUm2WimsX3fcB3YOptRh12YphQisMhfqNSNTZUmWyT3HEXS2A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "cwd": "^0.10.0",
+        "find-process": "^1.4.3",
+        "prompts": "^2.3.0",
+        "spawnd": "^4.4.0",
+        "tree-kill": "^1.2.2",
+        "wait-on": "^3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-diff": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
@@ -9640,6 +9903,70 @@
         "@jest/types": "^24.9.0",
         "jest-mock": "^24.9.0",
         "jest-util": "^24.9.0"
+      }
+    },
+    "jest-environment-puppeteer": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.4.0.tgz",
+      "integrity": "sha512-iV8S8+6qkdTM6OBR/M9gKywEk8GDSOe05hspCs5D8qKSwtmlUfdtHfB4cakdc68lC6YfK3AUsLirpfgodCHjzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "cwd": "^0.10.0",
+        "jest-dev-server": "^4.4.0",
+        "merge-deep": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-get-type": {
@@ -9744,6 +10071,16 @@
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
       "dev": true
+    },
+    "jest-puppeteer": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.4.0.tgz",
+      "integrity": "sha512-ZaiCTlPZ07B9HW0erAWNX6cyzBqbXMM7d2ugai4epBDKpKvRDpItlRQC6XjERoJELKZsPziFGS0OhhUvTvQAXA==",
+      "dev": true,
+      "requires": {
+        "expect-puppeteer": "^4.4.0",
+        "jest-environment-puppeteer": "^4.4.0"
+      }
     },
     "jest-regex-util": {
       "version": "24.9.0",
@@ -10187,6 +10524,12 @@
         "package-json": "^4.0.0"
       }
     },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -10461,6 +10804,70 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "merge-deep": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+      "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "clone-deep": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+          "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+          "dev": true,
+          "requires": {
+            "for-own": "^0.1.3",
+            "is-plain-object": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "lazy-cache": "^1.0.3",
+            "shallow-clone": "^0.1.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "shallow-clone": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+          "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.1",
+            "kind-of": "^2.0.1",
+            "lazy-cache": "^0.2.3",
+            "mixin-object": "^2.0.1"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.0.2"
+              }
+            },
+            "lazy-cache": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -10672,6 +11079,24 @@
         }
       }
     },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+          "dev": true
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -10686,6 +11111,12 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
     },
     "moment": {
       "version": "2.24.0",
@@ -12644,6 +13075,12 @@
         "is-hexadecimal": "^1.0.0"
       }
     },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -13601,52 +14038,43 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
-      "integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-3.3.0.tgz",
+      "integrity": "sha512-23zNqRltZ1PPoK28uRefWJ/zKb5Jhnzbbwbpcna2o5+QMn17F0khq5s1bdH3vPlyj+J36pubccR8wiNA/VE0Vw==",
       "dev": true,
       "requires": {
-        "@types/mime-types": "^2.1.0",
         "debug": "^4.1.0",
-        "extract-zip": "^1.6.6",
+        "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
         "mime": "^2.0.3",
-        "mime-types": "^2.1.25",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^6.1.0"
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
         },
-        "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
-            "mime-db": "1.43.0"
+            "glob": "^7.1.3"
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+          "dev": true
         }
       }
     },
@@ -14766,6 +15194,16 @@
         "resolve-from": "^3.0.0"
       }
     },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
+      }
+    },
     "resolve-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
@@ -14895,6 +15333,12 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
     },
     "rxjs": {
       "version": "6.5.3",
@@ -15415,6 +15859,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "spawnd": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.4.0.tgz",
+      "integrity": "sha512-jLPOfB6QOEgMOQY15Z6+lwZEhH3F5ncXxIaZ7WHPIapwNNLyjrs61okj3VJ3K6tmP5TZ6cO0VAu9rEY4MD4YQg==",
+      "dev": true,
+      "requires": {
+        "exit": "^0.1.2",
+        "signal-exit": "^3.0.2",
+        "tree-kill": "^1.2.2",
+        "wait-port": "^0.2.7"
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -15968,6 +16424,44 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
+    "tar-fs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -16294,6 +16788,12 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -16411,6 +16911,28 @@
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
       "requires": {
         "random-bytes": "~1.0.0"
+      }
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
       }
     },
     "undefsafe": {
@@ -16819,6 +17341,38 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "wait-on": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
+      "integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/joi": "^15.0.3",
+        "core-js": "^2.6.5",
+        "minimist": "^1.2.0",
+        "request": "^2.88.0",
+        "rx": "^4.1.0"
+      }
+    },
+    "wait-port": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.9.tgz",
+      "integrity": "sha512-hQ/cVKsNqGZ/UbZB/oakOGFqic00YAMM5/PEj3Bt4vKarv2jWIWzDbqlwT94qMs/exAQAsvMOq99sZblV92zxQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^3.0.2",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+          "dev": true
+        }
       }
     },
     "walker": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "nodemon",
-    "test": "jest --testPathPattern unit",
+    "test": "jest --verbose --testPathPattern __tests__/unit",
     "test-watch": "npm test -- --watch",
-    "test-e2e": "jest --testPathPattern e2e",
+    "test-e2e": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/*.test.js",
     "build": "next build",
     "start": "NODE_ENV=production node server/index.js",
     "lint": "eslint ."
@@ -47,11 +47,12 @@
     "eslint-plugin-jest": "^23.1.1",
     "eslint-plugin-react": "^7.17.0",
     "jest": "^24.9.0",
+    "jest-puppeteer": "^4.4.0",
     "jest-when": "^2.7.0",
     "mini-css-extract-plugin": "^0.8.0",
     "nock": "^12.0.3",
     "nodemon": "^1.19.4",
-    "puppeteer": "^2.1.1",
+    "puppeteer": "^3.3.0",
     "react-test-renderer": "^16.12.0"
   },
   "license": "ISC"

--- a/ui/pages/configure/cloud/[[...cloud]].js
+++ b/ui/pages/configure/cloud/[[...cloud]].js
@@ -65,43 +65,45 @@ export default class ConfigureCloudPage extends React.Component {
       <>
         <Breadcrumb items={[{ text: 'Configure' }, { text: 'Cloud' }]} />
         <CloudTabs selectedKey={selectedCloud} handleSelectCloud={this.handleSelectCloud}/>
-        {selectedCloud === 'GCP' ? (
-          <Tabs activeKey={activeKeys['GCP']} onChange={(key) => this.handleSelectKey('GCP', key)} destroyInactiveTabPane={true} tabPosition="left" style={{ marginTop: '20px' }}>
-            <Tabs.TabPane tab="Organization credentials" key="orgs">
-              <GCPOrganizationsList autoAllocateToAllTeams={true} />
-            </Tabs.TabPane>
-            <Tabs.TabPane tab="Project credentials" key="projects">
-              <GKECredentialsList />
-            </Tabs.TabPane>
-            <Tabs.TabPane tab="Project automation" key="project_automation">
-              <GCPProjectAutomationSettings />
-            </Tabs.TabPane>
-            <Tabs.TabPane tab="Cluster Plans" key="plans">
-              <PlanList kind="GKE" />
-            </Tabs.TabPane>
-            <Tabs.TabPane tab="Cluster Policies" key="policies">
-              <PolicyList kind="GKE"/>
-            </Tabs.TabPane>
-          </Tabs>
-        ) : null}
-        {selectedCloud === 'AWS' ? (
-          <Tabs activeKey={activeKeys['AWS']} onChange={(key) => this.handleSelectKey('AWS', key)} destroyInactiveTabPane={true} tabPosition="left" style={{ marginTop: '20px' }}>
-            <Tabs.TabPane tab="Account credentials" key="accounts">
-              <EKSCredentialsList />
-            </Tabs.TabPane>
-            <Tabs.TabPane tab="Cluster Plans" key="plans">
-              <PlanList kind="EKS" />
-            </Tabs.TabPane>
-            <Tabs.TabPane tab="Cluster Policies" key="policies">
-              <PolicyList kind="EKS" />
-            </Tabs.TabPane>
-            {!featureEnabled(KoreFeatures.SERVICES) ? null :
-              <Tabs.TabPane tab="Cloud Services" key="services">
-                <CloudServiceAdmin cloud="AWS" />
+        <div id="cloud_subtabs">
+          {selectedCloud === 'GCP' ? (
+            <Tabs activeKey={activeKeys['GCP']} onChange={(key) => this.handleSelectKey('GCP', key)} destroyInactiveTabPane={true} tabPosition="left" style={{ marginTop: '20px' }}>
+              <Tabs.TabPane tab="Organization credentials" key="orgs">
+                <GCPOrganizationsList autoAllocateToAllTeams={true} />
               </Tabs.TabPane>
-            }
-          </Tabs>
-        ) : null}
+              <Tabs.TabPane tab="Project credentials" key="projects">
+                <GKECredentialsList />
+              </Tabs.TabPane>
+              <Tabs.TabPane tab="Project automation" key="project_automation">
+                <GCPProjectAutomationSettings />
+              </Tabs.TabPane>
+              <Tabs.TabPane tab="Cluster Plans" key="plans">
+                <PlanList kind="GKE" />
+              </Tabs.TabPane>
+              <Tabs.TabPane tab="Cluster Policies" key="policies">
+                <PolicyList kind="GKE"/>
+              </Tabs.TabPane>
+            </Tabs>
+          ) : null}
+          {selectedCloud === 'AWS' ? (
+            <Tabs activeKey={activeKeys['AWS']} onChange={(key) => this.handleSelectKey('AWS', key)} destroyInactiveTabPane={true} tabPosition="left" style={{ marginTop: '20px' }}>
+              <Tabs.TabPane tab="Account credentials" key="accounts">
+                <EKSCredentialsList />
+              </Tabs.TabPane>
+              <Tabs.TabPane tab="Cluster Plans" key="plans">
+                <PlanList kind="EKS" />
+              </Tabs.TabPane>
+              <Tabs.TabPane tab="Cluster Policies" key="policies">
+                <PolicyList kind="EKS" />
+              </Tabs.TabPane>
+              {!featureEnabled(KoreFeatures.SERVICES) ? null :
+                <Tabs.TabPane tab="Cloud Services" key="services">
+                  <CloudServiceAdmin cloud="AWS" />
+                </Tabs.TabPane>
+              }
+            </Tabs>
+          ) : null}
+        </div>
       </>
     )
   }

--- a/ui/pages/configure/users.js
+++ b/ui/pages/configure/users.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Typography, List, Avatar, Tag, message } from 'antd'
+import { Typography, List, Avatar, Tag } from 'antd'
 const { Text } = Typography
 import getConfig from 'next/config'
 const { publicRuntimeConfig } = getConfig()
 
 import KoreApi from '../../lib/kore-api'
 import Breadcrumb from '../../lib/components/layout/Breadcrumb'
+import { successMessage, errorMessage } from '../../lib/utils/message'
 
 class ConfigureUsersPage extends React.Component {
   static propTypes = {
@@ -43,10 +44,10 @@ class ConfigureUsersPage extends React.Component {
         this.setState(state => ({
           admins: [ ...state.admins, username ]
         }))
-        message.success(`${username} is now admin`)
+        successMessage(`${username} is now admin`)
       } catch (err) {
         console.error('Error trying to make admin')
-        message.error(`Failed to make ${username} admin`)
+        errorMessage(`Failed to make ${username} admin`)
       }
     }
   }
@@ -58,10 +59,10 @@ class ConfigureUsersPage extends React.Component {
         this.setState(state => ({
           admins: state.admins.filter(m => m !== username)
         }))
-        message.success(`${username} is no longer admin`)
+        successMessage(`${username} is no longer admin`)
       } catch (err) {
         console.error('Error trying to revoke admin', err)
-        message.error(`Failed to revoke admin from user ${username}`)
+        errorMessage(`Failed to revoke admin from user ${username}`)
       }
     }
   }

--- a/ui/pages/prototype/setup/kore/cloud-access.js
+++ b/ui/pages/prototype/setup/kore/cloud-access.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import { Typography, Card, Alert, Divider, Tooltip, Radio, List, Icon, Steps, Button, Row, Col, Modal , Drawer, Form, Input, Popover, Result, message } from 'antd'
+import { Typography, Card, Alert, Divider, Tooltip, Radio, List, Icon, Steps, Button, Row, Col, Modal , Drawer, Form, Input, Popover, Result } from 'antd'
 const { Title, Text, Paragraph } = Typography
 const { Step } = Steps
 
@@ -16,6 +16,7 @@ const { publicRuntimeConfig } = getConfig()
 // prototype components
 import GCPOrganizationsList from '../../../../lib/prototype/components/credentials/GCPOrganizationsList'
 import AutomatedProjectForm from '../../../../lib/prototype/components/configure/AutomatedProjectForm'
+import { successMessage } from '../../../../lib/utils/message'
 
 class CloudAccessPage extends React.Component {
 
@@ -115,7 +116,7 @@ class CloudAccessPage extends React.Component {
       this.setState({
         gcpProjectList: this.state.gcpProjectList.filter(p => p.code !== code)
       })
-      message.success('GCP automated project removed')
+      successMessage('GCP automated project removed')
     }
   }
 
@@ -150,7 +151,7 @@ class CloudAccessPage extends React.Component {
       const gcpProjectList = copy(this.state.gcpProjectList)
       gcpProjectList.find(p => p.code === projectCode).plans.push(plan)
       this.setState({ gcpProjectList })
-      message.success('Plan associated')
+      successMessage('Plan associated')
     }
   }
 
@@ -186,7 +187,7 @@ class CloudAccessPage extends React.Component {
       const project = gcpProjectList.find(p => p.code === projectCode)
       project.plans = project.plans.filter(p => p !== plan)
       this.setState({ gcpProjectList })
-      message.success('Plan unassociated')
+      successMessage('Plan unassociated')
     }
   }
 
@@ -200,7 +201,7 @@ class CloudAccessPage extends React.Component {
       gcpProjectList: this.state.gcpProjectList.concat([{ code, plans: [], ...project }]),
       addProject: false
     })
-    message.success('GCP automated project added')
+    successMessage('GCP automated project added')
   }
 
   IconTooltip = ({ icon, text }) => (

--- a/ui/pages/prototype/teams/costs-demo.js
+++ b/ui/pages/prototype/teams/costs-demo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Router from 'next/router'
 import Error from 'next/error'
-import { Typography, Button, message, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
+import { Typography, Button, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
 const { Paragraph, Text } = Typography
 const { TabPane } = Tabs
 
@@ -11,6 +11,7 @@ import Breadcrumb from '../../../lib/components/layout/Breadcrumb'
 import redirect from '../../../lib/utils/redirect'
 import KoreApi from '../../../lib/kore-api'
 import SecurityStatusIcon from '../../../lib/components/security/SecurityStatusIcon'
+import { successMessage, errorMessage } from '../../../lib/utils/message'
 
 // prototype imports
 import TeamData from '../../../lib/prototype/utils/dummy-team-data'
@@ -81,11 +82,11 @@ class CostsDemoTeamDashboardPage extends React.Component {
       const team = this.props.team.metadata.name
       await (await KoreApi.client()).RemoveTeam(team)
       this.props.teamRemoved(team)
-      message.success(`Team "${team}" deleted`)
+      successMessage(`Team "${team}" deleted`)
       return redirect({ router: Router, path: '/' })
     } catch (err) {
       console.log('Error deleting team', err)
-      message.error('Team could not be deleted, please try again later')
+      errorMessage('Team could not be deleted, please try again later')
     }
   }
 

--- a/ui/pages/prototype/teams/demo.js
+++ b/ui/pages/prototype/teams/demo.js
@@ -4,7 +4,7 @@ import axios from 'axios'
 import Link from 'next/link'
 import Router from 'next/router'
 import Error from 'next/error'
-import { Typography, Card, List, Tag, Button, Avatar, Popconfirm, message, Select, Drawer, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
+import { Typography, Card, List, Tag, Button, Avatar, Popconfirm, Select, Drawer, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
 const { Paragraph, Text } = Typography
 const { Option } = Select
 const { TabPane } = Tabs
@@ -27,6 +27,7 @@ import TeamData from '../../../lib/prototype/utils/dummy-team-data'
 import Cluster from '../../../lib/prototype/components/teams/cluster/Cluster'
 import NamespaceClaim from '../../../lib/prototype/components/teams/namespace/NamespaceClaim'
 import ServiceForm from '../../../lib/prototype/components/teams/service/ServiceForm'
+import { successMessage, errorMessage, loadingMessage } from '../../../lib/utils/message'
 
 class TeamDashboard extends React.Component {
   static propTypes = {
@@ -140,7 +141,7 @@ class TeamDashboard extends React.Component {
 
     await asyncForEach(this.state.membersToAdd, async member => {
       await apiRequest(null, 'put', `${apiPaths.team(this.props.team.metadata.name).members}/${member}`)
-      message.success(`Team member added: ${member}`)
+      successMessage(`Team member added: ${member}`)
       members.items.push(member)
     })
 
@@ -157,10 +158,10 @@ class TeamDashboard extends React.Component {
         const members = state.members
         members.items = members.items.filter(m => m !== member)
         this.setState(state)
-        message.success(`Team member removed: ${member}`)
+        successMessage(`Team member removed: ${member}`)
       } catch (err) {
         console.error('Error removing team member', err)
-        message.error('Error removing team member, please try again.')
+        errorMessage('Error removing team member, please try again.')
       }
     }
   }
@@ -192,10 +193,10 @@ class TeamDashboard extends React.Component {
       cluster.status.status = 'Deleting'
       cluster.metadata.deletionTimestamp = new Date()
       this.setState(state, done)
-      message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
+      loadingMessage(`Cluster deletion requested: ${cluster.metadata.name}`)
     } catch (err) {
       console.error('Error deleting cluster', err)
-      message.error('Error deleting cluster, please try again.')
+      errorMessage('Error deleting cluster, please try again.')
     }
   }
 
@@ -212,7 +213,7 @@ class TeamDashboard extends React.Component {
     state.createNamespace = false
     state.namespaceClaims.items.push(namespaceClaim)
     this.setState(state)
-    message.loading(`Namespace "${namespaceClaim.spec.name}" requested on cluster "${namespaceClaim.spec.cluster.name}"`)
+    loadingMessage(`Namespace "${namespaceClaim.spec.name}" requested on cluster "${namespaceClaim.spec.cluster.name}"`)
   }
 
   deleteNamespace = async (name, done) => {
@@ -224,10 +225,10 @@ class TeamDashboard extends React.Component {
       namespaceClaim.status.status = 'Deleting'
       namespaceClaim.metadata.deletionTimestamp = new Date()
       this.setState(state, done)
-      message.loading(`Namespace deletion requested: ${namespaceClaim.spec.name}`)
+      loadingMessage(`Namespace deletion requested: ${namespaceClaim.spec.name}`)
     } catch (err) {
       console.error('Error deleting namespace', err)
-      message.error('Error deleting namespace, please try again.')
+      errorMessage('Error deleting namespace, please try again.')
     }
   }
 
@@ -244,11 +245,11 @@ class TeamDashboard extends React.Component {
     state.createCloudService = false
     state.cloudServices.push(cloudService)
     this.setState(state)
-    message.loading(`Cloud service "${cloudService.name}" requested.`)
+    loadingMessage(`Cloud service "${cloudService.name}" requested.`)
   }
 
   deleteCloudService = (name, plan) => () => {
-    message.success(`Cloud service deleted: ${name}`)
+    successMessage(`Cloud service deleted: ${name}`)
     this.setState({ cloudServices: copy(this.state.cloudServices).filter(s => `${s.name}_${s.plan}` !== `${name}_${plan}`) })
   }
 
@@ -301,11 +302,11 @@ class TeamDashboard extends React.Component {
       const api = await KoreApi.client()
       await api.RemoveTeam(team)
       this.props.teamRemoved(team)
-      message.success(`Team "${team}" deleted`)
+      successMessage(`Team "${team}" deleted`)
       return redirect({ router: Router, path: '/' })
     } catch (err) {
       console.log('Error deleting team', err)
-      message.error('Team could not be deleted, please try again later')
+      errorMessage('Team could not be deleted, please try again later')
     }
   }
 

--- a/ui/pages/security/resources/[group]/[version]/[kind]/[namespace]/[name].js
+++ b/ui/pages/security/resources/[group]/[version]/[kind]/[namespace]/[name].js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Typography, message } from 'antd'
+import { Typography } from 'antd'
 const { Title } = Typography
 
 import KoreApi from '../../../../../../../lib/kore-api'
 import Breadcrumb from '../../../../../../../lib/components/layout/Breadcrumb'
 import SecurityScanResult from '../../../../../../../lib/components/security/SecurityScanResult'
+import { errorMessage } from '../../../../../../../lib/utils/message'
 
 export default class SecurityResourcePage extends React.Component {
   static propTypes = {
@@ -41,7 +42,7 @@ export default class SecurityResourcePage extends React.Component {
     } catch (err) {
       console.error('Error loading history', err)
       this.setState({ historyLoading: false })
-      message.error(`Failed to load history for resource ${resource.name}`)
+      errorMessage(`Failed to load history for resource ${resource.name}`)
     }
   }
 

--- a/ui/pages/teams/[name]/[tab].js
+++ b/ui/pages/teams/[name]/[tab].js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Router from 'next/router'
 import Error from 'next/error'
-import { Typography, Button, message, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
+import { Typography, Button, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
 const { Paragraph, Text } = Typography
 const { TabPane } = Tabs
 
@@ -14,6 +14,7 @@ import ClustersTab from '../../../lib/components/teams/cluster/ClustersTab'
 import MembersTab from '../../../lib/components/teams/members/MembersTab'
 import SecurityTab from '../../../lib/components/teams/security/SecurityTab'
 import SecurityStatusIcon from '../../../lib/components/security/SecurityStatusIcon'
+import { successMessage, errorMessage } from '../../../lib/utils/message'
 
 class TeamDashboardTabPage extends React.Component {
   static propTypes = {
@@ -79,11 +80,11 @@ class TeamDashboardTabPage extends React.Component {
       const team = this.props.team.metadata.name
       await (await KoreApi.client()).RemoveTeam(team)
       this.props.teamRemoved(team)
-      message.success(`Team "${team}" deleted`)
+      successMessage(`Team "${team}" deleted`)
       return redirect({ router: Router, path: '/' })
     } catch (err) {
       console.log('Error deleting team', err)
-      message.error('Team could not be deleted, please try again later')
+      errorMessage('Team could not be deleted, please try again later')
     }
   }
 

--- a/ui/pages/teams/[name]/clusters/[cluster]/services/[service].js
+++ b/ui/pages/teams/[name]/clusters/[cluster]/services/[service].js
@@ -16,7 +16,7 @@ import apiPaths from '../../../../../../lib/utils/api-paths'
 import ServiceCredential from '../../../../../../lib/components/teams/service/ServiceCredential'
 import ServiceCredentialForm from '../../../../../../lib/components/teams/service/ServiceCredentialForm'
 import { isReadOnlyCRD } from '../../../../../../lib/utils/crd-helpers'
-import { errorMessage, loadingMessage } from '../../../../lib/utils/message'
+import { errorMessage, loadingMessage } from '../../../../../../lib/utils/message'
 
 class ServicePage extends React.Component {
   static propTypes = {

--- a/ui/pages/teams/[name]/clusters/[cluster]/services/[service].js
+++ b/ui/pages/teams/[name]/clusters/[cluster]/services/[service].js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { Typography, Collapse, Icon, Row, Col, List, Button, Form, Divider, Card, Badge, message, Drawer, Tag } from 'antd'
+import { Typography, Collapse, Icon, Row, Col, List, Button, Form, Divider, Card, Badge, Drawer, Tag } from 'antd'
 const { Text } = Typography
 
 import KoreApi from '../../../../../../lib/kore-api/index'
@@ -16,6 +16,7 @@ import apiPaths from '../../../../../../lib/utils/api-paths'
 import ServiceCredential from '../../../../../../lib/components/teams/service/ServiceCredential'
 import ServiceCredentialForm from '../../../../../../lib/components/teams/service/ServiceCredentialForm'
 import { isReadOnlyCRD } from '../../../../../../lib/utils/crd-helpers'
+import { errorMessage, loadingMessage } from '../../../../lib/utils/message'
 
 class ServicePage extends React.Component {
   static propTypes = {
@@ -143,10 +144,10 @@ class ServicePage extends React.Component {
         }
       }, done)
 
-      message.loading(`Service access deletion requested ${name}`)
+      loadingMessage(`Service access deletion requested ${name}`)
     } catch (err) {
       console.error('Error deleting service access', err)
-      message.error('Error deleting service access, please try again.')
+      errorMessage('Error deleting service access, please try again.')
     }
   }
 
@@ -165,7 +166,7 @@ class ServicePage extends React.Component {
         serviceCredentials: [ ...state.serviceCredentials, serviceCredential ]
       }
     })
-    message.loading(`Service access "${serviceCredential.metadata.name}" requested`)
+    loadingMessage(`Service access "${serviceCredential.metadata.name}" requested`)
   }
 
   onServiceConfigChanged = (updatedServiceParams) => {

--- a/ui/pages/teams/new.js
+++ b/ui/pages/teams/new.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
-import { Typography, Button, Card, List, Row, Col, Icon, Alert, message, Select, Tooltip } from 'antd'
+import { Typography, Button, Card, List, Row, Col, Icon, Alert, Select, Tooltip } from 'antd'
 const { Title, Paragraph, Text } = Typography
 
 import NewTeamForm from '../../lib/components/forms/NewTeamForm'
@@ -11,6 +11,7 @@ import Breadcrumb from '../../lib/components/layout/Breadcrumb'
 import copy from '../../lib/utils/object-copy'
 import asyncForEach from '../../lib/utils/async-foreach'
 import KoreApi from '../../lib/kore-api'
+import { successMessage, errorMessage } from '../../lib/utils/message'
 
 class NewTeamPage extends React.Component {
   static propTypes = {
@@ -64,7 +65,7 @@ class NewTeamPage extends React.Component {
 
     await asyncForEach(this.state.membersToAdd, async member => {
       await api.AddTeamMember(team, member)
-      message.success(`Team member added: ${member}`)
+      successMessage(`Team member added: ${member}`)
       members.push(member)
     })
 
@@ -86,10 +87,10 @@ class NewTeamPage extends React.Component {
         const state = copy(this.state)
         state.members = state.members.filter(m => m !== member)
         this.setState(state)
-        message.success(`Team member removed: ${member}`)
+        successMessage(`Team member removed: ${member}`)
       } catch (err) {
         console.error('Error removing team member', err)
-        message.error('Error removing team member, please try again.')
+        errorMessage('Error removing team member, please try again.')
       }
     }
   }


### PR DESCRIPTION
This PR improves the UI E2E testing structure to be more flexible and introduces tests for the GCP project credentials and GCP cluster plans sections.

It also tidies the messaging from various UI components to use notifications (so they can be dismissed by the automated tests) and introduces meaningful defaults where possible to the GKE and EKS plan schemas.