### PR TITLE
Update expected error message in E2E tests when trying to delete a team

### DIFF
--- a/test/e2e/integration/safeguards.bats
+++ b/test/e2e/integration/safeguards.bats
@@ -29,7 +29,7 @@ setup() {
 @test "We should not be able to delete the cluster if a namespace exists" {
   runit "${KORE} create namespace -c ${CLUSTER} ingress -t ${TEAM}"
   [[ "$status" -eq 0 ]]
-  runit "${KORE} delete teams ${TEAM} 2>&1 | grep 'all team resources must be deleted'"
+  runit "${KORE} delete teams ${TEAM} 2>&1 | grep 'the following objects need to be deleted first'"
   [[ "$status" -eq 0 ]]
   runit "${KORE} delete namespaceclaims ${CLUSTER}-ingress -t ${TEAM}"
   [[ "$status" -eq 0 ]]


### PR DESCRIPTION
## Summary

We've changed the error message when checking the object dependencies before deleting.

This only fixes the failing GKE E2E tests, the EKS errors are probably related to https://github.com/appvia/kore/issues/974