### PR TITLE
EKS Autoscaler Checks

### DIFF
--- a/test/e2e/integration/eks.bats
+++ b/test/e2e/integration/eks.bats
@@ -125,6 +125,10 @@ setup() {
   if ${KORE} get eksnodegroup ${CLUSTER}-default -t ${TEAM} -o json | jq '.spec.enableAutoscaler' | grep "false"; then
     skip "autoscaling is not enabled on eksnodegroup"
   fi
+
+  # @TODO NEEDS TO BE FIXED
+  skip "while the helm services controller is reviewed"
+
   runit "${KUBECTL} --context=${CLUSTER} -n kube-system get deployment ${deployment}"
   [[ "$status" -eq 0 ]]
   runit "${KUBECTL} --context=${CLUSTER} -n kube-system get deployment ${deployment}"


### PR DESCRIPTION
- these need to be skipped for now as the services controller appears to have some issues

```shell
 ✓ We should have a default pod security policy eks.privileged
 - We should see the number of nodes change when I update the desired state (skipped: autoscaling is enabled)
 - If autoscaling is enabled in the cluster we should see the deployment (skipped: while the helm services controller is reviewed)
```