### PR TITLE
Increase resource class on various critical-path circle CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ jobs:
       GOFLAGS: "-mod=vendor"
       USE_GIT_VERSION: "true"
 
+    resource_class: large
     docker:
       - image: circleci/golang:1.14
 
@@ -202,6 +203,7 @@ jobs:
       GOFLAGS: "-mod=vendor"
       USE_GIT_VERSION: "true"
 
+    resource_class: large
     docker:
       - image: circleci/golang:1.14
       - name: database
@@ -227,6 +229,7 @@ jobs:
       GOFLAGS: "-mod=vendor"
       USE_GIT_VERSION: "true"
 
+    resource_class: large
     docker:
       *SERVICES
 
@@ -266,6 +269,7 @@ jobs:
       GOFLAGS: "-mod=vendor"
       USE_GIT_VERSION: "true"
 
+    resource_class: large
     docker:
       - image: circleci/golang:1.14
 
@@ -372,6 +376,7 @@ jobs:
             make test
 
   test-ui-e2e:
+    resource_class: xlarge
     docker:
       - image: circleci/node:12
       - *SERVICES_ETCD


### PR DESCRIPTION
##  Summary

Changes resources classes for certain CircleCI steps to avoid failures and improve end-to-end run time for critical path steps.

## Testing

See https://app.circleci.com/pipelines/github/appvia/kore?branch=circle-resource-classes - 2 minute improvement in end-to-end run time and no failures from the 'test' job.
