### PR TITLE
Bugfix: Move the built-in app service plans to the application providers

### DIFF
--- a/pkg/controllers/management/kubernetes/aws_autoscaler.go
+++ b/pkg/controllers/management/kubernetes/aws_autoscaler.go
@@ -25,7 +25,7 @@ import (
 	eks "github.com/appvia/kore/pkg/apis/eks/v1alpha1"
 	"github.com/appvia/kore/pkg/controllers/helpers"
 	"github.com/appvia/kore/pkg/kore"
-	"github.com/appvia/kore/pkg/kore/assets"
+	"github.com/appvia/kore/pkg/serviceproviders/application"
 	awsutils "github.com/appvia/kore/pkg/utils/cloud/aws"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -79,7 +79,7 @@ func (a *awsAutoScaler) Delete() (reconcile.Result, error) {
 		}
 	}
 	a.kubeCluster.Status.Components.SetCondition(corev1.Component{
-		Name:    "Service/" + assets.HelmAppClusterAutoscaler,
+		Name:    "Service/" + application.HelmAppClusterAutoscaler,
 		Message: "Autoscaler and AWS roles are being deleted",
 		Status:  corev1.DeletingStatus,
 	})
@@ -141,7 +141,7 @@ func (a *awsAutoScaler) Ensure() (reconcile.Result, error) {
 		}
 	}
 	a.kubeCluster.Status.Components.SetCondition(corev1.Component{
-		Name:    "Service/" + assets.HelmAppClusterAutoscaler,
+		Name:    "Service/" + application.HelmAppClusterAutoscaler,
 		Message: "Autoscaler is being provisioned",
 		Status:  corev1.PendingStatus,
 	})
@@ -227,7 +227,7 @@ func (a *awsAutoScaler) Ensure() (reconcile.Result, error) {
 	// TODO: select a planwith the correct version
 	awsAutoScalerService, err := helpers.GetServiceFromPlanNameAndValues(
 		a.ctx,
-		assets.HelmAppClusterAutoscaler,
+		application.HelmAppClusterAutoscaler,
 		a.kubeCluster,
 		"kube-system",
 		map[string]interface{}{

--- a/pkg/kore/service_plans.go
+++ b/pkg/kore/service_plans.go
@@ -77,7 +77,7 @@ func (p servicePlansImpl) Update(ctx context.Context, plan *servicesv1.ServicePl
 
 	existing, err := p.Get(ctx, plan.Name)
 	if err != nil && err != ErrNotFound {
-		return err
+		return fmt.Errorf("failed to get plan %q: %w", plan.Name, err)
 	}
 
 	if !ignoreReadonly {
@@ -103,7 +103,7 @@ func (p servicePlansImpl) Update(ctx context.Context, plan *servicesv1.ServicePl
 	if schema == "" {
 		kind, err := p.ServiceKinds().Get(ctx, plan.Spec.Kind)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get service kind %q: %w", plan.Spec.Kind, err)
 		}
 		schema = kind.Spec.Schema
 	}

--- a/pkg/serviceproviders/application/application_suite_test.go
+++ b/pkg/serviceproviders/application/application_suite_test.go
@@ -1,0 +1,13 @@
+package application_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestApplication(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Application Suite")
+}

--- a/pkg/serviceproviders/application/factory.go
+++ b/pkg/serviceproviders/application/factory.go
@@ -69,6 +69,8 @@ func (d Factory) Create(ctx kore.Context, provider *servicesv1.ServiceProvider) 
 		plans = append(plans, *plan)
 	}
 
+	plans = append(plans, GetDefaultPlans()...)
+
 	return Provider{name: provider.Name, plans: plans}, nil
 }
 

--- a/pkg/serviceproviders/application/plans.go
+++ b/pkg/serviceproviders/application/plans.go
@@ -14,28 +14,27 @@
  * limitations under the License.
  */
 
-package assets
+package application
 
 import (
 	servicev1 "github.com/appvia/kore/pkg/apis/services/v1"
-
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-/*
- * Add any services here that are dependencies or Kore features and not provided as embedded manifests
- */
 
 const (
 	// HelmAppClusterAutoscaler is the plan name for instances of the cluster autoscaler
 	HelmAppClusterAutoscaler = "helm-app-cluster-autoscaler"
 )
 
-// GetDefaultServicePlans returns a collection of plans for the resources
-func GetDefaultServicePlans() []*servicev1.ServicePlan {
-	return []*servicev1.ServicePlan{
+// GetDefaultPlans returns a collection of plans for the resources
+func GetDefaultPlans() []servicev1.ServicePlan {
+	return []servicev1.ServicePlan{
 		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ServicePlan",
+				APIVersion: servicev1.GroupVersion.String(),
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      HelmAppClusterAutoscaler,
 				Namespace: "kore",

--- a/pkg/serviceproviders/application/plans_test.go
+++ b/pkg/serviceproviders/application/plans_test.go
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
-package assets_test
+package application_test
 
 import (
 	"fmt"
 
 	v1 "github.com/appvia/kore/pkg/apis/services/v1"
-	"github.com/appvia/kore/pkg/kore/assets"
 	"github.com/appvia/kore/pkg/serviceproviders/application"
 	"github.com/appvia/kore/pkg/utils/jsonschema"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ServicePlans", func() {
 	It("All plans should be valid", func() {
-		plans := assets.GetDefaultServicePlans()
+		plans := application.GetDefaultPlans()
 
 		for _, plan := range plans {
-			schema, err := func(p *v1.ServicePlan) (string, error) {
+			schema, err := func(p v1.ServicePlan) (string, error) {
 				switch p.Spec.Kind {
 				case application.ServiceKindHelmApp:
 					return application.HelmAppSchema, nil


### PR DESCRIPTION
## What

We've loaded the build-in app plans in the wrong place as:
 - on a fresh install the app service kind won't exist at that point
 - that code would run for all service providers, which we don't want