### PR TITLE
GCP Organization enhancements

### DIFF
--- a/ui/__tests__/e2e/01-first-time-setup.test.js
+++ b/ui/__tests__/e2e/01-first-time-setup.test.js
@@ -3,55 +3,89 @@ const { IndexPage } = require('./page-objects/index')
 const { SetupKorePage } = require('./page-objects/setup-kore')
 const { SetupKoreCloudAccessPage } = require('./page-objects/setup-kore-cloud-access')
 const { SetupKoreCompletePage } = require('./page-objects/setup-kore-complete')
+const { ConfigureCloudPage } = require('./page-objects/configure/cloud/configure-cloud')
+const { ConfigureCloudGCPOrgs } = require('./page-objects/configure/cloud/GCP/organizations')
 
 const page = global.page
 
-describe('First time login and setup', () => {
+describe('First time login and Kore setup - GCP', () => {
   const loginPage = new LoginPage(page)
   const indexPage = new IndexPage(page)
   const setupKorePage = new SetupKorePage(page)
   const setupKoreCompletePage = new SetupKoreCompletePage(page)
   const setupKoreCloudAccessPage = new SetupKoreCloudAccessPage(page)
 
-  beforeAll(async () => {
+  const testOrg = {
+    // Randomise name of test org.
+    name: `testorg-${Math.random().toString(36).substr(2, 5)}`,
+    summary: 'Org used by automated test',
+    parentID: '1234567890',
+    billingAccount: 'BILL-1234-ABCD',
+    json: 'kangaroo'
+  }
+
+  describe('Kore setup', () => {
+    test('admin user logs in and sets up GCP cloud access', async () => {
+      // admin user login
+      await loginPage.visitPage()
+      await loginPage.localUserLogin()
+
+      // If this is re-run, we don't go back to the setup. Check the URL and exit clean if
+      // not auto-redirected to the setup page.
+      // @TODO: Reset the environment as part of every test so this is re-runnable.
+      const currUrl = await page.url()
+      if (!currUrl.endsWith(setupKorePage.pagePath)) {
+        return
+      }
+
+      // kore setup page
+      setupKorePage.verifyPageURL()
+      await setupKorePage.clickPrimaryButton()
+
+      // cloud access setup
+      setupKoreCloudAccessPage.verifyPageURL()
+      await setupKoreCloudAccessPage.selectCloud('gcp')
+      await setupKoreCloudAccessPage.selectKoreManagedGcpProjects()
+      await setupKoreCloudAccessPage.addGcpOrganization(testOrg)
+      await expect(page).toMatch('GCP organization created successfully')
+      await setupKoreCloudAccessPage.nextStep()
+      await setupKoreCloudAccessPage.selectKoreManagedProjects('custom')
+      await setupKoreCloudAccessPage.setAutomatedProjectDefaults()
+      await setupKoreCloudAccessPage.save()
+      await setupKorePage.clickPrimaryButton()
+
+      // kore setup complete
+      setupKoreCompletePage.verifyPageURL()
+      await setupKoreCompletePage.clickPrimaryButton()
+
+      // main dashboard
+      indexPage.verifyPageURL()
+    })
   })
 
-  afterAll(() => {
-  })
+  describe('Verifying Kore setup', () => {
+    const cloudPage = new ConfigureCloudPage(page)
+    const orgsPage = new ConfigureCloudGCPOrgs(page)
 
-  test('admin user logs in and sets up GCP cloud access', async () => {
-    // admin user login
-    await loginPage.visitPage()
-    await loginPage.localUserLogin()
+    beforeAll(async () => {
+      await cloudPage.visitPage()
+      cloudPage.verifyPageURL()
+      await cloudPage.selectCloud('gcp')
+      await orgsPage.openTab()
+    })
 
-    // If this is re-run, we don't go back to the setup. Check the URL and exit clean if
-    // not auto-redirected to the setup page.
-    // @TODO: Reset the environment as part of every test so this is re-runnable.
-    const currUrl = await page.url()
-    if (!currUrl.endsWith(setupKorePage.pagePath)) {
-      return
-    }
+    test('has the correct URL', () => {
+      orgsPage.verifyPageURL()
+    })
 
-    // kore setup page
-    setupKorePage.verifyPageURL()
-    await setupKorePage.clickPrimaryButton()
-
-    // cloud access setup
-    setupKoreCloudAccessPage.verifyPageURL()
-    await setupKoreCloudAccessPage.selectCloud('gcp')
-    await setupKoreCloudAccessPage.selectKoreManagedGcpProjects()
-    await setupKoreCloudAccessPage.addGcpOrganization()
-    await setupKoreCloudAccessPage.nextStep()
-    await setupKoreCloudAccessPage.selectKoreManagedProjects('custom')
-    await setupKoreCloudAccessPage.setAutomatedProjectDefaults()
-    await setupKoreCloudAccessPage.save()
-    await setupKorePage.clickPrimaryButton()
-
-    // kore setup complete
-    setupKoreCompletePage.verifyPageURL()
-    await setupKoreCompletePage.clickPrimaryButton()
-
-    // main dashboard
-    indexPage.verifyPageURL()
+    test('allows the configured org to be deleted', async () => {
+      if (await orgsPage.orgConfigured()) {
+        return
+      }
+      await orgsPage.checkOrgListed(testOrg.name)
+      await orgsPage.delete(testOrg.name)
+      await orgsPage.confirmDelete()
+      await expect(page).toMatch('GCP organization deleted successfully')
+    })
   })
 })

--- a/ui/__tests__/e2e/01-first-time-setup.test.js
+++ b/ui/__tests__/e2e/01-first-time-setup.test.js
@@ -25,7 +25,7 @@ describe('First time login and Kore setup - GCP', () => {
   }
 
   describe('Kore setup', () => {
-    test('admin user logs in and sets up GCP cloud access', async () => {
+    it('admin user logs in and sets up GCP cloud access', async () => {
       // admin user login
       await loginPage.visitPage()
       await loginPage.localUserLogin()
@@ -74,11 +74,11 @@ describe('First time login and Kore setup - GCP', () => {
       await orgsPage.openTab()
     })
 
-    test('has the correct URL', () => {
+    it('has the correct URL', () => {
       orgsPage.verifyPageURL()
     })
 
-    test('allows the configured org to be deleted', async () => {
+    it('allows the configured org to be deleted', async () => {
       if (await orgsPage.orgConfigured()) {
         return
       }

--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -36,11 +36,11 @@ describe('Configure Cloud - GCP', () => {
       await orgsPage.closeAllNotifications()
     })
 
-    test('has the correct URL', () => {
+    it('has the correct URL', () => {
       orgsPage.verifyPageURL()
     })
 
-    test('adds a new organization', async () => {
+    it('adds a new organization', async () => {
       // I can't find a way to skip all the tests in a block using an async check
       // so this is required in each test, to skip if the GCP org is already configured
       // this would only happen when running locally, not on CI
@@ -53,14 +53,14 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('GCP organization created successfully')
     })
 
-    test('shows the organization', async () => {
+    it('shows the organization', async () => {
       if (await orgsPage.orgConfigured()) {
         return
       }
       await orgsPage.checkOrgListed(testOrg.name)
     })
 
-    test('edits the organization with a new description', async () => {
+    it('edits the organization with a new description', async () => {
       if (await orgsPage.orgConfigured()) {
         return
       }
@@ -70,7 +70,7 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('GCP organization updated successfully')
     })
 
-    test('edits a project credential with a new key', async () => {
+    it('edits a project credential with a new key', async () => {
       if (await orgsPage.orgConfigured()) {
         return
       }
@@ -80,7 +80,7 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('GCP organization updated successfully')
     })
 
-    test('allows the organization to be deleted', async () => {
+    it('allows the organization to be deleted', async () => {
       if (await orgsPage.orgConfigured()) {
         return
       }
@@ -109,36 +109,36 @@ describe('Configure Cloud - GCP', () => {
       await projCredsPage.closeAllNotifications()
     })
 
-    test('has the correct URL', () => {
+    it('has the correct URL', () => {
       projCredsPage.verifyPageURL()
     })
 
-    test('adds a new project credential', async () => {
+    it('adds a new project credential', async () => {
       await projCredsPage.add()
       await projCredsPage.populate(testCred)
       await projCredsPage.save()
       await expect(page).toMatch('GCP project credentials created successfully')
     })
 
-    test('shows project credentials', async () => {
+    it('shows project credentials', async () => {
       await projCredsPage.checkCredentialListed(testCred.name)
     })
 
-    test('edits a project credential with a new description', async () => {
+    it('edits a project credential with a new description', async () => {
       await projCredsPage.edit(testCred.name, testCred.project)
       await projCredsPage.populate({ summary: 'summary2' })
       await projCredsPage.save()
       await expect(page).toMatch('GCP project credentials updated successfully')
     })
 
-    test('edits a project credential with a new key', async () => {
+    it('edits a project credential with a new key', async () => {
       await projCredsPage.edit(testCred.name, testCred.project)
       await projCredsPage.replaceKey('sheep')
       await projCredsPage.save()
       await expect(page).toMatch('GCP project credentials updated successfully')
     })
 
-    test('allows credentials to be deleted', async () => {
+    it('allows credentials to be deleted', async () => {
       await projCredsPage.delete(testCred.name)
       await projCredsPage.confirmDelete()
       await expect(page).toMatch('GCP project credentials deleted successfully')
@@ -167,28 +167,28 @@ describe('Configure Cloud - GCP', () => {
       await clusterPlansPage.closeAllNotifications()
     })
 
-    test('has the correct URL', () => {
+    it('has the correct URL', () => {
       clusterPlansPage.verifyPageURL()
     })
 
-    test('views an existing plan', async () => {
+    it('views an existing plan', async () => {
       await clusterPlansPage.view('gke-development')
       // Check a random thing to ensure the plan is being displayed.
       await expect(page).toMatch('Authorized Master Networks')
       await clusterPlansPage.closeDrawer()
     })
 
-    test('does not allow editing of a read-only plan', async () => {
+    it('does not allow editing of a read-only plan', async () => {
       await clusterPlansPage.edit('gke-development')
       await expect(page).toMatch('This plan is read-only')
     })
 
-    test('does not allow deleting of a read-only plan', async () => {
+    it('does not allow deleting of a read-only plan', async () => {
       await clusterPlansPage.delete('gke-development')
       await expect(page).toMatch('This plan is read-only and cannot be deleted')
     })
 
-    test('creates a new plan using default values', async () => {
+    it('creates a new plan using default values', async () => {
       await clusterPlansPage.new()
       await expect(page).toMatch('New GKE plan')
       await clusterPlansPage.populatePlan(testPlan)
@@ -199,7 +199,7 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('GKE plan created successfully')
     })
 
-    test('edits an existing plan', async () => {
+    it('edits an existing plan', async () => {
       await clusterPlansPage.edit(testPlan.name)
       await clusterPlansPage.populatePlan({ region: 'europe-west1' })
       await clusterPlansPage.addNodePool()
@@ -216,7 +216,7 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('GKE plan updated successfully')
     })
 
-    test('edits an existing node pool', async () => {
+    it('edits an existing node pool', async () => {
       await clusterPlansPage.edit(testPlan.name)
       await clusterPlansPage.viewEditNodePool(1)
       await clusterPlansPage.populateNodePool({ enableAutoscaler: false, size: 10 })
@@ -225,7 +225,7 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('GKE plan updated successfully')
     })
 
-    test('allows deleting of a non-read-only plan', async () => {
+    it('allows deleting of a non-read-only plan', async () => {
       await clusterPlansPage.delete(testPlan.name)
       await clusterPlansPage.confirmDelete()
       await expect(page).toMatch(`${testPlan.name} plan deleted`)
@@ -251,28 +251,28 @@ describe('Configure Cloud - GCP', () => {
       await policiesPage.closeAllNotifications()
     })
 
-    test('has the correct URL', () => {
+    it('has the correct URL', () => {
       policiesPage.verifyPageURL()
     })
 
-    test('views an existing policy', async () => {
+    it('views an existing policy', async () => {
       await policiesPage.view('default-gke')
       // Check a random thing to ensure the plan is being displayed.
       await expect(page).toMatch('Authorized Master Networks')
       await policiesPage.closeDrawer()
     })
 
-    test('does not allow editing of a read-only policy', async () => {
+    it('does not allow editing of a read-only policy', async () => {
       await policiesPage.edit('default-gke')
       await expect(page).toMatch('This policy is read-only')
     })
 
-    test('does not allow deleting of a read-only policy', async () => {
+    it('does not allow deleting of a read-only policy', async () => {
       await policiesPage.delete('default-gke')
       await expect(page).toMatch('This policy is read-only and cannot be deleted')
     })
 
-    test('creates a new policy', async () => {
+    it('creates a new policy', async () => {
       await policiesPage.new()
       await expect(page).toMatch('New GKE policy')
       await policiesPage.populate(testPolicy)
@@ -291,7 +291,7 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('Policy created successfully')
     })
 
-    test('updates an existing policy', async () => {
+    it('updates an existing policy', async () => {
       await policiesPage.edit(testPolicy.name)
       await policiesPage.populate({ description: 'Updated Policy Description' })
       await policiesPage.togglePolicyAllow('clusterUsers')
@@ -301,7 +301,7 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('Policy saved successfully')
     })
 
-    test('views the updated policy', async () => {
+    it('views the updated policy', async () => {
       await policiesPage.view(testPolicy.name)
       await policiesPage.checkPolicyResult('domain', ConfigureCloudClusterPoliciesBase.RESULT_EXPLICIT_DENY)
       await policiesPage.checkPolicyResult('description', ConfigureCloudClusterPoliciesBase.RESULT_DEFAULT_DENY)
@@ -310,7 +310,7 @@ describe('Configure Cloud - GCP', () => {
       await policiesPage.closeDrawer()
     })
 
-    test('allows deleting of a non-read-only policy', async () => {
+    it('allows deleting of a non-read-only policy', async () => {
       await policiesPage.delete(testPolicy.name)
       await policiesPage.confirmDelete()
       await expect(page).toMatch('Policy Updated Policy Description deleted')

--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -41,6 +41,12 @@ describe('Configure Cloud - GCP', () => {
     })
 
     test('adds a new organization', async () => {
+      // I can't find a way to skip all the tests in a block using an async check
+      // so this is required in each test, to skip if the GCP org is already configured
+      // this would only happen when running locally, not on CI
+      if (await orgsPage.orgConfigured()) {
+        return
+      }
       await orgsPage.add()
       await orgsPage.populate(testOrg)
       await orgsPage.save()
@@ -48,10 +54,16 @@ describe('Configure Cloud - GCP', () => {
     })
 
     test('shows the organization', async () => {
+      if (await orgsPage.orgConfigured()) {
+        return
+      }
       await orgsPage.checkOrgListed(testOrg.name)
     })
 
     test('edits the organization with a new description', async () => {
+      if (await orgsPage.orgConfigured()) {
+        return
+      }
       await orgsPage.edit(testOrg.name, testOrg.parentID)
       await orgsPage.populate({ summary: 'summary2' })
       await orgsPage.save()
@@ -59,6 +71,9 @@ describe('Configure Cloud - GCP', () => {
     })
 
     test('edits a project credential with a new key', async () => {
+      if (await orgsPage.orgConfigured()) {
+        return
+      }
       await orgsPage.edit(testOrg.name, testOrg.parentID)
       await orgsPage.replaceKey('chicken')
       await orgsPage.save()
@@ -66,6 +81,9 @@ describe('Configure Cloud - GCP', () => {
     })
 
     test('allows the organization to be deleted', async () => {
+      if (await orgsPage.orgConfigured()) {
+        return
+      }
       await orgsPage.delete(testOrg.name)
       await orgsPage.confirmDelete()
       await expect(page).toMatch('GCP organization deleted successfully')

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/organizations.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/organizations.js
@@ -17,7 +17,19 @@ export class ConfigureCloudGCPOrgs extends ConfigureCloudPage {
   }
 
   /**
-   * Checks if the org is listed
+   * checks if any org is configured
+   */
+  async orgConfigured() {
+    try {
+      await this.p.waitForSelector('.ant-list-items', { timeout: 2000 })
+      return true
+    } catch(err) {
+      return false
+    }
+  }
+
+  /**
+   * Checks if an specific org is listed
    */
   async checkOrgListed(name) {
     await expect(this.p).toMatchElement(`#gcporg_${name}`)

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/organizations.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/organizations.js
@@ -1,0 +1,68 @@
+import { ConfigureCloudPage } from '../configure-cloud'
+import { clearFillTextInput, modalYes, waitForDrawerOpenClose } from '../../../utils'
+
+export class ConfigureCloudGCPOrgs extends ConfigureCloudPage {
+  constructor(p) {
+    super(p)
+    this.pagePath = '/configure/cloud/GCP/orgs'
+  }
+
+  async openTab() {
+    await this.selectCloud('gcp')
+    await this.selectSubTab('Organization credentials', 'GCP/orgs')
+  }
+
+  verifyPageURL() {
+    expect([this.pagePath, '/configure/cloud'].includes(this.p.url()))
+  }
+
+  /**
+   * Checks if the org is listed
+   */
+  async checkOrgListed(name) {
+    await expect(this.p).toMatchElement(`#gcporg_${name}`)
+  }
+
+  async add() {
+    await this.p.waitFor('.new-gcp-organization')
+    await expect(this.p).toClick('button', { text: 'Configure' })
+    await waitForDrawerOpenClose(this.p)
+    await expect(this.p).toMatch('New GCP organization')
+  }
+
+  async edit(name, parentID) {
+    await this.p.click(`a#gcporg_edit_${name}`)
+    await waitForDrawerOpenClose(this.p)
+    await expect(this.p).toMatch(`GCP Organization: ${parentID}`)
+  }
+
+  async populate({ name, summary, parentID, billingAccount, json }) {
+    await clearFillTextInput(this.p, 'gcp_organization_name', name)
+    await clearFillTextInput(this.p, 'gcp_organization_summary', summary)
+    await clearFillTextInput(this.p, 'gcp_organization_parentID', parentID)
+    await clearFillTextInput(this.p, 'gcp_organization_billingAccount', billingAccount)
+    if (json !== undefined) {
+      await this.p.type('textarea#gcp_organization_account', json)
+    }
+  }
+
+  async replaceKey(json) {
+    await this.p.type('input#gcporg_replace_key', ' ')
+    // Wait for service account text field to be shown:
+    await expect(this.p).toMatch('Service Account JSON')
+    await this.p.type('textarea#gcp_organization_account', json)
+  }
+
+  async save() {
+    await this.p.click('button#save')
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async delete(name) {
+    await this.p.click(`a#gcporg_del_${name}`)
+  }
+
+  async confirmDelete() {
+    await modalYes(this.p, 'Are you sure you want to delete the GCP Organization')
+  }
+}

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/projects.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/projects.js
@@ -41,7 +41,7 @@ export class ConfigureCloudGCPProjects extends ConfigureCloudPage {
   }
 
   async replaceKey(json) {
-    await this.p.type('input#gke_credentials_replace_key',' ')
+    await this.p.type('input#gke_credentials_replace_key', ' ')
     // Wait for service account text field to be shown:
     await expect(this.p).toMatch('Service Account JSON')
     await this.p.type('textarea#gke_credentials_account', json)

--- a/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/configure-cloud.js
@@ -26,7 +26,7 @@ export class ConfigureCloudPage extends BasePage {
     }
     // Check if we're already on the right page/tab (or the default page/tab is what we want)
     const currUrl = await this.p.url()
-    if (currUrl.endsWith(`/configure/cloud/${urlName}`) || (urlName === 'GCP/orgs' && currUrl.endsWith('/configure/cloud/'))) {
+    if (currUrl.endsWith(`/configure/cloud/${urlName}`) || (urlName === 'GCP/orgs' && currUrl.endsWith('/configure/cloud'))) {
       return
     }
     await this.p.waitFor(100)

--- a/ui/__tests__/e2e/page-objects/setup-kore-cloud-access.js
+++ b/ui/__tests__/e2e/page-objects/setup-kore-cloud-access.js
@@ -1,9 +1,11 @@
-const { BasePage } = require('./base')
+import { BasePage } from './base'
+import { ConfigureCloudGCPOrgs } from './configure/cloud/GCP/organizations'
 
 export class SetupKoreCloudAccessPage extends BasePage {
   constructor(p) {
     super(p)
     this.pagePath = '/setup/kore/cloud-access'
+    this.orgsPage = new ConfigureCloudGCPOrgs(p)
   }
 
   async selectCloud(name) {
@@ -14,24 +16,18 @@ export class SetupKoreCloudAccessPage extends BasePage {
     await this.p.click('.use-kore-managed-projects')
   }
 
+  /**
+   * Select the manage projects type
+   * @param type Either "cluster" or "custom"
+   */
   async selectKoreManagedProjects(type) {
-    // cluster or custom
     await this.p.click(`.automated-projects-${type}`)
   }
 
-  async addGcpOrganization() {
-    await this.p.waitFor('.new-gcp-organization')
-    await this.p.click('.new-gcp-organization')
-    await this.p.waitFor('#gcp_organization_parentID')
-    await this.p.type('#gcp_organization_parentID', 'test-org')
-    await this.p.type('#gcp_organization_billingAccount', 'BILL-1234')
-    await this.p.type('#gcp_organization_account', 'invalid service account JSON')
-    await this.p.type('#gcp_organization_name', 'Test org')
-    await this.p.type('#gcp_organization_summary', 'Org used by automated test')
-    await Promise.all([
-      this.p.waitFor('#gcp_organization_parentID', { hidden: true }),
-      this.p.click('#save')
-    ])
+  async addGcpOrganization(testOrg) {
+    await this.orgsPage.add()
+    await this.orgsPage.populate(testOrg)
+    await this.orgsPage.save()
   }
 
   async nextStep() {

--- a/ui/__tests__/unit/lib/components/plans/ManageClusterPlanForm.test.js
+++ b/ui/__tests__/unit/lib/components/plans/ManageClusterPlanForm.test.js
@@ -52,16 +52,16 @@ describe('ManageClusterPlanForm', () => {
       form.handleSubmit(event)
     })
 
-    test('prevents default', () => {
+    it('prevents default', () => {
       expect(event.preventDefault).toHaveBeenCalledTimes(1)
     })
 
-    test('sets form submitting in state', () => {
+    it('sets form submitting in state', () => {
       expect(form.setFormSubmitting).toHaveBeenCalledTimes(1)
       expect(form.setFormSubmitting.mock.calls[0]).toEqual([])
     })
 
-    test('validates fields', () => {
+    it('validates fields', () => {
       expect(props.form.validateFields).toHaveBeenCalledTimes(1)
     })
   })
@@ -90,13 +90,13 @@ describe('ManageClusterPlanForm', () => {
       form.state.planValues = planResource.spec.configuration
     })
 
-    test('handles form validation errors', async () => {
+    it('handles form validation errors', async () => {
       await form.process('error', null)
       expect(form.setFormSubmitting).toHaveBeenCalledTimes(1)
       expect(form.setFormSubmitting.mock.calls[0]).toEqual([false, 'Validation failed'])
     })
 
-    test('creates the resource and calls the wrapper component handleSubmit function', async () => {
+    it('creates the resource and calls the wrapper component handleSubmit function', async () => {
       apiScope.put(`${ApiTestHelpers.basePath}/plans/test-plan`, planResource).reply(200, planResource)
       await form.process(null, { description: 'Test plan', summary: 'Summary of plan' })
       expect(props.handleSubmit).toHaveBeenCalledTimes(1)
@@ -104,7 +104,7 @@ describe('ManageClusterPlanForm', () => {
       apiScope.done()
     })
 
-    test('handles validation errors when creating the resource', async () => {
+    it('handles validation errors when creating the resource', async () => {
       const fieldErrors = [{ field: 'prop1', type: 'required', message: 'prop1 is required' }]
       apiScope.put(`${ApiTestHelpers.basePath}/plans/test-plan`, planResource).reply(400, { message: 'Validation errors', fieldErrors })
       await form.process(null, { description: 'Test plan', summary: 'Summary of plan' })

--- a/ui/__tests__/unit/lib/components/policies/PolicyForm.test.js
+++ b/ui/__tests__/unit/lib/components/policies/PolicyForm.test.js
@@ -69,16 +69,16 @@ describe('PolicyForm', () => {
       form.handleSubmit(event)
     })
 
-    test('prevents default', () => {
+    it('prevents default', () => {
       expect(event.preventDefault).toHaveBeenCalledTimes(1)
     })
 
-    test('sets form submitting in state', () => {
+    it('sets form submitting in state', () => {
       expect(form.setFormSubmitting).toHaveBeenCalledTimes(1)
       expect(form.setFormSubmitting.mock.calls[0]).toEqual([])
     })
 
-    test('validates fields', () => {
+    it('validates fields', () => {
       expect(props.form.validateFields).toHaveBeenCalledTimes(1)
     })
   })
@@ -108,13 +108,13 @@ describe('PolicyForm', () => {
       form.state.allocatedTeams = ['*']
     })
 
-    test('handles form validation errors', async () => {
+    it('handles form validation errors', async () => {
       await form._process('error', null)
       expect(form.setFormSubmitting).toHaveBeenCalledTimes(1)
       expect(form.setFormSubmitting.mock.calls[0]).toEqual([false, 'Validation failed'])
     })
 
-    test('creates the resource and calls the wrapper component handleSubmit function', async () => {
+    it('creates the resource and calls the wrapper component handleSubmit function', async () => {
       apiScope.put(`${ApiTestHelpers.basePath}/planpolicies/allow-gke-node-type-changes`).reply(200, policyResource)
       apiScope.put(`${ApiTestHelpers.basePath}/teams/kore-admin/allocations/planpolicy-allow-gke-node-type-changes`).reply(200)
       await form._process(null, { summary: 'Allow GKE node type changes', description: 'Description of policy' })

--- a/ui/__tests__/unit/lib/components/teams/members/MembersTab.test.js
+++ b/ui/__tests__/unit/lib/components/teams/members/MembersTab.test.js
@@ -32,7 +32,7 @@ describe('MembersTab', () => {
     apiScope.done()
   })
 
-  test('sets up initial state', () => {
+  it('sets up initial state', () => {
     expect(membersTab.state).toEqual({
       dataLoading: false,
       members: initialMembers,
@@ -41,7 +41,7 @@ describe('MembersTab', () => {
     })
   })
 
-  test('updates member count', () => {
+  it('updates member count', () => {
     expect(props.getMemberCount).toHaveBeenCalledTimes(1)
     expect(props.getMemberCount.mock.calls[0]).toEqual([ 3 ])
   })
@@ -54,7 +54,7 @@ describe('MembersTab', () => {
       props.getMemberCount.mockClear()
     })
 
-    test('makes api request to add each member, sets state and updates member count', async () => {
+    it('makes api request to add each member, sets state and updates member count', async () => {
       membersTab.state.membersToAdd = ['one', 'two']
       await membersTab.addTeamMembers()
 
@@ -72,7 +72,7 @@ describe('MembersTab', () => {
       props.getMemberCount.mockClear()
     })
 
-    test('makes api request to remove the member, sets state and updates member count', async () => {
+    it('makes api request to remove the member, sets state and updates member count', async () => {
       await membersTab.deleteTeamMember('bob')()
 
       apiScope.done()

--- a/ui/__tests__/unit/lib/kore-api/kore-api-resources.test.js
+++ b/ui/__tests__/unit/lib/kore-api/kore-api-resources.test.js
@@ -9,7 +9,7 @@ describe('KoreApiResources', () => {
   })
 
   describe('#generatePlanResource', () => {
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const values = {
         name: 'my-plan',
         summary: 'Plan summary',
@@ -32,7 +32,7 @@ describe('KoreApiResources', () => {
   })
 
   describe('#generatePolicyResource', () => {
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const values = {
         name: 'my-policy',
         summary: 'Policy summary',
@@ -55,7 +55,7 @@ describe('KoreApiResources', () => {
   })
 
   describe('#generateServicePlanResource', () => {
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const values = {
         name: 'My service plan',
         summary: 'Policy summary',
@@ -88,7 +88,7 @@ describe('KoreApiResources', () => {
       }
     }
 
-    test('generates expected resource, with GCP org only', () => {
+    it('generates expected resource, with GCP org only', () => {
       const accountMgt = koreApiResources.generateAccountManagementResource(gcpOrg)
       expect(accountMgt).toBeDefined()
       expect(accountMgt.apiVersion).toBe('accounts.kore.appvia.io/v1beta1')
@@ -107,7 +107,7 @@ describe('KoreApiResources', () => {
       })
     })
 
-    test('generates expected resource with project rules', () => {
+    it('generates expected resource with project rules', () => {
       const gcpProjectList = [{
         name: 'Not prod',
         description: 'Not prod account',
@@ -127,7 +127,7 @@ describe('KoreApiResources', () => {
       expect(accountMgt.spec.rules).toEqual(gcpProjectList)
     })
 
-    test('sets resourceVersion if specified', () => {
+    it('sets resourceVersion if specified', () => {
       const accountMgt = koreApiResources.generateAccountManagementResource(gcpOrg, [], '123')
       expect(accountMgt).toBeDefined()
       expect(accountMgt.metadata.resourceVersion).toBe('123')
@@ -144,7 +144,7 @@ describe('KoreApiResources', () => {
       }
     }
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const resourceName = 'allocatedkind-my-resource'
       const teams = ['*']
       const name = 'My resource'
@@ -170,7 +170,7 @@ describe('KoreApiResources', () => {
   })
 
   describe('#generateTeamResource', () => {
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const values = {
         teamName: 'Team 1',
         teamDescription: 'This is the first team'
@@ -192,7 +192,7 @@ describe('KoreApiResources', () => {
       secretAccessKey: 'secret-key'
     }
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const secret = koreApiResources.generateSecretResource('team1', 'my-secret', 'secret-type', 'Super secret', data)
       expect(secret).toBeDefined()
       expect(secret.apiVersion).toBe('config.kore.appvia.io')
@@ -204,7 +204,7 @@ describe('KoreApiResources', () => {
       expect(secret.spec.data).toEqual(data)
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const secret = koreApiResources.team('team1').generateSecretResource('my-secret', 'secret-type', 'Super secret', data)
       expect(secret).toBeDefined()
     })
@@ -216,7 +216,7 @@ describe('KoreApiResources', () => {
       accountID: '1234567890'
     }
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const eksCredential = koreApiResources.generateEKSCredentialsResource('team1', values, 'my-secret')
       expect(eksCredential).toBeDefined()
       expect(eksCredential.apiVersion).toBe('aws.compute.kore.appvia.io/v1alpha1')
@@ -227,7 +227,7 @@ describe('KoreApiResources', () => {
       expect(eksCredential.spec.credentialsRef).toEqual({ name: 'my-secret', namespace: 'team1' })
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const eksCredential = koreApiResources.team('team1').generateEKSCredentialsResource('team1', values, 'my-secret')
       expect(eksCredential).toBeDefined()
     })
@@ -236,7 +236,7 @@ describe('KoreApiResources', () => {
   describe('#generateGKECredentialsResource', () => {
     const values = { project: 'my-project' }
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const gkeCredential = koreApiResources.generateGKECredentialsResource('team1', values, 'my-secret')
       expect(gkeCredential).toBeDefined()
       expect(gkeCredential.apiVersion).toBe('gke.compute.kore.appvia.io/v1alpha1')
@@ -247,7 +247,7 @@ describe('KoreApiResources', () => {
       expect(gkeCredential.spec.credentialsRef).toEqual({ name: 'my-secret', namespace: 'team1' })
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const gkeCredential = koreApiResources.team('team1').generateGKECredentialsResource('team1', values, 'my-secret')
       expect(gkeCredential).toBeDefined()
     })
@@ -260,7 +260,7 @@ describe('KoreApiResources', () => {
       billingAccount: 'ABC-124'
     }
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const gcpOrg = koreApiResources.generateGCPOrganizationResource('team1', values, 'my-secret')
       expect(gcpOrg).toBeDefined()
       expect(gcpOrg.apiVersion).toBe('gcp.compute.kore.appvia.io/v1alpha1')
@@ -272,7 +272,7 @@ describe('KoreApiResources', () => {
       expect(gcpOrg.spec.credentialsRef).toEqual({ name: 'my-secret', namespace: 'team1' })
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const gcpOrg = koreApiResources.team('team1').generateGCPOrganizationResource('team1', values, 'my-secret')
       expect(gcpOrg).toBeDefined()
     })
@@ -292,7 +292,7 @@ describe('KoreApiResources', () => {
     }
     const credentials = 'some-creds'
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const cluster = koreApiResources.generateClusterResource('team1', user, values, plan, planValues, credentials)
       expect(cluster).toBeDefined()
       expect(cluster.apiVersion).toBe('clusters.compute.kore.appvia.io/v1')
@@ -305,7 +305,7 @@ describe('KoreApiResources', () => {
       expect(cluster.spec.credentials).toEqual(credentials)
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const cluster = koreApiResources.team('team1').generateClusterResource(user, values, plan, planValues, credentials)
       expect(cluster).toBeDefined()
     })
@@ -323,7 +323,7 @@ describe('KoreApiResources', () => {
       name: 'my-namespace'
     }
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const namespaceClaim = koreApiResources.generateNamespaceClaimResource('team1', cluster, resourceName, values)
       expect(namespaceClaim).toBeDefined()
       expect(namespaceClaim.apiVersion).toBe('namespaceclaims.clusters.compute.kore.appvia.io/v1alpha1')
@@ -343,7 +343,7 @@ describe('KoreApiResources', () => {
 
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const namespaceClaim = koreApiResources.team('team1').generateNamespaceClaimResource(cluster, resourceName, values)
       expect(namespaceClaim).toBeDefined()
     })
@@ -368,7 +368,7 @@ describe('KoreApiResources', () => {
       a: 1, b: 2
     }
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const service = koreApiResources.generateServiceResource('team1', cluster, values, plan, planValues)
       expect(service).toBeDefined()
       expect(service.apiVersion).toBe('services.compute.kore.appvia.io/v1')
@@ -390,14 +390,14 @@ describe('KoreApiResources', () => {
       })
     })
 
-    test('sets cluster namespace as a new namespace, if specified', () => {
+    it('sets cluster namespace as a new namespace, if specified', () => {
       const values2 = { ...values, createNamespace: 'new-namespace' }
       const service = koreApiResources.generateServiceResource('team1', cluster, values2, plan, planValues)
       expect(service).toBeDefined()
       expect(service.spec.clusterNamespace).toBe(values2.createNamespace)
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const service = koreApiResources.team('team1').generateServiceResource(cluster, values, plan, planValues)
       expect(service).toBeDefined()
     })
@@ -423,7 +423,7 @@ describe('KoreApiResources', () => {
     }
     const clusterNamespace = 'my-namespace'
 
-    test('generates expected resource', () => {
+    it('generates expected resource', () => {
       const serviceCred = koreApiResources.generateServiceCredentialsResource('team1', name, secretName, config, service, cluster, clusterNamespace)
       expect(serviceCred).toBeDefined()
       expect(serviceCred.apiVersion).toBe('servicecredentials.services.kore.appvia.io/v1')
@@ -454,7 +454,7 @@ describe('KoreApiResources', () => {
 
     })
 
-    test('works when using the team wrapper', () => {
+    it('works when using the team wrapper', () => {
       const serviceCred = koreApiResources.team('team1').generateServiceCredentialsResource(name, secretName, config, service, cluster, clusterNamespace)
       expect(serviceCred).toBeDefined()
     })

--- a/ui/__tests__/unit/lib/utils/validation.test.js
+++ b/ui/__tests__/unit/lib/utils/validation.test.js
@@ -5,29 +5,29 @@ describe('validation', () => {
     describe('uriCompatible40CharMax', () => {
       const pattern = new RegExp(patterns.uriCompatible40CharMax.pattern)
 
-      test('matches correctly', () => {
+      it('matches correctly', () => {
         expect('a1').toMatch(pattern)
         expect('a'.repeat(40)).toMatch(pattern)
         expect('sensible-test-string1').toMatch(pattern)
       })
 
-      test('must be 40 chars or less', () => {
+      it('must be 40 chars or less', () => {
         expect('a'.repeat(41)).not.toMatch(pattern)
       })
 
-      test('must be lowercase', () => {
+      it('must be lowercase', () => {
         expect('string-with-UPPER-case').not.toMatch(pattern)
       })
 
-      test('must start with letter', () => {
+      it('must start with letter', () => {
         expect('1-test-string').not.toMatch(pattern)
       })
 
-      test('must only contain alphanumeric and hyphen', () => {
+      it('must only contain alphanumeric and hyphen', () => {
         expect('not_sensible_test_string1').not.toMatch(pattern)
       })
 
-      test('must end with alphanumeric', () => {
+      it('must end with alphanumeric', () => {
         expect('a1-').not.toMatch(pattern)
       })
     })
@@ -35,29 +35,29 @@ describe('validation', () => {
     describe('uriCompatible63CharMax', () => {
       const pattern = new RegExp(patterns.uriCompatible63CharMax.pattern)
 
-      test('matches correctly', () => {
+      it('matches correctly', () => {
         expect('a1').toMatch(pattern)
         expect('a'.repeat(63)).toMatch(pattern)
         expect('sensible-test-string1').toMatch(pattern)
       })
 
-      test('must be 63 chars or less', () => {
+      it('must be 63 chars or less', () => {
         expect('a'.repeat(64)).not.toMatch(pattern)
       })
 
-      test('must be lowercase', () => {
+      it('must be lowercase', () => {
         expect('string-with-UPPER-case').not.toMatch(pattern)
       })
 
-      test('must start with letter', () => {
+      it('must start with letter', () => {
         expect('1-test-string').not.toMatch(pattern)
       })
 
-      test('must only contain alphanumeric and hyphen', () => {
+      it('must only contain alphanumeric and hyphen', () => {
         expect('not_sensible_test_string1').not.toMatch(pattern)
       })
 
-      test('must end with alphanumeric', () => {
+      it('must end with alphanumeric', () => {
         expect('a1-').not.toMatch(pattern)
       })
     })

--- a/ui/__tests__/unit/pages/_app.test.js
+++ b/ui/__tests__/unit/pages/_app.test.js
@@ -50,7 +50,7 @@ describe('App', () => {
       })
 
       describe('CSR::no request present', () => {
-        test('makes request to get user session', async () => {
+        it('makes request to get user session', async () => {
           axios.get.mockResolvedValue({ data: sessionUser })
 
           const userSession = await App.getUserSession({ asPath: '/requested-path' })

--- a/ui/__tests__/unit/pages/teams/[name]/[tab].test.js
+++ b/ui/__tests__/unit/pages/teams/[name]/[tab].test.js
@@ -27,7 +27,7 @@ describe('TeamPage', () => {
 
   describe('#constructor', () => {
 
-    test('sets initial state', () => {
+    it('sets initial state', () => {
       expect(teamPage.state).toEqual({
         tabActiveKey: 'clusters',
         memberCount: -1,

--- a/ui/lib/components/credentials/GCPOrganization.js
+++ b/ui/lib/components/credentials/GCPOrganization.js
@@ -11,7 +11,8 @@ class GCPOrganization extends AutoRefreshComponent {
   static propTypes = {
     organization: PropTypes.object.isRequired,
     allTeams: PropTypes.array.isRequired,
-    editOrganization: PropTypes.func.isRequired
+    editOrganization: PropTypes.func.isRequired,
+    deleteOrganization: PropTypes.func.isRequired
   }
 
   componentDidUpdate(prevProps) {
@@ -33,7 +34,7 @@ class GCPOrganization extends AutoRefreshComponent {
   }
 
   render() {
-    const { organization, editOrganization, allTeams } = this.props
+    const { organization, editOrganization, deleteOrganization, allTeams } = this.props
     const created = moment(organization.metadata.creationTimestamp).fromNow()
 
     const displayAllocations = () => {
@@ -45,9 +46,10 @@ class GCPOrganization extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item key={organization.metadata.name} actions={[
+      <List.Item id={`gcporg_${organization.metadata.name}`} key={organization.metadata.name} actions={[
         <ResourceVerificationStatus key="verification_status" resourceStatus={organization.status} />,
-        <Text key="edit"><a onClick={editOrganization(organization)}><Icon type="edit" theme="filled"/> Edit</a></Text>
+        <Text key="delete_org"><a id={`gcporg_del_${organization.metadata.name}`}  onClick={deleteOrganization(organization)}><Icon type="delete" theme="filled"/> Delete</a></Text>,
+        <Text key="edit"><a id={`gcporg_edit_${organization.metadata.name}`} onClick={editOrganization(organization)}><Icon type="edit" theme="filled"/> Edit</a></Text>
       ]}>
         <List.Item.Meta
           avatar={<Avatar icon="cloud" />}

--- a/ui/lib/components/credentials/GCPOrganizationForm.js
+++ b/ui/lib/components/credentials/GCPOrganizationForm.js
@@ -85,7 +85,7 @@ class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
               style={{ marginTop: '10px' }}
             />
             <Form.Item label="Replace key">
-              <Checkbox id="gcp_org_replace_key" onChange={(e) => this.setState({ replaceKey: e.target.checked })} />
+              <Checkbox id="gcporg_replace_key" onChange={(e) => this.setState({ replaceKey: e.target.checked })} />
             </Form.Item>
           </>
         ) : null}

--- a/ui/lib/components/credentials/GCPOrganizationForm.js
+++ b/ui/lib/components/credentials/GCPOrganizationForm.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import VerifiedAllocatedResourceForm from '../resources/VerifiedAllocatedResourceForm'
 import KoreApi from '../../kore-api'
-import { Form, Input, Alert, Card } from 'antd'
+import { Checkbox, Form, Input, Alert, Card } from 'antd'
 import AllocationHelpers from '../../utils/allocation-helpers'
 
 class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
@@ -18,7 +18,7 @@ class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
     values.name = this.getMetadataName(values)
     const secretName = values.name
     const teamResources = KoreApi.resources().team(this.props.team)
-    if (!this.props.data) {
+    if (!this.props.data || this.state.replaceKey) {
       const secretData = { key: btoa(values.account) }
       const secretResource = teamResources.generateSecretResource(secretName, 'gcp-org', `GCP admin project Service Account for ${values.parentID}`, secretData)
       await api.UpdateTeamSecret(this.props.team, secretName, secretResource)
@@ -51,6 +51,7 @@ class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
 
   resourceFormFields = () => {
     const { form, data } = this.props
+    const { replaceKey } = this.state
     return (
       <Card style={{ marginBottom: '20px' }}>
         <Alert
@@ -75,21 +76,30 @@ class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
             <Input placeholder="Billing account" />,
           )}
         </Form.Item>
-        <Form.Item label="Service Account JSON" labelCol={{ span: 24 }} wrapperCol={{ span: 24 }} validateStatus={this.fieldError('account') ? 'error' : ''} help={this.fieldError('account') || Boolean(data) || 'The Service Account key in JSON format, with project creation permissions.'}>
-          {!data ? (
-            form.getFieldDecorator('account', {
-              rules: [{ required: true, message: 'Please enter your Service Account!' }]
-            })(
-              <Input.TextArea autoSize={{ minRows: 4, maxRows: 10  }} placeholder="Service Account JSON" />,
-            )
-          ) : (
+
+        {data ? (
+          <>
             <Alert
               message="For security reasons, the Service Account key is not shown after creation of the organization credential"
               type="warning"
-              style={{ marginBottom: '-20px', marginTop: '10px' }}
+              style={{ marginTop: '10px' }}
             />
-          )}
-        </Form.Item>
+            <Form.Item label="Replace key">
+              <Checkbox id="gcp_org_replace_key" onChange={(e) => this.setState({ replaceKey: e.target.checked })} />
+            </Form.Item>
+          </>
+        ) : null}
+
+        {!data || replaceKey ? (
+          <Form.Item label="Service Account JSON" labelCol={{ span: 24 }} wrapperCol={{ span: 24 }} validateStatus={this.fieldError('account') ? 'error' : ''} help={this.fieldError('account') || Boolean(data) || 'The Service Account key in JSON format, with project creation permissions.'}>
+            {form.getFieldDecorator('account', {
+              rules: [{ required: true, message: 'Please enter your Service Account!' }]
+            })(
+              <Input.TextArea autoSize={{ minRows: 4, maxRows: 10  }} placeholder="Service Account JSON" />,
+            )}
+          </Form.Item>
+        ) : null}
+
       </Card>
     )
   }

--- a/ui/lib/components/credentials/GKECredentials.js
+++ b/ui/lib/components/credentials/GKECredentials.js
@@ -11,7 +11,8 @@ class GKECredentials extends AutoRefreshComponent {
   static propTypes = {
     gkeCredentials: PropTypes.object.isRequired,
     allTeams: PropTypes.array.isRequired,
-    editGKECredential: PropTypes.func.isRequired
+    editGKECredential: PropTypes.func.isRequired,
+    deleteGKECredential: PropTypes.func.isRequired
   }
 
   componentDidUpdate(prevProps) {

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -132,6 +132,7 @@ class KoreApiClient {
   ListGCPOrganizations = (team) => this.apis.default.ListGCPOrganizations({ team })
   GetGCPOrganization = (team, name) => this.apis.default.GetGCPOrganization({ team, name })
   UpdateGCPOrganization = (team, name, org) => this.apis.default.UpdateGCPOrganization({ team, name, body: JSON.stringify(org) })
+  DeleteGCPOrganization = (team, name) => this.apis.default.DeleteGCPOrganization({ team, name })
   ListEKSCredentials = (team) => this.apis.default.ListEKSCredentials({ team })
   GetEKSCredentials = (team, name) => this.apis.default.GetEKSCredentials({ team, name })
   UpdateEKSCredentials = (team, name, resource) => this.apis.default.UpdateEKSCredentials({ team, name, body: JSON.stringify(resource) })

--- a/ui/server/controllers/apiproxy.js
+++ b/ui/server/controllers/apiproxy.js
@@ -27,7 +27,7 @@ function apiProxy(koreApiUrl) {
       }
       const message = (err.response && err.response.data && err.response.data.message) || err.message
       console.error(`Error making request to API with path ${apiUrlPath}`, status, message)
-      return res.status(status).send()
+      return res.status(status).send({ message })
     }
   }
 }


### PR DESCRIPTION
## Summary

Be able to replace the service account JSON key for the configured GCP organization.
Be able to delete the configured GCP organization

**Which issue(s) this PR resolves**:

Resolves #1011 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~ _N/A_

## Changes

Introducing a checkbox for replacing the Organization's JSON service account key.
Also adding functionality to delete the configured GCP Organization, this will also delete the associated `AccountManagement` CRD

### Additional changes

Adding/enhancing E2E tests for GCP Organizations.

## Screenshots

<img width="629" alt="Screen Shot 2020-06-29 at 13 18 08" src="https://user-images.githubusercontent.com/1334068/86004360-181a3a00-ba0b-11ea-8c13-c53369abcd47.png">
<img width="927" alt="Screen Shot 2020-06-29 at 13 18 35" src="https://user-images.githubusercontent.com/1334068/86004365-194b6700-ba0b-11ea-9f53-c7d81b92d4e5.png">

## Testing

Please provide detailed instructions about how to test this feature. This should include:
 * adding/editing GCP org
 * deleting GCP org
 * replacing service account JSON on GCP org

