### PR TITLE
Force approval when logging in to fix GSuite auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release v0.2.2 - 2020-06-26
+
+Bugfix release to enable [GSuite token refresh to continue to work for Kore CLI after first login](https://github.com/appvia/kore/issues/1006)
+
 ## Release v0.2.1 - 2020-06-25
 
 Bugfix release to enable [GSuite token refresh to work for Kore CLI](https://github.com/appvia/kore/issues/999)

--- a/pkg/cmd/utils/factory.go
+++ b/pkg/cmd/utils/factory.go
@@ -73,6 +73,10 @@ func (f *factory) refreshToken() {
 					auth.OIDC.AccessToken = refresh.AccessToken
 					auth.OIDC.IDToken = refresh.IDToken
 					_ = f.UpdateConfig()
+					log.Debug("id-token refreshed successfully")
+				} else {
+					log.WithError(err).Debug("error refreshing id-token")
+					log.Warn("Failed to refresh your access token, please run kore login")
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

GSuite auth only returns a refresh token on the first ever login by a user to a project, unless the additional parameter 'approval_prompt=force' is added to the initial request. This PR adds such to authentication when the auth is configured to use `https://accounts.google.com`.

**Which issue(s) this PR resolves**:
Resolves #1006 

## Checklist

~~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~~ n/a

## Changes

No changes to system behaviour. Refresh tokens now work for GSuite authentication as per other IDPs.

### Additional changes

Remove offline_access from the scopes if configured (or left at default) and google authentication in use, as we know that will cause a failure.

Addtional debug and warning logging on CLI when refreshing / failing to refresh token, rather than silently failing.

## Testing

Tested with GSuite auth and manually moving clock forward to force a refresh, works as expected:

```
markhughes@mark-appvia-laptop:~/go/src/github.com/appvia/kore [v0.2.1-fixauth ≡ +0 ~2 -0 | +0 ~1 -0]$ bin/kore get teams --verbose
...
DEBU[0000] attempting to refresh id-token
DEBU[0000] id-token refreshed successfully
DEBU[0000] making request to kore api                    endpoint="http://127.0.0.1:10080" method=GET uri=api/v1alpha1/teams
DEBU[0000] processing time of the request was            fields.time=63.624257ms
...
```

* Regression tested with Auth0 to check no ill effects.
