### PR TITLE
Disable animations for UI E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,6 +385,7 @@ jobs:
             npm start
           background: true
           environment:
+            KORE_UI_DISABLE_ANIMATIONS: 'true'
             KORE_BASE_URL: http://localhost:3000
             KORE_API_URL: http://localhost:10080/api/v1alpha1
             KORE_API_TOKEN: password

--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -1,4 +1,3 @@
-const { waitForDrawerOpenClose } = require('./page-objects/utils')
 const { ConfigureCloudPage } = require('./page-objects/configure/cloud/configure-cloud')
 const { ConfigureCloudGCPProjects } = require('./page-objects/configure/cloud/GCP/projects')
 const { ConfigureCloudGCPClusterPlans } = require('./page-objects/configure/cloud/GCP/cluster-plans')
@@ -85,7 +84,6 @@ describe('Configure Cloud - GCP', () => {
     beforeAll(async () => {
       // In case of gruff from previous tests, wait a beat before starting.
       await cloudPage.closeAllNotifications()
-      await waitForDrawerOpenClose(page)
       await clusterPlansPage.openTab()
       await clusterPlansPage.listLoaded()
     })
@@ -170,7 +168,6 @@ describe('Configure Cloud - GCP', () => {
     beforeAll(async () => {
       // In case of gruff from previous tests, wait a beat before starting.
       await cloudPage.closeAllNotifications()
-      await waitForDrawerOpenClose(page)
       await policiesPage.openTab()
       await policiesPage.listLoaded()
     })

--- a/ui/__tests__/e2e/03-configure-cloud-aws.test.js
+++ b/ui/__tests__/e2e/03-configure-cloud-aws.test.js
@@ -1,4 +1,3 @@
-const { waitForDrawerOpenClose } = require('./page-objects/utils')
 const { ConfigureCloudPage } = require('./page-objects/configure/cloud/configure-cloud')
 const { ConfigureCloudAWSAccounts } = require('./page-objects/configure/cloud/AWS/accounts')
 const { ConfigureCloudAWSClusterPlans } = require('./page-objects/configure/cloud/AWS/cluster-plans')
@@ -88,7 +87,6 @@ describe('Configure Cloud - AWS', () => {
     beforeAll(async () => {
       // In case of gruff from previous tests, wait a beat before starting.
       await cloudPage.closeAllNotifications()
-      await waitForDrawerOpenClose(page)
       await awsClusterPlansPage.openTab()
       await awsClusterPlansPage.listLoaded()
     })
@@ -172,7 +170,6 @@ describe('Configure Cloud - AWS', () => {
     beforeAll(async () => {
       // In case of gruff from previous tests, wait a beat before starting.
       await cloudPage.closeAllNotifications()
-      await waitForDrawerOpenClose(page)
       await policiesPage.openTab()
       await policiesPage.listLoaded()
     })

--- a/ui/__tests__/e2e/config.js
+++ b/ui/__tests__/e2e/config.js
@@ -4,5 +4,5 @@ module.exports = {
   // Use longer timeout if we're showing the browser:
   timeout: process.env.SHOW_BROWSER !== 'true' ? 15000 : 60000,
   expectTimeout: 1000,
-  drawerOpenClosePause: 500
+  drawerOpenClosePause: 75
 }

--- a/ui/__tests__/e2e/page-objects/configure/cloud/cluster-policies-base.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/cluster-policies-base.js
@@ -42,15 +42,13 @@ export class ConfigureCloudClusterPoliciesBase extends ConfigureCloudPage {
     await this.p.click(`#policy_${name}_disallow`)
   }
 
-  static RESULT_EXPLICIT_DENY = 'Changes explicitly denied by this policy'
-  static RESULT_EXPLICIT_ALLOW = 'Changes explicitly allowed by this policy'
-  static RESULT_DEFAULT_DENY = 'Changes will be denied by default'
-  static RESULT_DEFAULT_ALLOW = 'Changes will be allowed by default'
+  static RESULT_EXPLICIT_DENY = '.anticon-close-circle'
+  static RESULT_EXPLICIT_ALLOW = '.anticon-check-circle'
+  static RESULT_DEFAULT_DENY = '.anticon-close-square'
+  static RESULT_DEFAULT_ALLOW = '.anticon-check-square'
 
   async checkPolicyResult(name, expected) {
-    await this.p.hover(`#policy_${name}_result`)
-    const tt = await this.p.waitForSelector(`#policy_${name}_result_tt`)
-    await expect(tt).toMatch(expected)
+    await this.p.waitForSelector(`#policy_${name}_result${expected}`)
   }
 
   async save() {

--- a/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
@@ -12,6 +12,7 @@ export class ConfigureCloudPage extends BasePage {
     if (currUrl.toLowerCase().indexOf(`/configure/cloud/${name.toLowerCase()}/`) > -1 || (name.toLowerCase() === 'gcp' && currUrl.endsWith('/configure/cloud'))) {
       return
     }
+    await this.p.waitFor(100)
     await Promise.all([
       this.p.waitForNavigation(),
       this.p.click(`#tab-${name}`)
@@ -28,6 +29,7 @@ export class ConfigureCloudPage extends BasePage {
     if (currUrl.endsWith(`/configure/cloud/${urlName}`) || (urlName === 'GCP/orgs' && currUrl.endsWith('/configure/cloud/'))) {
       return
     }
+    await this.p.waitFor(100)
     await Promise.all([
       this.p.waitForNavigation(),
       subTab[0].click()

--- a/ui/__tests__/e2e/page-objects/utils.js
+++ b/ui/__tests__/e2e/page-objects/utils.js
@@ -4,7 +4,7 @@ export async function clearFillTextInput(pg, id, value) {
   if (value === undefined) {
     return
   }
-  const input = await pg.$(`input#${id}`)
+  const input = await pg.waitForSelector(`input#${id}`)
   await input.click({ clickCount: 3 })
   await input.type(value.toString())
 }

--- a/ui/config.js
+++ b/ui/config.js
@@ -67,5 +67,6 @@ module.exports = {
   clusterProviderMap: {
     'AWS': 'EKS',
     'GCP': 'GKE'
-  }
+  },
+  disableAnimations: process.env.KORE_UI_DISABLE_ANIMATIONS === 'true'
 }

--- a/ui/config.public.js
+++ b/ui/config.public.js
@@ -13,5 +13,6 @@ module.exports = {
   gtmId: config.kore.gtmId,
   showPrototypes: config.kore.showPrototypes,
   featureGates: config.kore.featureGates,
-  clusterProviderMap: config.clusterProviderMap
+  clusterProviderMap: config.clusterProviderMap,
+  disableAnimations: config.disableAnimations
 }

--- a/ui/lib/components/layout/SiderMenu.js
+++ b/ui/lib/components/layout/SiderMenu.js
@@ -49,7 +49,7 @@ class SiderMenu extends React.Component {
           </span>
         }
       >
-        {menuItem({ key: 'configure_cloud', text: 'Cloud', href: '/configure/cloud/[[...cloud]]', link: '/configure/cloud', icon: 'cloud' })}
+        {menuItem({ key: 'configure_cloud', text: 'Cloud', href: '/configure/cloud', link: '/configure/cloud', icon: 'cloud' })}
         {!featureEnabled(KoreFeatures.APPLICATION_SERVICES) ? null :
           menuItem({ key: 'configure_services', text: 'Services', link: '/configure/services', icon: 'cloud-server' })
         }

--- a/ui/lib/components/policies/Policy.js
+++ b/ui/lib/components/policies/Policy.js
@@ -103,9 +103,9 @@ export default class Policy extends React.Component {
       }
     }
     if (defaultAllow) {
-      return <Tooltip id={`policy_${name}_result_tt`} placement="left" title="Changes will be allowed by default, but another policy could disallow edits"><Icon id={`policy_${name}_result`} style={{ fontSize: '1.5em' }} type="check-circle" theme="twoTone" twoToneColor="silver" /></Tooltip>
+      return <Tooltip id={`policy_${name}_result_tt`} placement="left" title="Changes will be allowed by default, but another policy could disallow edits"><Icon id={`policy_${name}_result`} style={{ fontSize: '1.5em' }} type="check-square" theme="twoTone" twoToneColor="silver" /></Tooltip>
     }
-    return <Tooltip id={`policy_${name}_result_tt`} placement="left" title="Changes will be denied by default, but another policy could allow edits"><Icon id={`policy_${name}_result`} style={{ fontSize: '1.5em' }} type="close-circle" theme="twoTone" twoToneColor="silver" /></Tooltip>
+    return <Tooltip id={`policy_${name}_result_tt`} placement="left" title="Changes will be denied by default, but another policy could allow edits"><Icon id={`policy_${name}_result`} style={{ fontSize: '1.5em' }} type="close-square" theme="twoTone" twoToneColor="silver" /></Tooltip>
   }
 
   render() {

--- a/ui/lib/components/setup/GCPProjectAutomationSettings.js
+++ b/ui/lib/components/setup/GCPProjectAutomationSettings.js
@@ -246,7 +246,7 @@ class GCPProjectAutomationSettings extends React.Component {
       description={
         <div>
           <Paragraph style={{ marginTop: '10px' }}>No GCP organization credentials have been configured in Kore. Without these, Kore will be unable to managed GCP projects on your behalf.</Paragraph>
-          <Link href="/configure/cloud/[[...cloud]]" as="/configure/cloud/GCP/orgs"><Button type="secondary">Setup organization credentials</Button></Link>
+          <Link href="/configure/cloud/[...cloud]" as="/configure/cloud/GCP/orgs"><Button type="secondary">Setup organization credentials</Button></Link>
         </div>
       }
       type="warning"

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -10,9 +10,6 @@ const themeVariables = lessToJS(
 )
 
 module.exports = withLess({
-  experimental: {
-    optionalCatchAll: true
-  },
   lessLoaderOptions: {
     javascriptEnabled: true,
     modifyVars: themeVariables, // make your antd custom effective

--- a/ui/pages/_app.js
+++ b/ui/pages/_app.js
@@ -181,6 +181,21 @@ class MyApp extends App {
           <title>{props.title || 'Appvia Kore'}</title>
           <meta charSet="utf-8"/>
           <meta name="viewport" content="initial-scale=1.0, width=device-width"/>
+          {!publicRuntimeConfig.disableAnimations ? null : (
+            <style type="text/css" dangerouslySetInnerHTML={{
+              __html: `
+                *, *::after, *::before {
+                  transition-delay: 0s !important;
+                  transition-duration: 0s !important;
+                  animation-delay: -0.0001s !important;
+                  animation-duration: 0s !important;
+                  animation-play-state: paused !important;
+                  caret-color: transparent !important;
+                  color-adjust: exact !important;
+                }
+              `
+            }} />
+          )}
         </Head>
         <Layout style={{ minHeight:'100vh' }}>
           <Header className='top-header'>

--- a/ui/pages/configure/cloud/[...cloud].js
+++ b/ui/pages/configure/cloud/[...cloud].js
@@ -51,11 +51,11 @@ export default class ConfigureCloudPage extends React.Component {
   }
 
   handleSelectCloud = cloud => {
-    Router.push('/configure/cloud/[[...cloud]]', `/configure/cloud/${cloud}/${this.props.activeKeys[cloud]}`)
+    Router.push('/configure/cloud/[...cloud]', `/configure/cloud/${cloud}/${this.props.activeKeys[cloud]}`)
   }
 
   handleSelectKey = (cloud, key) => {
-    Router.push('/configure/cloud/[[...cloud]]', `/configure/cloud/${cloud}/${key}`)
+    Router.push('/configure/cloud/[...cloud]', `/configure/cloud/${cloud}/${key}`)
   }
 
   render() {

--- a/ui/pages/configure/cloud/index.js
+++ b/ui/pages/configure/cloud/index.js
@@ -1,0 +1,3 @@
+import ConfigureCloudPage from './[...cloud]'
+
+export default class ConfigureCloudDefaultPage extends ConfigureCloudPage {}

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -15,6 +15,10 @@ const redisClient = redis.createClient({ url: config.session.url })
 
 const nextjsPath = config.kore.showPrototypes ? '*' : /^((?!\/prototype).)*$/
 
+if (config.disableAnimations) {
+  console.log('Animations disabled - unset KORE_UI_DISABLE_ANIMATIONS to restore.')
+}
+
 app.prepare().then(() => {
   const server = express()
 


### PR DESCRIPTION
This makes tests much faster and less prone to random failures due to animations getting in the way. Should hopefully resolve the random failures we're seeing on a couple of the tests.

Also removed experimental feature from next.js and used the same approach as the teams page to show the default page correctly without the experimental catch-all slug being needed.