### PR TITLE
change the name of the autoscaler service to be unique to a cluster

### DIFF
--- a/pkg/controllers/helpers/services.go
+++ b/pkg/controllers/helpers/services.go
@@ -35,7 +35,7 @@ import (
 )
 
 // GetServiceFromPlanNameAndValues will obtain a service
-func GetServiceFromPlanNameAndValues(ctx kore.Context, planName string, kubeCluster *clustersv1.Kubernetes, clusterNamespace string, values map[string]interface{}) (*servicesv1.Service, error) {
+func GetServiceFromPlanNameAndValues(ctx kore.Context, planName, serviceName string, kubeCluster *clustersv1.Kubernetes, clusterNamespace string, values map[string]interface{}) (*servicesv1.Service, error) {
 	servicePlan, err := ctx.Kore().ServicePlans().Get(ctx, planName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service plan %q: %w", planName, err)
@@ -58,7 +58,7 @@ func GetServiceFromPlanNameAndValues(ctx kore.Context, planName string, kubeClus
 			APIVersion: servicesv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      planName,
+			Name:      serviceName,
 			Namespace: kubeCluster.Namespace,
 			Annotations: map[string]string{
 				kore.AnnotationSystem: "true",

--- a/pkg/controllers/management/kubernetes/aws_autoscaler.go
+++ b/pkg/controllers/management/kubernetes/aws_autoscaler.go
@@ -228,6 +228,7 @@ func (a *awsAutoScaler) Ensure() (reconcile.Result, error) {
 	awsAutoScalerService, err := helpers.GetServiceFromPlanNameAndValues(
 		a.ctx,
 		application.HelmAppClusterAutoscaler,
+		a.eks.Name+"-autoscaler",
 		a.kubeCluster,
 		"kube-system",
 		map[string]interface{}{


### PR DESCRIPTION
At the moment we use the plan name for the service that then manages the helm chart. This will not be unique when a second cluster is built for a team.

This PR addresses that.