### PR TITLE
Amending GKE credential to ask for Project ID, not name

### DIFF
--- a/ui/lib/components/credentials/GKECredentialsForm.js
+++ b/ui/lib/components/credentials/GKECredentialsForm.js
@@ -99,17 +99,17 @@ class GKECredentialsForm extends VerifiedAllocatedResourceForm {
     return (
       <Card style={{ marginBottom: '20px' }}>
         <Alert
-          message="Project name and service account"
+          message="Project and service account"
           description="Retrieve these values from your GCP project. Providing these gives Kore the ability to create clusters within the project."
           type="info"
           style={{ marginBottom: '20px' }}
         />
-        <Form.Item label="Project name" validateStatus={this.fieldError('project') ? 'error' : ''} help={this.fieldError('project') || 'The GCP project that Kore will be able to build clusters within.'}>
+        <Form.Item label="Project ID" validateStatus={this.fieldError('project') ? 'error' : ''} help={this.fieldError('project') || 'The GCP project ID that Kore will be able to build clusters within.'}>
           {form.getFieldDecorator('project', {
-            rules: [{ required: true, message: 'Please enter your project name!' }],
+            rules: [{ required: true, message: 'Please enter your project ID!' }],
             initialValue: data && data.spec.project
           })(
-            <Input placeholder="Project" name="project" />,
+            <Input placeholder="Project ID" name="project" />,
           )}
         </Form.Item>
 


### PR DESCRIPTION
## Summary

Amending GKE credential to ask for Project ID, not name. This accurately reflects the data required.

**Which issue(s) this PR resolves**:

Resolves #1009 

## Screenshots

<img width="681" alt="Screen Shot 2020-06-26 at 11 33 10" src="https://user-images.githubusercontent.com/1334068/85848479-19e0c500-b7a1-11ea-9444-10db0ba2ebaf.png">

## Testing

Please provide detailed instructions about how to test this feature. This should include:
 * creating a new GKE credential
 * editing GKE credentials
