### PR TITLE
Enhancing AutoRefreshComponent to refresh stable resources

### DIFF
--- a/ui/lib/components/credentials/EKSCredentials.js
+++ b/ui/lib/components/credentials/EKSCredentials.js
@@ -23,12 +23,12 @@ class EKSCredentials extends AutoRefreshComponent {
     }
   }
 
-  finalStateReached({ state }) {
+  stableStateReached({ state }) {
     const { eksCredentials } = this.props
-    if (state === AutoRefreshComponent.FINAL_STATES.SUCCESS) {
+    if (state === AutoRefreshComponent.STABLE_STATES.SUCCESS) {
       return successMessage(`AWS credentials for account "${eksCredentials.spec.accountID}" verified successfully`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.FAILURE) {
+    if (state === AutoRefreshComponent.STABLE_STATES.FAILURE) {
       return errorMessage(`AWS credentials for account "${eksCredentials.spec.accountID}" could not be verified`)
     }
   }

--- a/ui/lib/components/credentials/GCPOrganization.js
+++ b/ui/lib/components/credentials/GCPOrganization.js
@@ -22,12 +22,12 @@ class GCPOrganization extends AutoRefreshComponent {
     }
   }
 
-  finalStateReached({ state }) {
+  stableStateReached({ state }) {
     const { organization } = this.props
-    if (state === AutoRefreshComponent.FINAL_STATES.SUCCESS) {
+    if (state === AutoRefreshComponent.STABLE_STATES.SUCCESS) {
       return successMessage(`GCP organization "${organization.allocation.spec.name}" created successfully`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.FAILURE) {
+    if (state === AutoRefreshComponent.STABLE_STATES.FAILURE) {
       return errorMessage(`GCP organization "${organization.allocation.spec.name}" failed to be created`)
     }
   }

--- a/ui/lib/components/credentials/GKECredentials.js
+++ b/ui/lib/components/credentials/GKECredentials.js
@@ -22,12 +22,12 @@ class GKECredentials extends AutoRefreshComponent {
     }
   }
 
-  finalStateReached({ state }) {
+  stableStateReached({ state }) {
     const { gkeCredentials } = this.props
-    if (state === AutoRefreshComponent.FINAL_STATES.SUCCESS) {
+    if (state === AutoRefreshComponent.STABLE_STATES.SUCCESS) {
       return successMessage(`GCP credentials for project "${gkeCredentials.spec.project}" verified successfully`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.FAILURE) {
+    if (state === AutoRefreshComponent.STABLE_STATES.FAILURE) {
       return errorMessage(`GCP credentials for project "${gkeCredentials.spec.project}" could not be verified`)
     }
   }

--- a/ui/lib/components/teams/cluster/Cluster.js
+++ b/ui/lib/components/teams/cluster/Cluster.js
@@ -19,15 +19,15 @@ class Cluster extends AutoRefreshComponent {
     deleteCluster: PropTypes.func.isRequired
   }
 
-  finalStateReached({ state, deleted }) {
+  stableStateReached({ state, deleted }) {
     const { cluster } = this.props
     if (deleted) {
       return successMessage(`Cluster successfully deleted: ${cluster.metadata.name}`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.SUCCESS) {
+    if (state === AutoRefreshComponent.STABLE_STATES.SUCCESS) {
       return successMessage(`Cluster successfully created: ${cluster.metadata.name}`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.FAILURE) {
+    if (state === AutoRefreshComponent.STABLE_STATES.FAILURE) {
       return errorMessage(`Cluster failed to create: ${cluster.metadata.name}`)
     }
   }

--- a/ui/lib/components/teams/cluster/ClustersTab.js
+++ b/ui/lib/components/teams/cluster/ClustersTab.js
@@ -151,6 +151,7 @@ class ClustersTab extends React.Component {
                     handleUpdate={this.handleResourceUpdated('clusters')}
                     handleDelete={this.handleResourceDeleted('clusters')}
                     refreshMs={10000}
+                    stableRefreshMs={60000}
                     propsResourceDataKey="cluster"
                     resourceApiRequest={async () => await (await KoreApi.client()).GetCluster(team.metadata.name, cluster.metadata.name)}
                   />

--- a/ui/lib/components/teams/namespace/NamespaceClaim.js
+++ b/ui/lib/components/teams/namespace/NamespaceClaim.js
@@ -14,15 +14,15 @@ class NamespaceClaim extends AutoRefreshComponent {
     deleteNamespace: PropTypes.func.isRequired
   }
 
-  finalStateReached({ state, deleted }) {
+  stableStateReached({ state, deleted }) {
     const { namespaceClaim } = this.props
     if (deleted) {
       return successMessage(`Namespace "${namespaceClaim.spec.name}" deleted`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.SUCCESS) {
+    if (state === AutoRefreshComponent.STABLE_STATES.SUCCESS) {
       return successMessage(`Namespace "${namespaceClaim.spec.name}" created`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.FAILURE) {
+    if (state === AutoRefreshComponent.STABLE_STATES.FAILURE) {
       return errorMessage(`Namespace "${namespaceClaim.spec.name}" failed be to created`)
     }
   }

--- a/ui/lib/components/teams/service/Service.js
+++ b/ui/lib/components/teams/service/Service.js
@@ -20,15 +20,15 @@ class Service extends AutoRefreshComponent {
     style: PropTypes.object
   }
 
-  finalStateReached({ state, deleted }) {
+  stableStateReached({ state, deleted }) {
     const { service } = this.props
     if (deleted) {
       return successMessage(`Service successfully deleted: ${service.metadata.name}`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.SUCCESS) {
+    if (state === AutoRefreshComponent.STABLE_STATES.SUCCESS) {
       return successMessage(`Service successfully created: ${service.metadata.name}`)
     }
-    if (state === AutoRefreshComponent.FINAL_STATES.FAILURE) {
+    if (state === AutoRefreshComponent.STABLE_STATES.FAILURE) {
       return errorMessage(`Service failed to create: ${service.metadata.name}`)
     }
   }

--- a/ui/lib/components/teams/service/ServiceCredential.js
+++ b/ui/lib/components/teams/service/ServiceCredential.js
@@ -20,15 +20,15 @@ class ServiceCredential extends AutoRefreshComponent {
     deleteServiceCredential: PropTypes.func.isRequired
   }
 
-  finalStateReached({ state, deleted }) {
+  stableStateReached({ state, deleted }) {
     const { serviceCredential } = this.props
     if (deleted) {
       return successMessage(`Service access successfully deleted for service "${serviceCredential.spec.service.name}"`)
     }
-    if (state === ServiceCredential.FINAL_STATES.SUCCESS) {
+    if (state === ServiceCredential.STABLE_STATES.SUCCESS) {
       return successMessage(`Service access successfully created for service "${serviceCredential.spec.service.name}"`)
     }
-    if (state === ServiceCredential.FINAL_STATES.FAILURE) {
+    if (state === ServiceCredential.STABLE_STATES.FAILURE) {
       return errorMessage(`Service access failed to create for service "${serviceCredential.spec.service.name}"`)
     }
   }

--- a/ui/lib/components/teams/service/ServicesTab.js
+++ b/ui/lib/components/teams/service/ServicesTab.js
@@ -216,6 +216,7 @@ class ServicesTab extends React.Component {
                     handleUpdate={this.handleResourceUpdated('services')}
                     handleDelete={this.handleResourceDeleted('services')}
                     refreshMs={5000}
+                    stableRefreshMs={60000}
                     propsResourceDataKey="service"
                     resourceApiRequest={async () => await (await KoreApi.client()).GetService(team.metadata.name, service.metadata.name)}
                     style={{ paddingTop: 0, paddingBottom: '5px' }}

--- a/ui/lib/prototype/components/credentials/GCPOrganization.js
+++ b/ui/lib/prototype/components/credentials/GCPOrganization.js
@@ -22,7 +22,7 @@ class GCPOrganization extends AutoRefreshComponent {
     }
   }
 
-  finalStateReached() {
+  stableStateReached() {
     const { organization } = this.props
     const { allocation, status } = organization
     if (status.status === 'Success') {

--- a/ui/lib/prototype/components/teams/cluster/Cluster.js
+++ b/ui/lib/prototype/components/teams/cluster/Cluster.js
@@ -22,7 +22,7 @@ class Cluster extends AutoRefreshComponent {
     deleteCluster: PropTypes.func.isRequired
   }
 
-  finalStateReached() {
+  stableStateReached() {
     const { cluster } = this.props
     const { status, deleted } = cluster
     if (deleted) {

--- a/ui/lib/prototype/components/teams/namespace/NamespaceClaim.js
+++ b/ui/lib/prototype/components/teams/namespace/NamespaceClaim.js
@@ -14,7 +14,7 @@ class NamespaceClaim extends AutoRefreshComponent {
     deleteNamespace: PropTypes.func.isRequired
   }
 
-  finalStateReached() {
+  stableStateReached() {
     const { namespaceClaim } = this.props
     const { spec, status, deleted } = namespaceClaim
     if (deleted) {


### PR DESCRIPTION
* only do this if `stableRefreshMs` prop is defined
* renaming final states to stable states
* only trigger the final (now stable) state reached function if that status changed
* adding 60s stable refresh for clusters on the team page and services on the cluster page