### PR TITLE
Improve circleCI build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,25 @@ jobs:
 
     docker:
       - image: circleci/golang:1.14
+
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: |
+            make build
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - bin
+
+  test:
+    environment:
+      GOFLAGS: "-mod=vendor"
+      USE_GIT_VERSION: "true"
+
+    docker:
+      - image: circleci/golang:1.14
       - name: database
         image: mariadb:bionic
         environment:
@@ -202,16 +221,8 @@ jobs:
             TEST_USERS_DATABASE_URL: "root:pass@tcp(database:3306)/kore?parseTime=true"
           command: |
             make test
-      - run:
-          name: Build
-          command: |
-            make build
-      - persist_to_workspace:
-          root: ~/project
-          paths:
-            - bin
 
-  check-apis:
+  test-api:
     environment:
       GOFLAGS: "-mod=vendor"
       USE_GIT_VERSION: "true"
@@ -222,17 +233,12 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Checking generated API resources
-          command: |
-            make check-apis
-      - run:
           command: |
             make kore-apiserver
             bin/kore-apiserver --verbose
           background: true
           environment:
             <<: *SERVICES_ENV
-
       - run:
           name: Checking swagger
           command: |
@@ -243,7 +249,22 @@ jobs:
           command: |
             make check-swagger-apiclient api-test
           environment:
-            <<: *SERVICES_ENV
+            <<: *SERVICES_ENV      
+
+  check-apis:
+    environment:
+      GOFLAGS: "-mod=vendor"
+      USE_GIT_VERSION: "true"
+
+    docker:
+      - image: circleci/golang:1.14
+
+    steps:
+      - checkout
+      - run:
+          name: Checking generated API resources
+          command: |
+            make check-apis
 
   release:
     environment:
@@ -311,40 +332,40 @@ jobs:
             keys:
               - ui-node-v1-{{ checksum "ui/package-lock.json" }}
               - ui-node-v1-
-      - restore_cache:
-            keys:
-              - ui-next-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-              - ui-next-v1-{{ .Branch }}-
-              - ui-next-v1-
       - run:
           name: Installing UI dependencies
           working_directory: ~/project/ui
           command: |
-            make prep
+            make dependencies
       - save_cache:
             paths:
               - ui/node_modules
             key: ui-node-v1-{{ checksum "ui/package-lock.json" }}
       - run:
-          name: Testing UI
-          working_directory: ~/project/ui
-          command: |
-            make test
-      - run:
           name: Building UI
           working_directory: ~/project/ui
           command: |
             make build
-      - save_cache:
-            paths:
-              - ui/.next/cache
-            key: ui-next-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-      - persist_to_workspace:
-          root: ~/project
-          paths:
-            - ui/.next
 
   test-ui:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - restore_cache:
+            keys:
+              - ui-node-v1-{{ checksum "ui/package-lock.json" }}
+      - run:
+          name: Testing UI
+          working_directory: ~/project/ui
+          command: |
+            # Restore node modules only if we've not got a cache hit.
+            [[ -d node_modules ]] || make dependencies
+            make test
+
+  test-ui-e2e:
     docker:
       - image: circleci/node:12
       - *SERVICES_ETCD
@@ -355,6 +376,23 @@ jobs:
 
     steps:
       - checkout
+      - restore_cache:
+            keys:
+              - ui-node-v1-{{ checksum "ui/package-lock.json" }}
+      - run:
+          name: Running kore-ui
+          working_directory: ~/project/ui
+          command: |
+            # Restore node modules only if we've not got a cache hit.
+            [[ -d node_modules ]] || make dependencies
+            make build
+            npm start
+          background: true
+          environment:
+            KORE_BASE_URL: http://localhost:3000
+            KORE_API_URL: http://localhost:10080/api/v1alpha1
+            KORE_API_TOKEN: password
+            REDIS_URL: redis://redis:6379
       - run:
           name: Install Headless Chrome dependencies
           command: ./ui/scripts/install-e2e-deps.sh
@@ -367,25 +405,6 @@ jobs:
           background: true
           environment:
             <<: *SERVICES_ENV
-      - restore_cache:
-            keys:
-              - ui-node-v1-{{ checksum "ui/package-lock.json" }}
-              - ui-node-v1-
-      - run:
-          name: Running kore-ui
-          working_directory: ~/project/ui
-          command: |
-            # Restore node modules only if we've not got a cache hit.
-            [[ -d node_modules ]] || make prep
-            # Copy built UI into source tree from shared workspace
-            cp -R /tmp/workspace/ui/.next .
-            npm start
-          background: true
-          environment:
-            KORE_BASE_URL: http://localhost:3000
-            KORE_API_URL: http://localhost:10080/api/v1alpha1
-            KORE_API_TOKEN: password
-            REDIS_URL: redis://redis:6379
       - run:
           name: Waiting for API and UI
           command: |
@@ -495,6 +514,14 @@ workflows:
           filters:
             tags:
               only: /^v.*$/
+      - test:
+          filters:
+            tags:
+              only: /^v.*$/
+      - test-api:
+          filters:
+            tags:
+              only: /^v.*$/
       - check-apis:
           filters:
             tags:
@@ -503,6 +530,8 @@ workflows:
           requires:
             - check
             - build
+            - test
+            - test-api
             - check-apis
           filters:
             branches:
@@ -545,6 +574,8 @@ workflows:
           requires:
             - check
             - build
+            - test
+            - test-api
             - check-apis
             - check-release-notes
             - e2e_eks
@@ -559,9 +590,12 @@ workflows:
             tags:
               only: /^v.*$/
       - test-ui:
+          filters:
+            tags:
+              only: /^v.*$/
+      - test-ui-e2e:
           requires:
             - build
-            - build-ui
           filters:
             tags:
               only: /^v.*$/
@@ -574,6 +608,7 @@ workflows:
           requires:
             - build-ui
             - test-ui
+            - test-ui-e2e
       - deploy-qa:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,47 +22,62 @@ parameters:
 # Templates ---
 #
 
+services_etcd: &SERVICES_ETCD
+  name: etcd
+  image: bitnami/etcd:latest
+  environment:
+    ALLOW_NONE_AUTHENTICATION: "yes"
+
+services_redis: &SERVICES_REDIS
+  name: redis
+  image: redis:5
+
+services_database: &SERVICES_DATABASE
+  name: database
+  image: mariadb:bionic
+  environment:
+    MYSQL_ROOT_PASSWORD: pass
+  command:
+    sh -c "
+      echo 'CREATE DATABASE IF NOT EXISTS kore;' > /docker-entrypoint-initdb.d/init.sql;
+      /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
+
+services_kubectrlmgr: &SERVICES_KUBECTRLMGR
+  name: kube-controller-manager
+  image: gcr.io/google-containers/kube-controller-manager-amd64:v1.15.11
+  command:
+    - /usr/local/bin/kube-controller-manager
+    - --master=http://kube-apiserver:8080
+
+services_kubeapisvr: &SERVICES_KUBEAPISVR
+  name: kube-apiserver
+  image: gcr.io/google-containers/kube-apiserver-amd64:v1.15.11
+  command:
+    - /usr/local/bin/kube-apiserver
+    - --address=0.0.0.0
+    - --alsologtostderr
+    - --authorization-mode=RBAC
+    - --bind-address=0.0.0.0
+    - --default-watch-cache-size=200
+    - --delete-collection-workers=10
+    - --etcd-servers=http://etcd:2379
+    - --log-flush-frequency=10s
+    - --runtime-config=autoscaling/v1=false
+    - --runtime-config=autoscaling/v2beta1=false
+    - --runtime-config=autoscaling/v2beta2=false
+    - --runtime-config=batch/v1=false
+    - --runtime-config=batch/v1beta1=false
+    - --runtime-config=networking.k8s.io/v1=false
+    - --runtime-config=networking.k8s.io/v1beta1=false
+    - --runtime-config=node.k8s.io/v1beta1=false
+
 services: &SERVICES
   - image: circleci/golang:1.14
-  - name: etcd
-    image: bitnami/etcd:latest
-    environment:
-      ALLOW_NONE_AUTHENTICATION: "yes"
-  - name: redis
-    image: redis:5
-  - name: database
-    image: mariadb:bionic
-    environment:
-      MYSQL_ROOT_PASSWORD: pass
-    command:
-      sh -c "
-        echo 'CREATE DATABASE IF NOT EXISTS kore;' > /docker-entrypoint-initdb.d/init.sql;
-        /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
-  - name: kube-controller-manager
-    image: gcr.io/google-containers/kube-controller-manager-amd64:v1.15.11
-    command:
-      - /usr/local/bin/kube-controller-manager
-      - --master=http://kube-apiserver:8080
-  - name: kube-apiserver
-    image: gcr.io/google-containers/kube-apiserver-amd64:v1.15.11
-    command:
-      - /usr/local/bin/kube-apiserver
-      - --address=0.0.0.0
-      - --alsologtostderr
-      - --authorization-mode=RBAC
-      - --bind-address=0.0.0.0
-      - --default-watch-cache-size=200
-      - --delete-collection-workers=10
-      - --etcd-servers=http://etcd:2379
-      - --log-flush-frequency=10s
-      - --runtime-config=autoscaling/v1=false
-      - --runtime-config=autoscaling/v2beta1=false
-      - --runtime-config=autoscaling/v2beta2=false
-      - --runtime-config=batch/v1=false
-      - --runtime-config=batch/v1beta1=false
-      - --runtime-config=networking.k8s.io/v1=false
-      - --runtime-config=networking.k8s.io/v1beta1=false
-      - --runtime-config=node.k8s.io/v1beta1=false
+  - *SERVICES_ETCD
+  - *SERVICES_REDIS
+  - *SERVICES_DATABASE
+  - *SERVICES_KUBECTRLMGR
+  - *SERVICES_KUBEAPISVR
 
 service_env: &SERVICES_ENV
   KORE_ADMIN_PASS: "password"
@@ -191,6 +206,10 @@ jobs:
           name: Build
           command: |
             make build
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - bin
 
   check-apis:
     environment:
@@ -283,11 +302,29 @@ jobs:
 
   build-ui:
     docker:
-      - image: node:12
+      - image: circleci/node:12
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+      - restore_cache:
+            keys:
+              - ui-node-v1-{{ checksum "ui/package-lock.json" }}
+              - ui-node-v1-
+      - restore_cache:
+            keys:
+              - ui-next-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+              - ui-next-v1-{{ .Branch }}-
+              - ui-next-v1-
+      - run:
+          name: Installing UI dependencies
+          working_directory: ~/project/ui
+          command: |
+            make prep
+      - save_cache:
+            paths:
+              - ui/node_modules
+            key: ui-node-v1-{{ checksum "ui/package-lock.json" }}
       - run:
           name: Testing UI
           working_directory: ~/project/ui
@@ -298,44 +335,50 @@ jobs:
           working_directory: ~/project/ui
           command: |
             make build
+      - save_cache:
+            paths:
+              - ui/.next/cache
+            key: ui-next-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - ui/.next
 
   test-ui:
-    environment:
-      GOFLAGS: "-mod=vendor"
-      USE_GIT_VERSION: "true"
-
     docker:
-      *SERVICES
+      - image: circleci/node:12
+      - *SERVICES_ETCD
+      - *SERVICES_REDIS
+      - *SERVICES_DATABASE
+      - *SERVICES_KUBECTRLMGR
+      - *SERVICES_KUBEAPISVR
 
     steps:
       - checkout
       - run:
-          name: Install Node.js and Headless Chrome dependencies
-          command: |
-            sudo apt-get update && sudo apt-get install -yq \
-              jq gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-              libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-              libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-              libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-              fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm1
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt install nodejs
-            node --version
-            npm --version
+          name: Install Headless Chrome dependencies
+          command: ./ui/scripts/install-e2e-deps.sh
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Running kore-apiserver
           command: |
-            make kore-apiserver
-            bin/kore-apiserver --verbose
+            /tmp/workspace/bin/kore-apiserver --verbose
           background: true
           environment:
             <<: *SERVICES_ENV
+      - restore_cache:
+            keys:
+              - ui-node-v1-{{ checksum "ui/package-lock.json" }}
+              - ui-node-v1-
       - run:
           name: Running kore-ui
           working_directory: ~/project/ui
           command: |
-            npm install
-            npm run build
+            # Restore node modules only if we've not got a cache hit.
+            [[ -d node_modules ]] || make prep
+            # Copy built UI into source tree from shared workspace
+            cp -R /tmp/workspace/ui/.next .
             npm start
           background: true
           environment:
@@ -354,7 +397,7 @@ jobs:
           environment:
             NODE_ENV: development
           command: |
-            npm run test-e2e
+            make test-e2e
 
   release-ui:
     environment:
@@ -516,6 +559,9 @@ workflows:
             tags:
               only: /^v.*$/
       - test-ui:
+          requires:
+            - build
+            - build-ui
           filters:
             tags:
               only: /^v.*$/

--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ api-wait:
 
 ui-wait:
 	@echo "--> Waiting for UI..."
-	@hack/bin/http_test.sh http://127.0.0.1:3000
+	@hack/bin/http_test.sh http://127.0.0.1:3000 100
 
 compose-down:
 	@echo "--> Removing the test environment"

--- a/hack/bin/http_test.sh
+++ b/hack/bin/http_test.sh
@@ -5,10 +5,12 @@ set -o nounset
 set -o pipefail
 
 address=${1?'expected address'}
-for i in {1..10} ; do
+maxtries=${2:-50}
+
+for  i in {1..10} ; do
     ret=0
     curl \
-        --retry 50 \
+        --retry $maxtries \
         --retry-delay 3 \
         --retry-connrefused \
         -sSL ${address} >/dev/null 2>&1 || ret=$?

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -5,7 +5,7 @@ VERSION ?= latest
 
 default: build
 
-prep: 
+dependencies: 
 	@echo "--> Preparing"
 	npm install
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -5,14 +5,16 @@ VERSION ?= latest
 
 default: build
 
+prep: 
+	@echo "--> Preparing"
+	npm install
+
 build:
 	@echo "--> Building"
-	npm install
 	npm run build
 
 test:
 	@echo "--> Testing"
-	npm install
 	npm run lint
 	npm test
 

--- a/ui/scripts/install-e2e-deps.sh
+++ b/ui/scripts/install-e2e-deps.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This installs the dependencies required for headless chromium to work.
+# See list of packages here: 
+# https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
+
+sudo apt-get update && sudo apt-get install -yq \
+              jq gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+              libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+              libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
+              libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+              fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm1


### PR DESCRIPTION
This PR splits and parallelises a number of the circle CI steps to get the most expensive / lengthy steps underway as soon as possible.

It also uses the built binaries from the main 'build' step for e2e testing the UI, meaning the UI test step can be run on a node image instead of a golang one.

Lastly, it adds caching for node_modules to speed up the UI build time significantly.