### PR TITLE
Force render Collapse Panel to ensure the config is present

### DIFF
--- a/ui/lib/components/teams/cluster/ClusterOptionsForm.js
+++ b/ui/lib/components/teams/cluster/ClusterOptionsForm.js
@@ -163,7 +163,7 @@ class ClusterOptionsForm extends React.Component {
         ) : null}
         {selectedPlan ? (
           <Collapse>
-            <Collapse.Panel header="Customize cluster parameters">
+            <Collapse.Panel header="Customize cluster parameters" forceRender={true}>
               <UsePlanForm
                 team={this.props.team}
                 resourceType="cluster"


### PR DESCRIPTION
## Summary

Bugfix for creating a cluster.

**Which issue(s) this PR resolves**:

Resolves #975 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~  _N/A_

## Changes

Force render Collapse Panel to ensure the config is present. The issue was due to some data being read from the config when did not exist.
