### PR TITLE
Preventing multiple intervals being set when deleting a resource

### DIFF
--- a/ui/lib/components/teams/AutoRefreshComponent.js
+++ b/ui/lib/components/teams/AutoRefreshComponent.js
@@ -81,6 +81,9 @@ class AutoRefreshComponent extends React.Component {
     if (this.getStableState() && !this.props.stableRefreshMs) {
       return
     }
+    if (this.interval) {
+      clearInterval(this.interval)
+    }
     this.interval = setInterval(this.refreshResource, this.getStableState() ? this.props.stableRefreshMs : this.props.refreshMs)
   }
 


### PR DESCRIPTION
* this issue was due to the addition of the stable refresh interval
* the resource calls to start refreshing when it's deleted which, when a stable refresh is taking place, created another interval which was never cleared
* the fix is to always clear the interval before setting a new one