### PR TITLE
Cascading delete and dependecy checks for teams, clusters, namespaces and service-related objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ swagger-validate:
 swagger-apiclient:
 	@$(MAKE) swagger-json
 	@echo "--> Creating API client based on the swagger definition"
-	@rm -r pkg/apiclient/*
+	@rm -rf pkg/apiclient/*
 	@go run github.com/go-swagger/go-swagger/cmd/swagger generate client -q -f swagger.json -c pkg/apiclient -m pkg/apiclient/models
 
 check-swagger-apiclient: swagger-apiclient

--- a/pkg/apiclient/operations/delete_service_credentials_parameters.go
+++ b/pkg/apiclient/operations/delete_service_credentials_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewDeleteServiceCredentialsParams creates a new DeleteServiceCredentialsParams object
@@ -60,6 +61,11 @@ for the delete service credentials operation typically these are written to a ht
 */
 type DeleteServiceCredentialsParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Name
 	  Is the name of the service credentials
 
@@ -109,6 +115,17 @@ func (o *DeleteServiceCredentialsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the delete service credentials params
+func (o *DeleteServiceCredentialsParams) WithCascade(cascade *bool) *DeleteServiceCredentialsParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the delete service credentials params
+func (o *DeleteServiceCredentialsParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithName adds the name to the delete service credentials params
 func (o *DeleteServiceCredentialsParams) WithName(name string) *DeleteServiceCredentialsParams {
 	o.SetName(name)
@@ -138,6 +155,22 @@ func (o *DeleteServiceCredentialsParams) WriteToRequest(r runtime.ClientRequest,
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {

--- a/pkg/apiclient/operations/delete_service_kind_parameters.go
+++ b/pkg/apiclient/operations/delete_service_kind_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewDeleteServiceKindParams creates a new DeleteServiceKindParams object
@@ -60,6 +61,11 @@ for the delete service kind operation typically these are written to a http.Requ
 */
 type DeleteServiceKindParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Name
 	  The name of the service kind you wish to delete
 
@@ -104,6 +110,17 @@ func (o *DeleteServiceKindParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the delete service kind params
+func (o *DeleteServiceKindParams) WithCascade(cascade *bool) *DeleteServiceKindParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the delete service kind params
+func (o *DeleteServiceKindParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithName adds the name to the delete service kind params
 func (o *DeleteServiceKindParams) WithName(name string) *DeleteServiceKindParams {
 	o.SetName(name)
@@ -122,6 +139,22 @@ func (o *DeleteServiceKindParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {

--- a/pkg/apiclient/operations/delete_service_p_lan_parameters.go
+++ b/pkg/apiclient/operations/delete_service_p_lan_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewDeleteServicePLanParams creates a new DeleteServicePLanParams object
@@ -60,6 +61,11 @@ for the delete service p lan operation typically these are written to a http.Req
 */
 type DeleteServicePLanParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Name
 	  The name of the service plan you wish to delete
 
@@ -104,6 +110,17 @@ func (o *DeleteServicePLanParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the delete service p lan params
+func (o *DeleteServicePLanParams) WithCascade(cascade *bool) *DeleteServicePLanParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the delete service p lan params
+func (o *DeleteServicePLanParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithName adds the name to the delete service p lan params
 func (o *DeleteServicePLanParams) WithName(name string) *DeleteServicePLanParams {
 	o.SetName(name)
@@ -122,6 +139,22 @@ func (o *DeleteServicePLanParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {

--- a/pkg/apiclient/operations/delete_service_parameters.go
+++ b/pkg/apiclient/operations/delete_service_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewDeleteServiceParams creates a new DeleteServiceParams object
@@ -60,6 +61,11 @@ for the delete service operation typically these are written to a http.Request
 */
 type DeleteServiceParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Name
 	  Is the name of the service
 
@@ -109,6 +115,17 @@ func (o *DeleteServiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the delete service params
+func (o *DeleteServiceParams) WithCascade(cascade *bool) *DeleteServiceParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the delete service params
+func (o *DeleteServiceParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithName adds the name to the delete service params
 func (o *DeleteServiceParams) WithName(name string) *DeleteServiceParams {
 	o.SetName(name)
@@ -138,6 +155,22 @@ func (o *DeleteServiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {

--- a/pkg/apiclient/operations/delete_service_provider_parameters.go
+++ b/pkg/apiclient/operations/delete_service_provider_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewDeleteServiceProviderParams creates a new DeleteServiceProviderParams object
@@ -60,6 +61,11 @@ for the delete service provider operation typically these are written to a http.
 */
 type DeleteServiceProviderParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Name
 	  The name of the service provider you wish to delete
 
@@ -104,6 +110,17 @@ func (o *DeleteServiceProviderParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the delete service provider params
+func (o *DeleteServiceProviderParams) WithCascade(cascade *bool) *DeleteServiceProviderParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the delete service provider params
+func (o *DeleteServiceProviderParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithName adds the name to the delete service provider params
 func (o *DeleteServiceProviderParams) WithName(name string) *DeleteServiceProviderParams {
 	o.SetName(name)
@@ -122,6 +139,22 @@ func (o *DeleteServiceProviderParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {

--- a/pkg/apiclient/operations/remove_cluster_parameters.go
+++ b/pkg/apiclient/operations/remove_cluster_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewRemoveClusterParams creates a new RemoveClusterParams object
@@ -60,6 +61,11 @@ for the remove cluster operation typically these are written to a http.Request
 */
 type RemoveClusterParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Name
 	  Is the name of the cluster
 
@@ -109,6 +115,17 @@ func (o *RemoveClusterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the remove cluster params
+func (o *RemoveClusterParams) WithCascade(cascade *bool) *RemoveClusterParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the remove cluster params
+func (o *RemoveClusterParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithName adds the name to the remove cluster params
 func (o *RemoveClusterParams) WithName(name string) *RemoveClusterParams {
 	o.SetName(name)
@@ -138,6 +155,22 @@ func (o *RemoveClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {

--- a/pkg/apiclient/operations/remove_namespace_parameters.go
+++ b/pkg/apiclient/operations/remove_namespace_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewRemoveNamespaceParams creates a new RemoveNamespaceParams object
@@ -60,6 +61,11 @@ for the remove namespace operation typically these are written to a http.Request
 */
 type RemoveNamespaceParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Name
 	  Is name the of the namespace claim you are acting upon
 
@@ -109,6 +115,17 @@ func (o *RemoveNamespaceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the remove namespace params
+func (o *RemoveNamespaceParams) WithCascade(cascade *bool) *RemoveNamespaceParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the remove namespace params
+func (o *RemoveNamespaceParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithName adds the name to the remove namespace params
 func (o *RemoveNamespaceParams) WithName(name string) *RemoveNamespaceParams {
 	o.SetName(name)
@@ -138,6 +155,22 @@ func (o *RemoveNamespaceParams) WriteToRequest(r runtime.ClientRequest, reg strf
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {

--- a/pkg/apiclient/operations/remove_team_parameters.go
+++ b/pkg/apiclient/operations/remove_team_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewRemoveTeamParams creates a new RemoveTeamParams object
@@ -60,6 +61,11 @@ for the remove team operation typically these are written to a http.Request
 */
 type RemoveTeamParams struct {
 
+	/*Cascade
+	  If true then all objects owned by this object will be deleted too.
+
+	*/
+	Cascade *bool
 	/*Team
 	  Is the name of the team you are acting within
 
@@ -104,6 +110,17 @@ func (o *RemoveTeamParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCascade adds the cascade to the remove team params
+func (o *RemoveTeamParams) WithCascade(cascade *bool) *RemoveTeamParams {
+	o.SetCascade(cascade)
+	return o
+}
+
+// SetCascade adds the cascade to the remove team params
+func (o *RemoveTeamParams) SetCascade(cascade *bool) {
+	o.Cascade = cascade
+}
+
 // WithTeam adds the team to the remove team params
 func (o *RemoveTeamParams) WithTeam(team string) *RemoveTeamParams {
 	o.SetTeam(team)
@@ -122,6 +139,22 @@ func (o *RemoveTeamParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
+
+	if o.Cascade != nil {
+
+		// query param cascade
+		var qrCascade bool
+		if o.Cascade != nil {
+			qrCascade = *o.Cascade
+		}
+		qCascade := swag.FormatBool(qrCascade)
+		if qCascade != "" {
+			if err := r.SetQueryParam("cascade", qCascade); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param team
 	if err := r.SetPathParam("team", o.Team); err != nil {

--- a/pkg/apis/clusters/v1/cluster_types.go
+++ b/pkg/apis/clusters/v1/cluster_types.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// GroupVersion is the GVK for a Cluster
-var ClusterGroupVersionKind = schema.GroupVersionKind{
+// ClusterGVK is the GVK for a Cluster
+var ClusterGVK = schema.GroupVersionKind{
 	Group:   GroupVersion.Group,
 	Version: GroupVersion.Version,
 	Kind:    "Cluster",

--- a/pkg/apis/clusters/v1/namespaceclaim_types.go
+++ b/pkg/apis/clusters/v1/namespaceclaim_types.go
@@ -20,7 +20,15 @@ import (
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// NamespaceClaimGVK is the GVK for a NamespaceClaim
+var NamespaceClaimGVK = schema.GroupVersionKind{
+	Group:   GroupVersion.Group,
+	Version: GroupVersion.Version,
+	Kind:    "NamespaceClaim",
+}
 
 // NamespaceClaimSpec defines the desired state of NamespaceClaim
 // +k8s:openapi-gen=true

--- a/pkg/apiserver/clusters.go
+++ b/pkg/apiserver/clusters.go
@@ -78,7 +78,7 @@ func (u teamHandler) deleteCluster(req *restful.Request, resp *restful.Response)
 		name := req.PathParameter("name")
 		team := req.PathParameter("team")
 
-		object, err := u.Teams().Team(team).Clusters().Delete(ctx, name)
+		object, err := u.Teams().Team(team).Clusters().Delete(ctx, name, parseDeleteOpts(req)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/apiserver/helpers.go
+++ b/pkg/apiserver/helpers.go
@@ -138,3 +138,14 @@ func writeError(req *restful.Request, resp *restful.Response, err error, code in
 		log.WithError(err).Error("failed to respond to request")
 	}
 }
+
+func parseDeleteOpts(req *restful.Request) []kore.DeleteOptionFunc {
+	cascade := req.QueryParameter("cascade")
+
+	var opts []kore.DeleteOptionFunc
+	if cascade == "true" {
+		opts = append(opts, kore.DeleteOptionCascade(true))
+	}
+
+	return opts
+}

--- a/pkg/apiserver/helpers.go
+++ b/pkg/apiserver/helpers.go
@@ -110,6 +110,8 @@ func handleError(req *restful.Request, resp *restful.Response, err error) {
 		code = http.StatusForbidden
 	case validation.Error, *validation.Error:
 		code = http.StatusBadRequest
+	case validation.ErrDependencyViolation, *validation.ErrDependencyViolation:
+		code = http.StatusConflict
 	}
 
 	if err == gorm.ErrRecordNotFound {
@@ -126,6 +128,8 @@ func handleError(req *restful.Request, resp *restful.Response, err error) {
 func writeError(req *restful.Request, resp *restful.Response, err error, code int) {
 	switch err.(type) {
 	case validation.Error, *validation.Error:
+		// Error can be directly serialized to json so just return that.
+	case validation.ErrDependencyViolation, *validation.ErrDependencyViolation:
 		// Error can be directly serialized to json so just return that.
 	default:
 		err = newError(err.Error()).

--- a/pkg/apiserver/namespaces.go
+++ b/pkg/apiserver/namespaces.go
@@ -78,7 +78,7 @@ func (u teamHandler) deleteNamespace(req *restful.Request, resp *restful.Respons
 		team := req.PathParameter("team")
 		name := req.PathParameter("name")
 
-		original, err := u.Teams().Team(team).NamespaceClaims().Delete(req.Request.Context(), name)
+		original, err := u.Teams().Team(team).NamespaceClaims().Delete(req.Request.Context(), name, parseDeleteOpts(req)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/apiserver/params/delete_cascade.go
+++ b/pkg/apiserver/params/delete_cascade.go
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package params
+
+import (
+	"github.com/emicklei/go-restful"
+)
+
+// DeleteCascade is a query parameter for setting the delete cascade policy
+func DeleteCascade() *restful.Parameter {
+	return restful.QueryParameter("cascade", "If true then all objects owned by this object will be deleted too.").DataType("boolean")
+}

--- a/pkg/apiserver/service_credentials.go
+++ b/pkg/apiserver/service_credentials.go
@@ -90,7 +90,7 @@ func (u teamHandler) deleteServiceCredentials(req *restful.Request, resp *restfu
 		name := req.PathParameter("name")
 		team := req.PathParameter("team")
 
-		object, err := u.Teams().Team(team).ServiceCredentials().Delete(ctx, name)
+		object, err := u.Teams().Team(team).ServiceCredentials().Delete(ctx, name, parseDeleteOpts(req)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/apiserver/service_kinds.go
+++ b/pkg/apiserver/service_kinds.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/appvia/kore/pkg/apiserver/params"
+
 	"github.com/appvia/kore/pkg/apiserver/filters"
 
 	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
@@ -90,6 +92,7 @@ func (p *serviceKindsHandler) Register(i kore.Interface, builder utils.PathBuild
 			Doc("Deletes a service kind").
 			Operation("DeleteServiceKind").
 			Param(ws.PathParameter("name", "The name of the service kind you wish to delete")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusNotFound, "the service kind with the given name doesn't exist", nil).
 			Returns(http.StatusOK, "Contains the service kind definition", servicesv1.ServiceKind{}),
 	)

--- a/pkg/apiserver/service_plans.go
+++ b/pkg/apiserver/service_plans.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/appvia/kore/pkg/apiserver/params"
+
 	"github.com/appvia/kore/pkg/kore/authentication"
 
 	"github.com/appvia/kore/pkg/apiserver/filters"
@@ -124,6 +126,7 @@ func (p *servicePlansHandler) Register(i kore.Interface, builder utils.PathBuild
 			Doc("Deletes a service plan").
 			Operation("DeleteServicePLan").
 			Param(ws.PathParameter("name", "The name of the service plan you wish to delete")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusNotFound, "the service plan with the given name doesn't exist", nil).
 			Returns(http.StatusOK, "Contains the service plan definition", servicesv1.ServicePlan{}),
 	)
@@ -220,7 +223,7 @@ func (p servicePlansHandler) deleteServicePlan(req *restful.Request, resp *restf
 	handleErrors(req, resp, func() error {
 		name := req.PathParameter("name")
 
-		plan, err := p.ServicePlans().Delete(req.Request.Context(), name, false)
+		plan, err := p.ServicePlans().Delete(req.Request.Context(), name, parseDeleteOpts(req)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/apiserver/service_plans.go
+++ b/pkg/apiserver/service_plans.go
@@ -176,7 +176,7 @@ func (p servicePlansHandler) listServicePlans(req *restful.Request, resp *restfu
 		user := authentication.MustGetIdentity(req.Request.Context())
 		kind := strings.ToLower(req.QueryParameter("kind"))
 
-		list, err := p.ServicePlans().ListFiltered(req.Request.Context(), func(plan servicesv1.ServicePlan) bool {
+		list, err := p.ServicePlans().List(req.Request.Context(), func(plan servicesv1.ServicePlan) bool {
 			if kind != "" && plan.Spec.Kind != kind {
 				return false
 			}

--- a/pkg/apiserver/service_providers.go
+++ b/pkg/apiserver/service_providers.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/appvia/kore/pkg/apiserver/params"
+
 	"github.com/appvia/kore/pkg/apiserver/filters"
 
 	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
@@ -110,6 +112,7 @@ func (p *serviceProvidersHandler) Register(i kore.Interface, builder utils.PathB
 			Doc("Deletes a service provider").
 			Operation("DeleteServiceProvider").
 			Param(ws.PathParameter("name", "The name of the service provider you wish to delete")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusNotFound, "the service provider with the given name doesn't exist", nil).
 			Returns(http.StatusOK, "Contains the service provider definition", servicesv1.ServiceProvider{}),
 	)
@@ -170,7 +173,7 @@ func (p serviceProvidersHandler) deleteServiceProvider(req *restful.Request, res
 	handleErrors(req, resp, func() error {
 		name := req.PathParameter("name")
 
-		provider, err := p.ServiceProviders().Delete(req.Request.Context(), name)
+		provider, err := p.ServiceProviders().Delete(req.Request.Context(), name, parseDeleteOpts(req)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/apiserver/services.go
+++ b/pkg/apiserver/services.go
@@ -119,7 +119,7 @@ func (u teamHandler) deleteService(req *restful.Request, resp *restful.Response)
 		name := req.PathParameter("name")
 		team := req.PathParameter("team")
 
-		object, err := u.Teams().Team(team).Services().Delete(ctx, name)
+		object, err := u.Teams().Team(team).Services().Delete(ctx, name, parseDeleteOpts(req)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/apiserver/services.go
+++ b/pkg/apiserver/services.go
@@ -62,7 +62,7 @@ func (u teamHandler) listServices(req *restful.Request, resp *restful.Response) 
 		if user.IsGlobalAdmin() {
 			list, err = u.Teams().Team(team).Services().List(req.Request.Context())
 		} else {
-			list, err = u.Teams().Team(team).Services().ListFiltered(req.Request.Context(), func(service servicesv1.Service) bool {
+			list, err = u.Teams().Team(team).Services().List(req.Request.Context(), func(service servicesv1.Service) bool {
 				return service.Annotations[kore.AnnotationSystem] != "true"
 			})
 		}

--- a/pkg/apiserver/teams.go
+++ b/pkg/apiserver/teams.go
@@ -139,6 +139,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Doc("Used to delete a team from the kore").
 			Operation("RemoveTeam").
 			Param(ws.PathParameter("team", "Is the name of the team you are acting within")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusOK, "Contains the former team definition from the kore", orgv1.Team{}).
 			Returns(http.StatusNotFound, "Team does not exist", nil).
 			Returns(http.StatusNotAcceptable, "Indicates you cannot delete the team for one or more reasons", Error{}).
@@ -819,7 +820,7 @@ func (u teamHandler) findTeamAudit(req *restful.Request, resp *restful.Response)
 // deleteTeam is responsible for deleting a team from the kore
 func (u teamHandler) deleteTeam(req *restful.Request, resp *restful.Response) {
 	handleErrors(req, resp, func() error {
-		err := u.Teams().Delete(req.Request.Context(), req.PathParameter("team"))
+		err := u.Teams().Delete(req.Request.Context(), req.PathParameter("team"), parseDeleteOpts(req)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/apiserver/teams.go
+++ b/pkg/apiserver/teams.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/appvia/kore/pkg/apiserver/params"
+
 	"github.com/appvia/kore/pkg/apiserver/filters"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
@@ -320,6 +322,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Operation("RemoveNamespace").
 			Param(ws.PathParameter("name", "Is name the of the namespace claim you are acting upon")).
 			Param(ws.PathParameter("team", "Is the name of the team you are acting within")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusOK, "Contains the former definition from the kore", clustersv1.NamespaceClaim{}).
 			Returns(http.StatusInternalServerError, "A generic API error containing the cause of the error", Error{}),
 	)
@@ -422,6 +425,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Operation("RemoveCluster").
 			Param(ws.PathParameter("name", "Is the name of the cluster")).
 			Param(ws.PathParameter("team", "Is the name of the team you are acting within")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusNotFound, "the cluster with the given name doesn't exist", nil).
 			Returns(http.StatusOK, "Contains the former cluster definition from the kore", clustersv1.Cluster{}),
 	)
@@ -720,6 +724,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Operation("DeleteService").
 			Param(ws.PathParameter("name", "Is the name of the service")).
 			Param(ws.PathParameter("team", "Is the name of the team you are acting within")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusNotFound, "the service with the given name doesn't exist", nil).
 			Returns(http.StatusOK, "Contains the former service definition from the kore", servicesv1.Service{}),
 	)
@@ -764,6 +769,7 @@ func (u *teamHandler) Register(i kore.Interface, builder utils.PathBuilder) (*re
 			Operation("DeleteServiceCredentials").
 			Param(ws.PathParameter("name", "Is the name of the service credentials")).
 			Param(ws.PathParameter("team", "Is the name of the team you are acting within")).
+			Param(params.DeleteCascade()).
 			Returns(http.StatusNotFound, "the service credentials with the given name doesn't exist", nil).
 			Returns(http.StatusOK, "Contains the former service credentials definition", servicesv1.ServiceCredentials{}),
 	)

--- a/pkg/cmd/kore/delete/delete.go
+++ b/pkg/cmd/kore/delete/delete.go
@@ -40,6 +40,8 @@ type DeleteOptions struct {
 	Resource string
 	// Team string
 	Team string
+	// Cascade if true, cascade the deletion of the resources managed by this resource
+	Cascade bool
 }
 
 // NewCmdDelete creates and returns the delete command
@@ -74,6 +76,7 @@ func NewCmdDelete(factory cmdutil.Factory) *cobra.Command {
 	}
 
 	command.Flags().StringSliceVarP(&o.Paths, "file", "f", []string{}, "path to file containing resource definition/s ('-' for stdin) `PATH`")
+	command.Flags().BoolVar(&o.Cascade, "cascade", false, "if true, cascade the deletion of the resources managed by this resource")
 
 	command.AddCommand(
 		NewCmdDeleteAdmin(factory),
@@ -97,6 +100,10 @@ func (o *DeleteOptions) Run() error {
 	request := o.ClientWithResource(resource).Name(o.Name)
 	if resource.IsTeamScoped() {
 		request.Team(o.Team)
+	}
+
+	if o.Cascade {
+		request.Parameters(client.QueryParameter("cascade", "true"))
 	}
 
 	return o.WaitForDeletion(request, o.Name, o.NoWait)
@@ -166,6 +173,10 @@ func (o *DeleteOptions) DeleteByPath() error {
 			request := o.ClientWithResource(resource).Name(name)
 			if x.Resource.IsTeamScoped() {
 				request.Team(o.Team)
+			}
+
+			if o.Cascade {
+				request.Parameters(client.QueryParameter("cascade", "true"))
 			}
 
 			endpoint := fmt.Sprintf("%s/%s", groupversion, name)

--- a/pkg/controllers/helpers/services.go
+++ b/pkg/controllers/helpers/services.go
@@ -167,7 +167,7 @@ func EnsureService(ctx kore.Context, original *servicesv1.Service, owner runtime
 
 // DeleteServices will remove services and return reconcile status
 func DeleteServices(ctx kore.Context, team string, owner runtime.Object, components corev1.Components) (reconcile.Result, error) {
-	adminServicesList, err := ctx.Kore().Teams().Team(team).Services().ListFiltered(ctx, func(service servicesv1.Service) bool {
+	adminServicesList, err := ctx.Kore().Teams().Team(team).Services().List(ctx, func(service servicesv1.Service) bool {
 		return service.Annotations[kore.AnnotationOwner] == kubernetes.MustGetRuntimeSelfLink(owner)
 	})
 	if err != nil {

--- a/pkg/controllers/servicecredentials/reconcile.go
+++ b/pkg/controllers/servicecredentials/reconcile.go
@@ -18,7 +18,10 @@ package servicecredentials
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"github.com/appvia/kore/pkg/controllers/helpers"
 
 	"github.com/appvia/kore/pkg/kore"
 
@@ -38,7 +41,7 @@ const (
 )
 
 // Reconcile is the entrypoint for the reconciliation logic
-func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (c *Controller) Reconcile(request reconcile.Request) (reconcileResult reconcile.Result, reconcileError error) {
 	ctx := context.Background()
 
 	logger := c.logger.WithFields(log.Fields{
@@ -59,24 +62,46 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	original := creds.DeepCopy()
 
-	// @step: retrieve the object from the api
-	service := &servicesv1.Service{}
-	if err := c.mgr.GetClient().Get(ctx, creds.Spec.Service.NamespacedName(), service); err != nil {
-		if kerrors.IsNotFound(err) {
-			logger.Debug("service does not exist")
+	defer func() {
+		if err := c.mgr.GetClient().Status().Patch(ctx, creds, client.MergeFrom(original)); err != nil {
+			logger.WithError(err).Error("failed to update the service credentials status")
+			reconcileResult = reconcile.Result{}
+			reconcileError = err
+		}
+	}()
+
+	koreCtx := kore.NewContext(ctx, logger, c.mgr.GetClient(), c)
+
+	provider, err := c.ServiceProviders().GetProviderForKind(koreCtx, creds.Spec.Kind)
+	if err != nil {
+		if err == kore.ErrNotFound {
+			creds.Status.Status = corev1.ErrorStatus
+			creds.Status.Message = fmt.Sprintf("There is no service provider for kind %q", creds.Spec.Kind)
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
-
-		logger.WithError(err).Error("failed to retrieve service from api")
+		creds.Status.Status = corev1.ErrorStatus
+		creds.Status.Message = err.Error()
 		return reconcile.Result{}, err
 	}
 
-	spCtx := kore.NewContext(ctx, logger, c.mgr.GetClient(), c)
-	provider, err := c.ServiceProviders().GetProviderForKind(spCtx, creds.Spec.Kind)
+	service, err := c.Teams().Team(creds.Spec.Service.Namespace).Services().Get(ctx, creds.Spec.Service.Name)
 	if err != nil {
-		creds.Status.Status = corev1.ErrorStatus
-		creds.Status.Message = err.Error()
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		if err == kore.ErrNotFound {
+			creds.Status.Status = corev1.PendingStatus
+			creds.Status.Message = fmt.Sprintf("Service %q does not exist", creds.Spec.Service.Name)
+			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	if service.Status.Status != corev1.SuccessStatus {
+		creds.Status.Status = corev1.PendingStatus
+		creds.Status.Message = fmt.Sprintf("Service %q is not ready", creds.Spec.Service.Name)
+		return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+	}
+
+	if !kore.IsSystemResource(creds) && !kubernetes.HasOwnerReferenceWithKind(creds, servicesv1.ServiceGVK) {
+		return helpers.EnsureOwnerReference(ctx, c.mgr.GetClient(), creds, service)
 	}
 
 	finalizer := kubernetes.NewFinalizer(c.mgr.GetClient(), finalizerName)
@@ -86,10 +111,9 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	result, err := func() (reconcile.Result, error) {
 		ensure := []controllers.EnsureFunc{
-			c.ensureFinalizer(logger, creds, finalizer),
 			c.ensurePending(logger, creds),
-			c.EnsureActiveService(logger, service),
-			c.EnsureActiveCluster(logger, creds),
+			c.EnsureDependencies(logger, creds),
+			c.ensureFinalizer(logger, creds, finalizer),
 			c.ensureSecret(logger, service, creds, provider),
 		}
 
@@ -113,33 +137,17 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 		if controllers.IsCriticalError(err) {
 			creds.Status.Status = corev1.FailureStatus
-		}
-	}
-
-	if err == nil && !result.Requeue && result.RequeueAfter == 0 {
-		creds.Status.Status = corev1.SuccessStatus
-	}
-
-	if err := c.mgr.GetClient().Status().Patch(ctx, creds, client.MergeFrom(original)); err != nil {
-		logger.WithError(err).Error("failed to update the service credentials status")
-
-		return reconcile.Result{}, err
-	}
-
-	if err != nil {
-		if controllers.IsCriticalError(err) {
 			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, err
-	}
 
-	if creds.Status.Status == corev1.SuccessStatus {
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, err
 	}
 
 	if result.Requeue || result.RequeueAfter > 0 {
 		return result, nil
 	}
 
-	return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	creds.Status.Status = corev1.SuccessStatus
+
+	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/serviceproviders/reconcile.go
+++ b/pkg/controllers/serviceproviders/reconcile.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Reconcile is the entrypoint for the reconciliation logic
-func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (c *Controller) Reconcile(request reconcile.Request) (reconcileResult reconcile.Result, reconcileError error) {
 	ctx := context.Background()
 
 	logger := c.logger.WithFields(log.Fields{
@@ -61,6 +61,15 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 	original := serviceProvider.DeepCopy()
+
+	defer func() {
+		if err := c.mgr.GetClient().Status().Patch(ctx, serviceProvider, client.MergeFrom(original)); err != nil {
+			logger.WithError(err).Error("failed to update the service provider status")
+
+			reconcileResult = reconcile.Result{}
+			reconcileError = err
+		}
+	}()
 
 	finalizer := kubernetes.NewFinalizer(c.mgr.GetClient(), finalizerName)
 	if finalizer.IsDeletionCandidate(serviceProvider) {
@@ -192,26 +201,18 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 		if controllers.IsCriticalError(err) {
 			serviceProvider.Status.Status = corev1.FailureStatus
-		}
-	}
-
-	if err == nil && !result.Requeue && result.RequeueAfter == 0 {
-		serviceProvider.Status.Status = corev1.SuccessStatus
-		serviceProvider.Status.Message = ""
-	}
-
-	if err := c.mgr.GetClient().Status().Patch(ctx, serviceProvider, client.MergeFrom(original)); err != nil {
-		logger.WithError(err).Error("failed to update the service provider status")
-
-		return reconcile.Result{}, err
-	}
-
-	if err != nil {
-		if controllers.IsCriticalError(err) {
 			return reconcile.Result{}, nil
 		}
+
 		return reconcile.Result{}, err
 	}
+
+	if result.Requeue || result.RequeueAfter > 0 {
+		return result, nil
+	}
+
+	serviceProvider.Status.Status = corev1.SuccessStatus
+	serviceProvider.Status.Message = ""
 
 	return result, nil
 }

--- a/pkg/controllers/services/reconcile.go
+++ b/pkg/controllers/services/reconcile.go
@@ -18,17 +18,13 @@ package services
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
 	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
 	"github.com/appvia/kore/pkg/utils/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	log "github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,52 +56,6 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 	original := service.DeepCopy()
-
-	if service.Spec.ClusterNamespace != "" && service.Annotations[kore.AnnotationSystem] != kore.AnnotationValueTrue {
-		team := service.Spec.Cluster.Namespace
-		namespaceName := fmt.Sprintf("%s-%s", service.Spec.Cluster.Name, service.Spec.ClusterNamespace)
-		namesplaceClaim := &clustersv1.NamespaceClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      namespaceName,
-				Namespace: team,
-			},
-		}
-
-		// check if the namespace specified has a NamespaceClaim
-		found, err := kubernetes.GetIfExists(ctx, c.mgr.GetClient(), namesplaceClaim)
-		if err != nil {
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-		}
-		if !found {
-			// create NamespaceClaim
-			logger.Infof("creating NamespaceClaim for namespace: %s", service.Spec.ClusterNamespace)
-			namespaceClaim := &clustersv1.NamespaceClaim{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: clustersv1.GroupVersion.String(),
-					Kind:       "NamespaceClaim",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      namespaceName,
-					Namespace: team,
-				},
-				Spec: clustersv1.NamespaceClaimSpec{
-					Name: service.Spec.ClusterNamespace,
-					Cluster: corev1.Ownership{
-						Group:     clustersv1.GroupVersion.Group,
-						Version:   clustersv1.GroupVersion.Version,
-						Kind:      "Cluster",
-						Namespace: service.Spec.Cluster.Namespace,
-						Name:      service.Spec.Cluster.Name,
-					},
-				},
-			}
-
-			if _, err := kubernetes.CreateOrUpdate(ctx, c.mgr.GetClient(), namespaceClaim); err != nil {
-				logger.WithError(err).Error("trying to update or create the namespaceClaim")
-				return reconcile.Result{}, err
-			}
-		}
-	}
 
 	spCtx := kore.NewContext(ctx, logger, c.mgr.GetClient(), c)
 	provider, err := c.ServiceProviders().GetProviderForKind(spCtx, service.Spec.Kind)

--- a/pkg/controllers/user/teams/controller.go
+++ b/pkg/controllers/user/teams/controller.go
@@ -34,6 +34,7 @@ import (
 )
 
 type teamController struct {
+	kore.Interface
 	// mgr is the controller manager
 	mgr manager.Manager
 	// stopCh is the stop channel
@@ -52,7 +53,9 @@ func (t *teamController) Name() string {
 }
 
 // Run starts the controller
-func (t *teamController) Run(ctx context.Context, cfg *rest.Config, _ kore.Interface) error {
+func (t *teamController) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
+	t.Interface = hi
+
 	logger := log.WithFields(log.Fields{
 		"controller": t.Name(),
 	})

--- a/pkg/kore/clusters.go
+++ b/pkg/kore/clusters.go
@@ -27,7 +27,6 @@ import (
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
 	"github.com/appvia/kore/pkg/kore/assets"
-	"github.com/appvia/kore/pkg/kore/authentication"
 	"github.com/appvia/kore/pkg/store"
 	"github.com/appvia/kore/pkg/utils"
 	"github.com/appvia/kore/pkg/utils/jsonschema"
@@ -64,15 +63,9 @@ type clustersImpl struct {
 func (c *clustersImpl) Delete(ctx context.Context, name string) (*clustersv1.Cluster, error) {
 	// @TODO check whether the user is an admin in the team
 
-	user := authentication.MustGetIdentity(ctx)
-	if !user.IsMember(c.team) && !user.IsGlobalAdmin() {
-		return nil, NewErrNotAllowed("must be global admin or a team member")
-	}
-
 	logger := log.WithFields(log.Fields{
 		"cluster": name,
 		"team":    c.team,
-		"user":    user.Username(),
 	})
 	logger.Info("attempting to delete the cluster")
 
@@ -111,11 +104,6 @@ func (c *clustersImpl) List(ctx context.Context) (*clustersv1.ClusterList, error
 
 // Get returns a specific cluster
 func (c *clustersImpl) Get(ctx context.Context, name string) (*clustersv1.Cluster, error) {
-	user := authentication.MustGetIdentity(ctx)
-	if !user.IsMember(c.team) && !user.IsGlobalAdmin() {
-		return nil, NewErrNotAllowed("must be global admin or a team member")
-	}
-
 	cluster := &clustersv1.Cluster{}
 
 	if err := c.Store().Client().Get(ctx,
@@ -136,11 +124,6 @@ func (c *clustersImpl) Get(ctx context.Context, name string) (*clustersv1.Cluste
 
 // Update is used to update the cluster
 func (c *clustersImpl) Update(ctx context.Context, cluster *clustersv1.Cluster) error {
-	user := authentication.MustGetIdentity(ctx)
-	if !user.IsMember(c.team) && !user.IsGlobalAdmin() {
-		return NewErrNotAllowed("must be global admin or a team member")
-	}
-
 	existing, err := c.Get(ctx, cluster.Name)
 	if err != nil && err != ErrNotFound {
 		return err

--- a/pkg/kore/clusters.go
+++ b/pkg/kore/clusters.go
@@ -44,7 +44,7 @@ const (
 // Clusters returns the an interface for handling clusters
 type Clusters interface {
 	// Delete is used to delete a cluster
-	Delete(context.Context, string) (*clustersv1.Cluster, error)
+	Delete(context.Context, string, ...DeleteOptionFunc) (*clustersv1.Cluster, error)
 	// Get returns a specific cluster
 	Get(context.Context, string) (*clustersv1.Cluster, error)
 	// List returns a list of clusters we have access to
@@ -60,7 +60,9 @@ type clustersImpl struct {
 }
 
 // Delete is used to delete a cluster
-func (c *clustersImpl) Delete(ctx context.Context, name string) (*clustersv1.Cluster, error) {
+func (c *clustersImpl) Delete(ctx context.Context, name string, o ...DeleteOptionFunc) (*clustersv1.Cluster, error) {
+	opts := ResolveDeleteOptions(o)
+
 	// @TODO check whether the user is an admin in the team
 
 	logger := log.WithFields(log.Fields{
@@ -84,7 +86,7 @@ func (c *clustersImpl) Delete(ctx context.Context, name string) (*clustersv1.Clu
 		return nil, validation.NewError("the cluster can not be deleted").WithFieldError(validation.FieldRoot, validation.ReadOnly, "cluster is read-only")
 	}
 
-	return original, c.Store().Client().Delete(ctx, store.DeleteOptions.From(original))
+	return original, c.Store().Client().Delete(ctx, append(opts.StoreOptions(), store.DeleteOptions.From(original))...)
 }
 
 // List returns a list of clusters we have access to

--- a/pkg/kore/errors.go
+++ b/pkg/kore/errors.go
@@ -16,7 +16,9 @@
 
 package kore
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrOnRevision indicates the object is older than the revision in source.

--- a/pkg/kore/helpers.go
+++ b/pkg/kore/helpers.go
@@ -288,6 +288,11 @@ func EmptyUser(username string) *orgv1.User {
 	}
 }
 
+// IsReadOnlyResource returns true if the given Kubernetes object is read-only
+func IsReadOnlyResource(object metav1.Object) bool {
+	return object.GetAnnotations()[AnnotationReadOnly] == AnnotationValueTrue
+}
+
 // IsSystemResource returns true if the given Kubernetes object is managed by Kore
 func IsSystemResource(object metav1.Object) bool {
 	return object.GetAnnotations()[AnnotationSystem] == AnnotationValueTrue

--- a/pkg/kore/helpers.go
+++ b/pkg/kore/helpers.go
@@ -287,3 +287,8 @@ func EmptyUser(username string) *orgv1.User {
 		Spec: orgv1.UserSpec{Username: username},
 	}
 }
+
+// IsSystemResource returns true if the given Kubernetes object is managed by Kore
+func IsSystemResource(object metav1.Object) bool {
+	return object.GetAnnotations()[AnnotationSystem] == AnnotationValueTrue
+}

--- a/pkg/kore/korefakes/fake_service_credentials.go
+++ b/pkg/kore/korefakes/fake_service_credentials.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FakeServiceCredentials struct {
-	DeleteStub        func(context.Context, string) (*v1.ServiceCredentials, error)
+	DeleteStub        func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServiceCredentials, error)
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
+		arg3 []kore.DeleteOptionFunc
 	}
 	deleteReturns struct {
 		result1 *v1.ServiceCredentials
@@ -68,17 +69,18 @@ type FakeServiceCredentials struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceCredentials) Delete(arg1 context.Context, arg2 string) (*v1.ServiceCredentials, error) {
+func (fake *FakeServiceCredentials) Delete(arg1 context.Context, arg2 string, arg3 ...kore.DeleteOptionFunc) (*v1.ServiceCredentials, error) {
 	fake.deleteMutex.Lock()
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
+		arg3 []kore.DeleteOptionFunc
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Delete", []interface{}{arg1, arg2, arg3})
 	fake.deleteMutex.Unlock()
 	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2)
+		return fake.DeleteStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -93,17 +95,17 @@ func (fake *FakeServiceCredentials) DeleteCallCount() int {
 	return len(fake.deleteArgsForCall)
 }
 
-func (fake *FakeServiceCredentials) DeleteCalls(stub func(context.Context, string) (*v1.ServiceCredentials, error)) {
+func (fake *FakeServiceCredentials) DeleteCalls(stub func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServiceCredentials, error)) {
 	fake.deleteMutex.Lock()
 	defer fake.deleteMutex.Unlock()
 	fake.DeleteStub = stub
 }
 
-func (fake *FakeServiceCredentials) DeleteArgsForCall(i int) (context.Context, string) {
+func (fake *FakeServiceCredentials) DeleteArgsForCall(i int) (context.Context, string, []kore.DeleteOptionFunc) {
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
 	argsForCall := fake.deleteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeServiceCredentials) DeleteReturns(result1 *v1.ServiceCredentials, result2 error) {

--- a/pkg/kore/korefakes/fake_service_kinds.go
+++ b/pkg/kore/korefakes/fake_service_kinds.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FakeServiceKinds struct {
-	DeleteStub        func(context.Context, string) (*v1.ServiceKind, error)
+	DeleteStub        func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServiceKind, error)
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
+		arg3 []kore.DeleteOptionFunc
 	}
 	deleteReturns struct {
 		result1 *v1.ServiceKind
@@ -82,17 +83,18 @@ type FakeServiceKinds struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceKinds) Delete(arg1 context.Context, arg2 string) (*v1.ServiceKind, error) {
+func (fake *FakeServiceKinds) Delete(arg1 context.Context, arg2 string, arg3 ...kore.DeleteOptionFunc) (*v1.ServiceKind, error) {
 	fake.deleteMutex.Lock()
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
+		arg3 []kore.DeleteOptionFunc
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Delete", []interface{}{arg1, arg2, arg3})
 	fake.deleteMutex.Unlock()
 	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2)
+		return fake.DeleteStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -107,17 +109,17 @@ func (fake *FakeServiceKinds) DeleteCallCount() int {
 	return len(fake.deleteArgsForCall)
 }
 
-func (fake *FakeServiceKinds) DeleteCalls(stub func(context.Context, string) (*v1.ServiceKind, error)) {
+func (fake *FakeServiceKinds) DeleteCalls(stub func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServiceKind, error)) {
 	fake.deleteMutex.Lock()
 	defer fake.deleteMutex.Unlock()
 	fake.DeleteStub = stub
 }
 
-func (fake *FakeServiceKinds) DeleteArgsForCall(i int) (context.Context, string) {
+func (fake *FakeServiceKinds) DeleteArgsForCall(i int) (context.Context, string, []kore.DeleteOptionFunc) {
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
 	argsForCall := fake.deleteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeServiceKinds) DeleteReturns(result1 *v1.ServiceKind, result2 error) {

--- a/pkg/kore/korefakes/fake_service_kinds.go
+++ b/pkg/kore/korefakes/fake_service_kinds.go
@@ -10,6 +10,19 @@ import (
 )
 
 type FakeServiceKinds struct {
+	CheckDeleteStub        func(context.Context, *v1.ServiceKind, ...kore.DeleteOptionFunc) error
+	checkDeleteMutex       sync.RWMutex
+	checkDeleteArgsForCall []struct {
+		arg1 context.Context
+		arg2 *v1.ServiceKind
+		arg3 []kore.DeleteOptionFunc
+	}
+	checkDeleteReturns struct {
+		result1 error
+	}
+	checkDeleteReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeleteStub        func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServiceKind, error)
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
@@ -81,6 +94,68 @@ type FakeServiceKinds struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeServiceKinds) CheckDelete(arg1 context.Context, arg2 *v1.ServiceKind, arg3 ...kore.DeleteOptionFunc) error {
+	fake.checkDeleteMutex.Lock()
+	ret, specificReturn := fake.checkDeleteReturnsOnCall[len(fake.checkDeleteArgsForCall)]
+	fake.checkDeleteArgsForCall = append(fake.checkDeleteArgsForCall, struct {
+		arg1 context.Context
+		arg2 *v1.ServiceKind
+		arg3 []kore.DeleteOptionFunc
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("CheckDelete", []interface{}{arg1, arg2, arg3})
+	fake.checkDeleteMutex.Unlock()
+	if fake.CheckDeleteStub != nil {
+		return fake.CheckDeleteStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkDeleteReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeServiceKinds) CheckDeleteCallCount() int {
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
+	return len(fake.checkDeleteArgsForCall)
+}
+
+func (fake *FakeServiceKinds) CheckDeleteCalls(stub func(context.Context, *v1.ServiceKind, ...kore.DeleteOptionFunc) error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = stub
+}
+
+func (fake *FakeServiceKinds) CheckDeleteArgsForCall(i int) (context.Context, *v1.ServiceKind, []kore.DeleteOptionFunc) {
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
+	argsForCall := fake.checkDeleteArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeServiceKinds) CheckDeleteReturns(result1 error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = nil
+	fake.checkDeleteReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeServiceKinds) CheckDeleteReturnsOnCall(i int, result1 error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = nil
+	if fake.checkDeleteReturnsOnCall == nil {
+		fake.checkDeleteReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkDeleteReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeServiceKinds) Delete(arg1 context.Context, arg2 string, arg3 ...kore.DeleteOptionFunc) (*v1.ServiceKind, error) {
@@ -404,6 +479,8 @@ func (fake *FakeServiceKinds) UpdateReturnsOnCall(i int, result1 error) {
 func (fake *FakeServiceKinds) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
 	fake.getMutex.RLock()

--- a/pkg/kore/korefakes/fake_service_plans.go
+++ b/pkg/kore/korefakes/fake_service_plans.go
@@ -10,12 +10,12 @@ import (
 )
 
 type FakeServicePlans struct {
-	DeleteStub        func(context.Context, string, bool) (*v1.ServicePlan, error)
+	DeleteStub        func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServicePlan, error)
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
-		arg3 bool
+		arg3 []kore.DeleteOptionFunc
 	}
 	deleteReturns struct {
 		result1 *v1.ServicePlan
@@ -113,18 +113,18 @@ type FakeServicePlans struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServicePlans) Delete(arg1 context.Context, arg2 string, arg3 bool) (*v1.ServicePlan, error) {
+func (fake *FakeServicePlans) Delete(arg1 context.Context, arg2 string, arg3 ...kore.DeleteOptionFunc) (*v1.ServicePlan, error) {
 	fake.deleteMutex.Lock()
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
-		arg3 bool
+		arg3 []kore.DeleteOptionFunc
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("Delete", []interface{}{arg1, arg2, arg3})
 	fake.deleteMutex.Unlock()
 	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2, arg3)
+		return fake.DeleteStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -139,13 +139,13 @@ func (fake *FakeServicePlans) DeleteCallCount() int {
 	return len(fake.deleteArgsForCall)
 }
 
-func (fake *FakeServicePlans) DeleteCalls(stub func(context.Context, string, bool) (*v1.ServicePlan, error)) {
+func (fake *FakeServicePlans) DeleteCalls(stub func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServicePlan, error)) {
 	fake.deleteMutex.Lock()
 	defer fake.deleteMutex.Unlock()
 	fake.DeleteStub = stub
 }
 
-func (fake *FakeServicePlans) DeleteArgsForCall(i int) (context.Context, string, bool) {
+func (fake *FakeServicePlans) DeleteArgsForCall(i int) (context.Context, string, []kore.DeleteOptionFunc) {
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
 	argsForCall := fake.deleteArgsForCall[i]

--- a/pkg/kore/korefakes/fake_service_plans.go
+++ b/pkg/kore/korefakes/fake_service_plans.go
@@ -69,30 +69,17 @@ type FakeServicePlans struct {
 		result1 bool
 		result2 error
 	}
-	ListStub        func(context.Context) (*v1.ServicePlanList, error)
+	ListStub        func(context.Context, ...func(plan v1.ServicePlan) bool) (*v1.ServicePlanList, error)
 	listMutex       sync.RWMutex
 	listArgsForCall []struct {
 		arg1 context.Context
+		arg2 []func(plan v1.ServicePlan) bool
 	}
 	listReturns struct {
 		result1 *v1.ServicePlanList
 		result2 error
 	}
 	listReturnsOnCall map[int]struct {
-		result1 *v1.ServicePlanList
-		result2 error
-	}
-	ListFilteredStub        func(context.Context, func(v1.ServicePlan) bool) (*v1.ServicePlanList, error)
-	listFilteredMutex       sync.RWMutex
-	listFilteredArgsForCall []struct {
-		arg1 context.Context
-		arg2 func(v1.ServicePlan) bool
-	}
-	listFilteredReturns struct {
-		result1 *v1.ServicePlanList
-		result2 error
-	}
-	listFilteredReturnsOnCall map[int]struct {
 		result1 *v1.ServicePlanList
 		result2 error
 	}
@@ -372,16 +359,17 @@ func (fake *FakeServicePlans) HasReturnsOnCall(i int, result1 bool, result2 erro
 	}{result1, result2}
 }
 
-func (fake *FakeServicePlans) List(arg1 context.Context) (*v1.ServicePlanList, error) {
+func (fake *FakeServicePlans) List(arg1 context.Context, arg2 ...func(plan v1.ServicePlan) bool) (*v1.ServicePlanList, error) {
 	fake.listMutex.Lock()
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		arg1 context.Context
-	}{arg1})
-	fake.recordInvocation("List", []interface{}{arg1})
+		arg2 []func(plan v1.ServicePlan) bool
+	}{arg1, arg2})
+	fake.recordInvocation("List", []interface{}{arg1, arg2})
 	fake.listMutex.Unlock()
 	if fake.ListStub != nil {
-		return fake.ListStub(arg1)
+		return fake.ListStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -396,17 +384,17 @@ func (fake *FakeServicePlans) ListCallCount() int {
 	return len(fake.listArgsForCall)
 }
 
-func (fake *FakeServicePlans) ListCalls(stub func(context.Context) (*v1.ServicePlanList, error)) {
+func (fake *FakeServicePlans) ListCalls(stub func(context.Context, ...func(plan v1.ServicePlan) bool) (*v1.ServicePlanList, error)) {
 	fake.listMutex.Lock()
 	defer fake.listMutex.Unlock()
 	fake.ListStub = stub
 }
 
-func (fake *FakeServicePlans) ListArgsForCall(i int) context.Context {
+func (fake *FakeServicePlans) ListArgsForCall(i int) (context.Context, []func(plan v1.ServicePlan) bool) {
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
 	argsForCall := fake.listArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeServicePlans) ListReturns(result1 *v1.ServicePlanList, result2 error) {
@@ -430,70 +418,6 @@ func (fake *FakeServicePlans) ListReturnsOnCall(i int, result1 *v1.ServicePlanLi
 		})
 	}
 	fake.listReturnsOnCall[i] = struct {
-		result1 *v1.ServicePlanList
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServicePlans) ListFiltered(arg1 context.Context, arg2 func(v1.ServicePlan) bool) (*v1.ServicePlanList, error) {
-	fake.listFilteredMutex.Lock()
-	ret, specificReturn := fake.listFilteredReturnsOnCall[len(fake.listFilteredArgsForCall)]
-	fake.listFilteredArgsForCall = append(fake.listFilteredArgsForCall, struct {
-		arg1 context.Context
-		arg2 func(v1.ServicePlan) bool
-	}{arg1, arg2})
-	fake.recordInvocation("ListFiltered", []interface{}{arg1, arg2})
-	fake.listFilteredMutex.Unlock()
-	if fake.ListFilteredStub != nil {
-		return fake.ListFilteredStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.listFilteredReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeServicePlans) ListFilteredCallCount() int {
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
-	return len(fake.listFilteredArgsForCall)
-}
-
-func (fake *FakeServicePlans) ListFilteredCalls(stub func(context.Context, func(v1.ServicePlan) bool) (*v1.ServicePlanList, error)) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = stub
-}
-
-func (fake *FakeServicePlans) ListFilteredArgsForCall(i int) (context.Context, func(v1.ServicePlan) bool) {
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
-	argsForCall := fake.listFilteredArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeServicePlans) ListFilteredReturns(result1 *v1.ServicePlanList, result2 error) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = nil
-	fake.listFilteredReturns = struct {
-		result1 *v1.ServicePlanList
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServicePlans) ListFilteredReturnsOnCall(i int, result1 *v1.ServicePlanList, result2 error) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = nil
-	if fake.listFilteredReturnsOnCall == nil {
-		fake.listFilteredReturnsOnCall = make(map[int]struct {
-			result1 *v1.ServicePlanList
-			result2 error
-		})
-	}
-	fake.listFilteredReturnsOnCall[i] = struct {
 		result1 *v1.ServicePlanList
 		result2 error
 	}{result1, result2}
@@ -574,8 +498,6 @@ func (fake *FakeServicePlans) Invocations() map[string][][]interface{} {
 	defer fake.hasMutex.RUnlock()
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/kore/korefakes/fake_service_plans.go
+++ b/pkg/kore/korefakes/fake_service_plans.go
@@ -10,6 +10,19 @@ import (
 )
 
 type FakeServicePlans struct {
+	CheckDeleteStub        func(context.Context, *v1.ServicePlan, ...kore.DeleteOptionFunc) error
+	checkDeleteMutex       sync.RWMutex
+	checkDeleteArgsForCall []struct {
+		arg1 context.Context
+		arg2 *v1.ServicePlan
+		arg3 []kore.DeleteOptionFunc
+	}
+	checkDeleteReturns struct {
+		result1 error
+	}
+	checkDeleteReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeleteStub        func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.ServicePlan, error)
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
@@ -98,6 +111,68 @@ type FakeServicePlans struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeServicePlans) CheckDelete(arg1 context.Context, arg2 *v1.ServicePlan, arg3 ...kore.DeleteOptionFunc) error {
+	fake.checkDeleteMutex.Lock()
+	ret, specificReturn := fake.checkDeleteReturnsOnCall[len(fake.checkDeleteArgsForCall)]
+	fake.checkDeleteArgsForCall = append(fake.checkDeleteArgsForCall, struct {
+		arg1 context.Context
+		arg2 *v1.ServicePlan
+		arg3 []kore.DeleteOptionFunc
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("CheckDelete", []interface{}{arg1, arg2, arg3})
+	fake.checkDeleteMutex.Unlock()
+	if fake.CheckDeleteStub != nil {
+		return fake.CheckDeleteStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkDeleteReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeServicePlans) CheckDeleteCallCount() int {
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
+	return len(fake.checkDeleteArgsForCall)
+}
+
+func (fake *FakeServicePlans) CheckDeleteCalls(stub func(context.Context, *v1.ServicePlan, ...kore.DeleteOptionFunc) error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = stub
+}
+
+func (fake *FakeServicePlans) CheckDeleteArgsForCall(i int) (context.Context, *v1.ServicePlan, []kore.DeleteOptionFunc) {
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
+	argsForCall := fake.checkDeleteArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeServicePlans) CheckDeleteReturns(result1 error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = nil
+	fake.checkDeleteReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeServicePlans) CheckDeleteReturnsOnCall(i int, result1 error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = nil
+	if fake.checkDeleteReturnsOnCall == nil {
+		fake.checkDeleteReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkDeleteReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeServicePlans) Delete(arg1 context.Context, arg2 string, arg3 ...kore.DeleteOptionFunc) (*v1.ServicePlan, error) {
@@ -488,6 +563,8 @@ func (fake *FakeServicePlans) UpdateReturnsOnCall(i int, result1 error) {
 func (fake *FakeServicePlans) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
 	fake.getMutex.RLock()

--- a/pkg/kore/korefakes/fake_services.go
+++ b/pkg/kore/korefakes/fake_services.go
@@ -10,6 +10,19 @@ import (
 )
 
 type FakeServices struct {
+	CheckDeleteStub        func(context.Context, *v1.Service, ...kore.DeleteOptionFunc) error
+	checkDeleteMutex       sync.RWMutex
+	checkDeleteArgsForCall []struct {
+		arg1 context.Context
+		arg2 *v1.Service
+		arg3 []kore.DeleteOptionFunc
+	}
+	checkDeleteReturns struct {
+		result1 error
+	}
+	checkDeleteReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeleteStub        func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.Service, error)
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
@@ -67,6 +80,68 @@ type FakeServices struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeServices) CheckDelete(arg1 context.Context, arg2 *v1.Service, arg3 ...kore.DeleteOptionFunc) error {
+	fake.checkDeleteMutex.Lock()
+	ret, specificReturn := fake.checkDeleteReturnsOnCall[len(fake.checkDeleteArgsForCall)]
+	fake.checkDeleteArgsForCall = append(fake.checkDeleteArgsForCall, struct {
+		arg1 context.Context
+		arg2 *v1.Service
+		arg3 []kore.DeleteOptionFunc
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("CheckDelete", []interface{}{arg1, arg2, arg3})
+	fake.checkDeleteMutex.Unlock()
+	if fake.CheckDeleteStub != nil {
+		return fake.CheckDeleteStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkDeleteReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeServices) CheckDeleteCallCount() int {
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
+	return len(fake.checkDeleteArgsForCall)
+}
+
+func (fake *FakeServices) CheckDeleteCalls(stub func(context.Context, *v1.Service, ...kore.DeleteOptionFunc) error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = stub
+}
+
+func (fake *FakeServices) CheckDeleteArgsForCall(i int) (context.Context, *v1.Service, []kore.DeleteOptionFunc) {
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
+	argsForCall := fake.checkDeleteArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeServices) CheckDeleteReturns(result1 error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = nil
+	fake.checkDeleteReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeServices) CheckDeleteReturnsOnCall(i int, result1 error) {
+	fake.checkDeleteMutex.Lock()
+	defer fake.checkDeleteMutex.Unlock()
+	fake.CheckDeleteStub = nil
+	if fake.checkDeleteReturnsOnCall == nil {
+		fake.checkDeleteReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkDeleteReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeServices) Delete(arg1 context.Context, arg2 string, arg3 ...kore.DeleteOptionFunc) (*v1.Service, error) {
@@ -326,6 +401,8 @@ func (fake *FakeServices) UpdateReturnsOnCall(i int, result1 error) {
 func (fake *FakeServices) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.checkDeleteMutex.RLock()
+	defer fake.checkDeleteMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
 	fake.getMutex.RLock()

--- a/pkg/kore/korefakes/fake_services.go
+++ b/pkg/kore/korefakes/fake_services.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FakeServices struct {
-	DeleteStub        func(context.Context, string) (*v1.Service, error)
+	DeleteStub        func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.Service, error)
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
+		arg3 []kore.DeleteOptionFunc
 	}
 	deleteReturns struct {
 		result1 *v1.Service
@@ -81,17 +82,18 @@ type FakeServices struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServices) Delete(arg1 context.Context, arg2 string) (*v1.Service, error) {
+func (fake *FakeServices) Delete(arg1 context.Context, arg2 string, arg3 ...kore.DeleteOptionFunc) (*v1.Service, error) {
 	fake.deleteMutex.Lock()
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
+		arg3 []kore.DeleteOptionFunc
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Delete", []interface{}{arg1, arg2, arg3})
 	fake.deleteMutex.Unlock()
 	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2)
+		return fake.DeleteStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -106,17 +108,17 @@ func (fake *FakeServices) DeleteCallCount() int {
 	return len(fake.deleteArgsForCall)
 }
 
-func (fake *FakeServices) DeleteCalls(stub func(context.Context, string) (*v1.Service, error)) {
+func (fake *FakeServices) DeleteCalls(stub func(context.Context, string, ...kore.DeleteOptionFunc) (*v1.Service, error)) {
 	fake.deleteMutex.Lock()
 	defer fake.deleteMutex.Unlock()
 	fake.DeleteStub = stub
 }
 
-func (fake *FakeServices) DeleteArgsForCall(i int) (context.Context, string) {
+func (fake *FakeServices) DeleteArgsForCall(i int) (context.Context, string, []kore.DeleteOptionFunc) {
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
 	argsForCall := fake.deleteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeServices) DeleteReturns(result1 *v1.Service, result2 error) {

--- a/pkg/kore/korefakes/fake_services.go
+++ b/pkg/kore/korefakes/fake_services.go
@@ -39,30 +39,17 @@ type FakeServices struct {
 		result1 *v1.Service
 		result2 error
 	}
-	ListStub        func(context.Context) (*v1.ServiceList, error)
+	ListStub        func(context.Context, ...func(v1.Service) bool) (*v1.ServiceList, error)
 	listMutex       sync.RWMutex
 	listArgsForCall []struct {
 		arg1 context.Context
+		arg2 []func(v1.Service) bool
 	}
 	listReturns struct {
 		result1 *v1.ServiceList
 		result2 error
 	}
 	listReturnsOnCall map[int]struct {
-		result1 *v1.ServiceList
-		result2 error
-	}
-	ListFilteredStub        func(context.Context, func(v1.Service) bool) (*v1.ServiceList, error)
-	listFilteredMutex       sync.RWMutex
-	listFilteredArgsForCall []struct {
-		arg1 context.Context
-		arg2 func(v1.Service) bool
-	}
-	listFilteredReturns struct {
-		result1 *v1.ServiceList
-		result2 error
-	}
-	listFilteredReturnsOnCall map[int]struct {
 		result1 *v1.ServiceList
 		result2 error
 	}
@@ -211,16 +198,17 @@ func (fake *FakeServices) GetReturnsOnCall(i int, result1 *v1.Service, result2 e
 	}{result1, result2}
 }
 
-func (fake *FakeServices) List(arg1 context.Context) (*v1.ServiceList, error) {
+func (fake *FakeServices) List(arg1 context.Context, arg2 ...func(v1.Service) bool) (*v1.ServiceList, error) {
 	fake.listMutex.Lock()
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		arg1 context.Context
-	}{arg1})
-	fake.recordInvocation("List", []interface{}{arg1})
+		arg2 []func(v1.Service) bool
+	}{arg1, arg2})
+	fake.recordInvocation("List", []interface{}{arg1, arg2})
 	fake.listMutex.Unlock()
 	if fake.ListStub != nil {
-		return fake.ListStub(arg1)
+		return fake.ListStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -235,17 +223,17 @@ func (fake *FakeServices) ListCallCount() int {
 	return len(fake.listArgsForCall)
 }
 
-func (fake *FakeServices) ListCalls(stub func(context.Context) (*v1.ServiceList, error)) {
+func (fake *FakeServices) ListCalls(stub func(context.Context, ...func(v1.Service) bool) (*v1.ServiceList, error)) {
 	fake.listMutex.Lock()
 	defer fake.listMutex.Unlock()
 	fake.ListStub = stub
 }
 
-func (fake *FakeServices) ListArgsForCall(i int) context.Context {
+func (fake *FakeServices) ListArgsForCall(i int) (context.Context, []func(v1.Service) bool) {
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
 	argsForCall := fake.listArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeServices) ListReturns(result1 *v1.ServiceList, result2 error) {
@@ -269,70 +257,6 @@ func (fake *FakeServices) ListReturnsOnCall(i int, result1 *v1.ServiceList, resu
 		})
 	}
 	fake.listReturnsOnCall[i] = struct {
-		result1 *v1.ServiceList
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServices) ListFiltered(arg1 context.Context, arg2 func(v1.Service) bool) (*v1.ServiceList, error) {
-	fake.listFilteredMutex.Lock()
-	ret, specificReturn := fake.listFilteredReturnsOnCall[len(fake.listFilteredArgsForCall)]
-	fake.listFilteredArgsForCall = append(fake.listFilteredArgsForCall, struct {
-		arg1 context.Context
-		arg2 func(v1.Service) bool
-	}{arg1, arg2})
-	fake.recordInvocation("ListFiltered", []interface{}{arg1, arg2})
-	fake.listFilteredMutex.Unlock()
-	if fake.ListFilteredStub != nil {
-		return fake.ListFilteredStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.listFilteredReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeServices) ListFilteredCallCount() int {
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
-	return len(fake.listFilteredArgsForCall)
-}
-
-func (fake *FakeServices) ListFilteredCalls(stub func(context.Context, func(v1.Service) bool) (*v1.ServiceList, error)) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = stub
-}
-
-func (fake *FakeServices) ListFilteredArgsForCall(i int) (context.Context, func(v1.Service) bool) {
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
-	argsForCall := fake.listFilteredArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeServices) ListFilteredReturns(result1 *v1.ServiceList, result2 error) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = nil
-	fake.listFilteredReturns = struct {
-		result1 *v1.ServiceList
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServices) ListFilteredReturnsOnCall(i int, result1 *v1.ServiceList, result2 error) {
-	fake.listFilteredMutex.Lock()
-	defer fake.listFilteredMutex.Unlock()
-	fake.ListFilteredStub = nil
-	if fake.listFilteredReturnsOnCall == nil {
-		fake.listFilteredReturnsOnCall = make(map[int]struct {
-			result1 *v1.ServiceList
-			result2 error
-		})
-	}
-	fake.listFilteredReturnsOnCall[i] = struct {
 		result1 *v1.ServiceList
 		result2 error
 	}{result1, result2}
@@ -408,8 +332,6 @@ func (fake *FakeServices) Invocations() map[string][][]interface{} {
 	defer fake.getMutex.RUnlock()
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
-	fake.listFilteredMutex.RLock()
-	defer fake.listFilteredMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/kore/service_credentials.go
+++ b/pkg/kore/service_credentials.go
@@ -94,16 +94,16 @@ func (s *serviceCredentialsImpl) List(ctx context.Context, filters ...func(crede
 	}
 
 	res := []servicesv1.ServiceCredentials{}
-	for _, sc := range list.Items {
+	for _, item := range list.Items {
 		if func() bool {
 			for _, filter := range filters {
-				if !filter(sc) {
+				if !filter(item) {
 					return false
 				}
 			}
 			return true
 		}() {
-			res = append(res, sc)
+			res = append(res, item)
 		}
 	}
 	list.Items = res

--- a/pkg/kore/service_credentials.go
+++ b/pkg/kore/service_credentials.go
@@ -37,7 +37,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . ServiceCredentials
 type ServiceCredentials interface {
 	// Delete is used to delete service credentials
-	Delete(context.Context, string) (*servicesv1.ServiceCredentials, error)
+	Delete(context.Context, string, ...DeleteOptionFunc) (*servicesv1.ServiceCredentials, error)
 	// Get returns a specific service credentials
 	Get(context.Context, string) (*servicesv1.ServiceCredentials, error)
 	// List returns a list of service credentials.
@@ -54,7 +54,9 @@ type serviceCredentialsImpl struct {
 }
 
 // Delete is used to delete service credentials
-func (s *serviceCredentialsImpl) Delete(ctx context.Context, name string) (*servicesv1.ServiceCredentials, error) {
+func (s *serviceCredentialsImpl) Delete(ctx context.Context, name string, o ...DeleteOptionFunc) (*servicesv1.ServiceCredentials, error) {
+	opts := ResolveDeleteOptions(o)
+
 	logger := log.WithFields(log.Fields{
 		"serviceCredentials": name,
 		"team":               s.team,
@@ -72,7 +74,7 @@ func (s *serviceCredentialsImpl) Delete(ctx context.Context, name string) (*serv
 		return nil, err
 	}
 
-	return original, s.Store().Client().Delete(ctx, store.DeleteOptions.From(original))
+	return original, s.Store().Client().Delete(ctx, append(opts.StoreOptions(), store.DeleteOptions.From(original))...)
 }
 
 // List returns a list of service credentials we have access to

--- a/pkg/kore/service_kinds.go
+++ b/pkg/kore/service_kinds.go
@@ -39,6 +39,7 @@ type ServiceKinds interface {
 	// Get returns the service kind
 	Get(context.Context, string) (*servicesv1.ServiceKind, error)
 	// List returns the existing service kinds
+	// The optional filter functions can be used to include items only for which all functions return true
 	List(context.Context, ...func(servicesv1.ServiceKind) bool) (*servicesv1.ServiceKindList, error)
 	// Has checks if a service kind exists
 	Has(context.Context, string) (bool, error)

--- a/pkg/kore/service_plans.go
+++ b/pkg/kore/service_plans.go
@@ -107,12 +107,13 @@ func (p servicePlansImpl) Update(ctx context.Context, plan *servicesv1.ServicePl
 		}
 	}
 
+	kind, err := p.ServiceKinds().Get(ctx, plan.Spec.Kind)
+	if err != nil {
+		return fmt.Errorf("failed to get service kind %q: %w", plan.Spec.Kind, err)
+	}
+
 	schema := plan.Spec.Schema
 	if schema == "" {
-		kind, err := p.ServiceKinds().Get(ctx, plan.Spec.Kind)
-		if err != nil {
-			return fmt.Errorf("failed to get service kind %q: %w", plan.Spec.Kind, err)
-		}
 		schema = kind.Spec.Schema
 	}
 

--- a/pkg/kore/service_plans.go
+++ b/pkg/kore/service_plans.go
@@ -25,13 +25,12 @@ import (
 	"strings"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
-	"github.com/appvia/kore/pkg/utils/jsonutils"
-
-	"github.com/appvia/kore/pkg/utils"
-
 	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
 	"github.com/appvia/kore/pkg/store"
+	"github.com/appvia/kore/pkg/utils"
 	"github.com/appvia/kore/pkg/utils/jsonschema"
+	"github.com/appvia/kore/pkg/utils/jsonutils"
+	"github.com/appvia/kore/pkg/utils/kubernetes"
 	"github.com/appvia/kore/pkg/utils/validation"
 
 	log "github.com/sirupsen/logrus"
@@ -47,6 +46,8 @@ type ServicePlanDetails struct {
 // ServicePlans is the interface to manage service plans
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . ServicePlans
 type ServicePlans interface {
+	// CheckDelete verifies whether the service plan can be deleted
+	CheckDelete(context.Context, *servicesv1.ServicePlan, ...DeleteOptionFunc) error
 	// Delete is used to delete a service plan in the kore
 	Delete(context.Context, string, ...DeleteOptionFunc) (*servicesv1.ServicePlan, error)
 	// Get returns the service plan
@@ -147,6 +148,41 @@ func (p servicePlansImpl) Update(ctx context.Context, plan *servicesv1.ServicePl
 	return nil
 }
 
+// CheckDelete verifies whether the service plan can be deleted
+func (p servicePlansImpl) CheckDelete(ctx context.Context, servicePlan *servicesv1.ServicePlan, o ...DeleteOptionFunc) error {
+	opts := ResolveDeleteOptions(o)
+
+	if !opts.Cascade {
+		var dependents []kubernetes.DependentReference
+
+		teamList, err := p.Teams().List(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list teams: %w", err)
+		}
+
+		for _, team := range teamList.Items {
+			services, err := p.Teams().Team(team.Name).Services().List(ctx, func(s servicesv1.Service) bool {
+				return s.Spec.Plan == servicePlan.Name
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list services: %w", err)
+			}
+			for _, item := range services.Items {
+				dependents = append(dependents, kubernetes.DependentReferenceFromObject(&item))
+			}
+		}
+
+		if len(dependents) > 0 {
+			return validation.ErrDependencyViolation{
+				Message:    "the following objects need to be deleted first",
+				Dependents: dependents,
+			}
+		}
+	}
+
+	return nil
+}
+
 // Delete is used to delete a service plan in the kore
 func (p servicePlansImpl) Delete(ctx context.Context, name string, o ...DeleteOptionFunc) (*servicesv1.ServicePlan, error) {
 	opts := ResolveDeleteOptions(o)
@@ -166,29 +202,8 @@ func (p servicePlansImpl) Delete(ctx context.Context, name string, o ...DeleteOp
 		return nil, err
 	}
 
-	if !opts.IgnoreReadOnly {
-		if plan.Annotations[AnnotationReadOnly] == AnnotationValueTrue {
-			return nil, validation.NewError("the service plan can not be deleted").
-				WithFieldError(validation.FieldRoot, validation.ReadOnly, "service plan is read-only")
-		}
-	}
-
-	servicesWithPlan, err := p.getServicesWithPlan(ctx, name)
-	if err != nil {
+	if err := opts.Check(plan, func(o ...DeleteOptionFunc) error { return p.CheckDelete(ctx, plan, o...) }); err != nil {
 		return nil, err
-	}
-	if len(servicesWithPlan) > 0 {
-		if len(servicesWithPlan) <= 5 {
-			return nil, fmt.Errorf(
-				"the service plan can not be deleted as there are %d services using it: %s",
-				len(servicesWithPlan),
-				strings.Join(servicesWithPlan, ", "),
-			)
-		}
-		return nil, fmt.Errorf(
-			"the service plan can not be deleted as there are %d services using it",
-			len(servicesWithPlan),
-		)
 	}
 
 	if err := p.Store().Client().Delete(ctx, append(opts.StoreOptions(), store.DeleteOptions.From(plan))...); err != nil {
@@ -352,27 +367,4 @@ func (p servicePlansImpl) compileTemplate(content string, cluster *clustersv1.Cl
 	}
 
 	return tmplBuf.String(), nil
-}
-
-func (p servicePlansImpl) getServicesWithPlan(ctx context.Context, clusterName string) ([]string, error) {
-	var res []string
-
-	teamList, err := p.Teams().List(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, team := range teamList.Items {
-		servicesList, err := p.Teams().Team(team.Name).Services().List(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, service := range servicesList.Items {
-			if service.Spec.Plan == clusterName {
-				res = append(res, fmt.Sprintf("%s/%s", team.Name, service.Name))
-			}
-		}
-	}
-
-	return res, nil
 }

--- a/pkg/kore/service_providers.go
+++ b/pkg/kore/service_providers.go
@@ -423,7 +423,7 @@ func (p *serviceProvidersImpl) GetProviderForKind(ctx Context, kind string) (Ser
 	}
 
 	if len(providerList.Items) == 0 {
-		return nil, fmt.Errorf("no available service provider for kind %q", kind)
+		return nil, ErrNotFound
 	}
 
 	return p.register(ctx, &providerList.Items[0])

--- a/pkg/kore/services.go
+++ b/pkg/kore/services.go
@@ -43,7 +43,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Services
 type Services interface {
 	// Delete is used to delete a service
-	Delete(context.Context, string) (*servicesv1.Service, error)
+	Delete(context.Context, string, ...DeleteOptionFunc) (*servicesv1.Service, error)
 	// Get returns a specific service
 	Get(context.Context, string) (*servicesv1.Service, error)
 	// List returns a list of services
@@ -61,7 +61,9 @@ type servicesImpl struct {
 }
 
 // Delete is used to delete a service
-func (s *servicesImpl) Delete(ctx context.Context, name string) (*servicesv1.Service, error) {
+func (s *servicesImpl) Delete(ctx context.Context, name string, o ...DeleteOptionFunc) (*servicesv1.Service, error) {
+	opts := ResolveDeleteOptions(o)
+
 	logger := log.WithFields(log.Fields{
 		"service": name,
 		"team":    s.team,
@@ -92,7 +94,7 @@ func (s *servicesImpl) Delete(ctx context.Context, name string) (*servicesv1.Ser
 		return nil, fmt.Errorf("the service can not be deleted, please delete all service credentials first")
 	}
 
-	return original, s.Store().Client().Delete(ctx, store.DeleteOptions.From(original))
+	return original, s.Store().Client().Delete(ctx, append(opts.StoreOptions(), store.DeleteOptions.From(original))...)
 }
 
 // List returns a list of services we have access to

--- a/pkg/kore/services.go
+++ b/pkg/kore/services.go
@@ -170,7 +170,8 @@ func (s *servicesImpl) Update(ctx context.Context, service *servicesv1.Service) 
 		)
 	}
 
-	if err := s.validateCluster(ctx, service); err != nil {
+	_, err := s.validateCluster(ctx, service)
+	if err != nil {
 		return err
 	}
 
@@ -341,9 +342,9 @@ func (s *servicesImpl) validateConfiguration(ctx context.Context, service, exist
 	return nil
 }
 
-func (s *servicesImpl) validateCluster(ctx context.Context, service *servicesv1.Service) error {
+func (s *servicesImpl) validateCluster(ctx context.Context, service *servicesv1.Service) (*clustersv1.Cluster, error) {
 	if service.Spec.Cluster.Name == "" {
-		return validation.NewError("%q failed validation", service.Name).WithFieldError(
+		return nil, validation.NewError("%q failed validation", service.Name).WithFieldError(
 			"cluster.name",
 			validation.Required,
 			"must be set",
@@ -351,7 +352,7 @@ func (s *servicesImpl) validateCluster(ctx context.Context, service *servicesv1.
 	}
 
 	if service.Spec.Cluster.Namespace != service.Namespace {
-		return validation.NewError("%q failed validation", service.Name).WithFieldErrorf(
+		return nil, validation.NewError("%q failed validation", service.Name).WithFieldErrorf(
 			"cluster.namespace",
 			validation.InvalidValue,
 			"must be the same as the team name: %q",
@@ -359,12 +360,12 @@ func (s *servicesImpl) validateCluster(ctx context.Context, service *servicesv1.
 		)
 	}
 
-	if !service.Spec.Cluster.HasGroupVersionKind(clustersv1.ClusterGroupVersionKind) {
-		return validation.NewError("%q failed validation", service.Name).WithFieldErrorf(
+	if !service.Spec.Cluster.HasGroupVersionKind(clustersv1.ClusterGVK) {
+		return nil, validation.NewError("%q failed validation", service.Name).WithFieldErrorf(
 			"cluster",
 			validation.InvalidValue,
 			"must have type of %s",
-			clustersv1.ClusterGroupVersionKind,
+			clustersv1.ClusterGVK,
 		)
 	}
 

--- a/pkg/serviceproviders/application/provider.go
+++ b/pkg/serviceproviders/application/provider.go
@@ -98,9 +98,9 @@ func (p Provider) Catalog(ctx kore.Context, provider *servicesv1.ServiceProvider
 
 func (p Provider) AdminServices() []servicesv1.Service {
 	cluster := corev1.Ownership{
-		Group:     clustersv1.ClusterGroupVersionKind.Group,
-		Version:   clustersv1.ClusterGroupVersionKind.Version,
-		Kind:      clustersv1.ClusterGroupVersionKind.Kind,
+		Group:     clustersv1.ClusterGVK.Group,
+		Version:   clustersv1.ClusterGVK.Version,
+		Kind:      clustersv1.ClusterGVK.Kind,
 		Namespace: "kore-admin",
 		Name:      "kore",
 	}

--- a/pkg/store/client_options.go
+++ b/pkg/store/client_options.go
@@ -17,6 +17,7 @@
 package store
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -49,6 +50,13 @@ var DeleteOptions DeleteOptionsType
 func (d DeleteOptionsType) From(value runtime.Object) DeleteOptionFunc {
 	return func(r *rclient) {
 		r.value = value
+	}
+}
+
+// PropagationPolicy sets the delete propagation policy
+func (d DeleteOptionsType) PropagationPolicy(propagationPolicy metav1.DeletionPropagation) DeleteOptionFunc {
+	return func(r *rclient) {
+		r.propagationPolicy = propagationPolicy
 	}
 }
 

--- a/pkg/utils/kubernetes/ownership.go
+++ b/pkg/utils/kubernetes/ownership.go
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kubernetes
+
+import (
+	"github.com/appvia/kore/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// EnsureOwnerReference ensures the given owner is present in the object's owner references list
+func EnsureOwnerReference(object Object, owner Object, blockOwnerDeletion bool) {
+	if HasOwnerReference(object, owner) {
+		return
+	}
+
+	object.SetOwnerReferences(append(object.GetOwnerReferences(), metav1.OwnerReference{
+		APIVersion:         owner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Kind:               owner.GetObjectKind().GroupVersionKind().Kind,
+		Name:               owner.GetName(),
+		UID:                owner.GetUID(),
+		BlockOwnerDeletion: utils.BoolPtr(blockOwnerDeletion),
+	}))
+}
+
+func HasOwnerReference(object Object, owner Object) bool {
+	for _, o := range object.GetOwnerReferences() {
+		if o.UID == owner.GetUID() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func HasOwnerReferenceWithKind(object Object, gvk schema.GroupVersionKind) bool {
+	for _, o := range object.GetOwnerReferences() {
+		if o.APIVersion == gvk.GroupVersion().String() && o.Kind == gvk.Kind {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/utils/kubernetes/types.go
+++ b/pkg/utils/kubernetes/types.go
@@ -17,13 +17,39 @@
 package kubernetes
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// Object is a Kubernetes object
 type Object interface {
 	runtime.Object
 	metav1.Object
+}
+
+// DependentReference is an object reference to a dependent object in the same namespace
+type DependentReference struct {
+	// API version of the dependent
+	APIVersion string `json:"apiVersion"`
+	// Kind of the dependent
+	Kind string `json:"kind"`
+	// Name of the dependent
+	Name string `json:"name"`
+}
+
+func (d DependentReference) String() string {
+	return fmt.Sprintf("%s/%s/%s", d.APIVersion, d.Kind, d.Name)
+}
+
+// DependentReferenceFromObject creates a DependentReference from the given object
+func DependentReferenceFromObject(o Object) DependentReference {
+	return DependentReference{
+		APIVersion: o.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Kind:       o.GetObjectKind().GroupVersionKind().Kind,
+		Name:       o.GetName(),
+	}
 }
 
 // KubernetesAPI is the configuration for the kubernetes api

--- a/pkg/utils/validation/dependency_violation.go
+++ b/pkg/utils/validation/dependency_violation.go
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	"strings"
+
+	"github.com/appvia/kore/pkg/utils/kubernetes"
+)
+
+type ErrDependencyViolation struct {
+	Message    string                          `json:"message"`
+	Dependents []kubernetes.DependentReference `json:"dependents"`
+}
+
+func (e ErrDependencyViolation) Error() string {
+	str := strings.TrimRight(e.Message, ":") + ":\n"
+	for _, d := range e.Dependents {
+		str = str + " * " + d.String() + "\n"
+	}
+	return str
+}

--- a/ui/kore-api-swagger.json
+++ b/ui/kore-api-swagger.json
@@ -2088,6 +2088,12 @@
             "name": "team",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {

--- a/ui/kore-api-swagger.json
+++ b/ui/kore-api-swagger.json
@@ -1431,6 +1431,12 @@
             "name": "name",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {
@@ -1617,6 +1623,12 @@
             "name": "name",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {
@@ -1859,6 +1871,12 @@
             "name": "name",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2495,6 +2513,12 @@
             "name": "team",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {
@@ -3823,6 +3847,12 @@
             "name": "team",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {
@@ -4529,6 +4559,12 @@
             "name": "team",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {
@@ -4731,6 +4767,12 @@
             "name": "team",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "If true then all objects owned by this object will be deleted too.",
+            "name": "cascade",
+            "in": "query"
           }
         ],
         "responses": {

--- a/ui/lib/components/teams/cluster/Cluster.js
+++ b/ui/lib/components/teams/cluster/Cluster.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import Link from 'next/link'
-import { List, Icon, Typography, Modal, Popconfirm, Tag, Tooltip } from 'antd'
-const { Text, Paragraph } = Typography
+import { List, Icon, Typography, Popconfirm, Tag, Tooltip } from 'antd'
+const { Text } = Typography
 
 import { clusterProviderIconSrcMap, inProgressStatusList } from '../../../utils/ui-helpers'
 import ResourceStatusTag from '../../resources/ResourceStatusTag'
@@ -33,24 +33,6 @@ class Cluster extends AutoRefreshComponent {
   }
 
   deleteCluster = () => {
-    const { namespaceClaims } = this.props
-    if (namespaceClaims.length > 0) {
-      return Modal.warning({
-        title: 'Warning: cluster cannot be deleted',
-        content: (
-          <div>
-            <Paragraph strong>The cluster namespaces must be deleted first</Paragraph>
-            <List
-              size="small"
-              dataSource={namespaceClaims}
-              renderItem={ns => <List.Item>{ns.spec.name}</List.Item>}
-            />
-          </div>
-        ),
-        onOk() {}
-      })
-    }
-
     this.props.deleteCluster(this.props.cluster.metadata.name, () => {
       this.startRefreshing()
     })

--- a/ui/lib/components/teams/cluster/ClustersTab.js
+++ b/ui/lib/components/teams/cluster/ClustersTab.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import Link from 'next/link'
-import { Button, Col, Divider, Icon, Row, Tag, Tooltip, Typography } from 'antd'
+import { Button, Col, Divider, Icon, Row, Tag, Tooltip, Typography, Modal, List } from 'antd'
 const { Paragraph, Text } = Typography
 import { get } from 'lodash'
 
@@ -89,7 +89,22 @@ class ClustersTab extends React.Component {
       this.setState({ clusters }, done)
       loadingMessage(`Cluster deletion requested: ${cluster.metadata.name}`)
     } catch (err) {
-      console.error('Error deleting cluster', err)
+      if (err.statusCode === 409 && err.dependents) {
+        return Modal.warning({
+          title: 'The cluster can not be deleted',
+          content: (
+            <div>
+              <Paragraph strong>Error: {err.message}</Paragraph>
+              <List
+                size="small"
+                dataSource={err.dependents}
+                renderItem={d => <List.Item>{d.kind}: {d.name}</List.Item>}
+              />
+            </div>
+          ),
+          onOk() {}
+        })
+      }
       errorMessage('Error deleting cluster, please try again.')
     }
   }

--- a/ui/lib/components/teams/service/ServicesTab.js
+++ b/ui/lib/components/teams/service/ServicesTab.js
@@ -116,31 +116,25 @@ class ServicesTab extends React.Component {
       this.setState({ services }, done)
       loadingMessage(`Service deletion requested: ${service.metadata.name}`)
     } catch (err) {
+      if (err.statusCode === 409 && err.dependents) {
+        return Modal.warning({
+          title: 'The service can not be deleted',
+          content: (
+            <div>
+              <Paragraph strong>Error: {err.message}</Paragraph>
+              <List
+                size="small"
+                dataSource={err.dependents}
+                renderItem={d => <List.Item>{d.kind}: {d.name}</List.Item>}
+              />
+            </div>
+          ),
+          onOk() {}
+        })
+      }
       console.error('Error deleting service', err)
       errorMessage('Error deleting service, please try again.')
     }
-  }
-
-  deleteServiceConfirm = async (name, done) => {
-    const serviceCredentials = this.state.serviceCredentials.filter(sc => sc.spec.service.name === name)
-    if (serviceCredentials.length > 0) {
-      return Modal.warning({
-        title: 'Warning: service cannot be deleted',
-        width: 600,
-        content: (
-          <div>
-            <Paragraph strong>The following cluster namespaces currently have access to the service, this access must be removed before the service can be deleted.</Paragraph>
-            <List
-              size="small"
-              dataSource={serviceCredentials}
-              renderItem={sc => <List.Item>{sc.spec.cluster.name} / {sc.spec.clusterNamespace}</List.Item>}
-            />
-          </div>
-        ),
-        onOk() {}
-      })
-    }
-    await this.deleteService(name, done)
   }
 
   handleResourceUpdated = (resourceType) => {
@@ -212,7 +206,7 @@ class ServicesTab extends React.Component {
                     cluster={cluster}
                     service={service}
                     serviceKind={serviceKinds.find(sk => sk.metadata.name === service.spec.kind)}
-                    deleteService={this.deleteServiceConfirm}
+                    deleteService={this.deleteService}
                     handleUpdate={this.handleResourceUpdated('services')}
                     handleDelete={this.handleResourceDeleted('services')}
                     refreshMs={5000}

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -38,8 +38,8 @@ class KoreApiClient {
           ensureRefreshFromServer: true
         })
       }
-      if (err.response && err.response.status === 400 && err.response.body) {
-        throw err.response.body
+      if (err.response && (err.response.status === 400 || err.response.status === 409) && err.response.body) {
+        throw { ...err.response.body, statusCode: err.response.status }
       }
       // @TODO: Handle validation errors (400) and forbidden (403)
       throw err

--- a/ui/pages/teams/[name]/[tab].js
+++ b/ui/pages/teams/[name]/[tab].js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import Router from 'next/router'
 import Error from 'next/error'
-import { Typography, Button, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs } from 'antd'
+import { Typography, Button, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs, List } from 'antd'
 const { Paragraph, Text } = Typography
 const { TabPane } = Tabs
 
@@ -83,21 +83,28 @@ class TeamDashboardTabPage extends React.Component {
       successMessage(`Team "${team}" deleted`)
       return redirect({ router: Router, path: '/' })
     } catch (err) {
+      if (err.statusCode === 409 && err.dependents) {
+        return Modal.warning({
+          title: 'The team can not be deleted',
+          content: (
+            <div>
+              <Paragraph strong>Error: {err.message}</Paragraph>
+              <List
+                size="small"
+                dataSource={err.dependents}
+                renderItem={d => <List.Item>{d.kind}: {d.name}</List.Item>}
+              />
+            </div>
+          ),
+          onOk() {}
+        })
+      }
       console.log('Error deleting team', err)
       errorMessage('Team could not be deleted, please try again later')
     }
   }
 
   deleteTeamConfirm = () => {
-    const { clusterCount } = this.state
-    if (clusterCount > 0) {
-      return Modal.warning({
-        title: 'Warning: team cannot be deleted',
-        content: 'The clusters must be deleted first',
-        onOk() {}
-      })
-    }
-
     Modal.confirm({
       title: 'Are you sure you want to delete this team?',
       content: 'This cannot be undone',

--- a/ui/server/controllers/apiproxy.js
+++ b/ui/server/controllers/apiproxy.js
@@ -21,9 +21,9 @@ function apiProxy(koreApiUrl) {
       return res.json(result.data)
     } catch (err) {
       const status = (err.response && err.response.status) || 500
-      if (status === 400) {
+      if (status === 400 || status === 409) {
         console.log(`Validation error for ${apiUrlPath}`, err.response.data)
-        res.status(400).json(err.response.data).send()
+        res.status(status).json(err.response.data).send()
       }
       const message = (err.response && err.response.data && err.response.data.message) || err.message
       console.error(`Error making request to API with path ${apiUrlPath}`, status, message)


### PR DESCRIPTION
## What

All listed changes were done only on teams, namespaces and service-related objects.

### New error type: validation.ErrDependencyViolation

This error should be used when an action can not be completed because of some existing/missing dependencies.

If you throw this error in the API logic, the API will return 409 Conflict.

Both the UI and the CLI will handle and display this error correctly. (On the UI we handle this in some cases explicitely)

### Delete options in the API: kore.DeleteOptions

With delete options you can control how a delete must be done:
 - kore.DeleteOptionSkipCheck: the delete checks must be skipped
 - kore.DeleteOptionIgnoreReadOnly: delete read-only objects
 - kore.DeleteOptionCascade: cascading delete, all child objects will be deleted (through `metadata.OwnerReferences`) with propagationPolicy=Foreground

Through some API endpoints (team, cluster, namespace, service related ones) you can set the `cascade` option to trigger a cascading delete.

If cascade=true is not set, we will check whether the object has still dependencies. In case it has, we will return with a dependency violation error (409)

See https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/ for more details.

### Delete check logic in separate methods

Pre-delete checks were moved to a DeleteCheck() method which will also be called from the relevant controllers to ensure users don't delete objects with kubectl or by other means.

### The UI doesn't do dependency checks anymore and relies on the API instead

In some cases we did some manual checks on the UI, all those were replied with the dependency violation error check.

### Uniform list filtering methods on all service objects

You can now pass filtering functions to all .List() methods.

### When creating an application service with a new namespace, we will create the namespace in the API instead of the controller

This will allow us to refresh the namespaces tab with up-to-date list after a successful service create API call. (But this is not part of this PR, see https://github.com/appvia/kore/pull/968).

## Testing

- Please create some clusters, namespaces, services, application services and service creds
- Try delete a team, cluster, etc. which has dependencies. Both the CLI and UI should throw an error
 - Try the cascading delete on different levels, it should delete all child objects successfully
