### PR TITLE
Request access type offline so we get a refresh token when the user logs in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,8 +539,6 @@ workflows:
             tags:
               only: /^v.*$/
       - check-release-notes:
-          requires:
-            - release
           filters:
             branches:
               ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release v0.2.1 - 2020-06-25
+
+Bugfix release to enable [GSuite token refresh to work for Kore CLI](https://github.com/appvia/kore/issues/999)
+
 ## Release v0.2.0 - 2020-05-30
 
 This release of Kore adds the following key features:

--- a/pkg/apiserver/login.go
+++ b/pkg/apiserver/login.go
@@ -154,7 +154,7 @@ func (l *loginHandler) authorizerHandler(req *restful.Request, resp *restful.Res
 		"scopes":       strings.Join(l.Config().IDPClientScopes, ","),
 	}).Info("providing authorization redirect to identity service")
 
-	http.Redirect(resp.ResponseWriter, req.Request, l.oidcConfig.AuthCodeURL(state), http.StatusTemporaryRedirect)
+	http.Redirect(resp.ResponseWriter, req.Request, l.oidcConfig.AuthCodeURL(state, oauth2.AccessTypeOffline), http.StatusTemporaryRedirect)
 }
 
 // callbackHandler is responsible for handling the callback


### PR DESCRIPTION
Resolves #999 

This has been tested by:

* Create new kore-in-kind configured to use Google as IDP
* Log in
* Push local time on laptop forward by 58 minutes
* Check still working (`bin/kore get teams --verbose` - note no token refresh)
* Wait until token expires (2 minutes)
* Check still working (`bin/kore get teams --verbose` - note token refresh being requested and access continuing to work)

Also regression tested against Auth0 by:

* Create new kore-in-kind with normal auth0 configuration.
* Repeat above test.