### PR TITLE
Fixing namespaces not appearing on the cluster page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release v0.2.3 - 2020-06-29
+
+Bugfix release to enable [Namespaces not appearing on cluster page](https://github.com/appvia/kore/issues/1016)
+
 ## Release v0.2.2 - 2020-06-26
 
 Bugfix release to enable [GSuite token refresh to continue to work for Kore CLI after first login](https://github.com/appvia/kore/issues/1006)

--- a/ui/lib/components/teams/namespace/NamespacesTab.js
+++ b/ui/lib/components/teams/namespace/NamespacesTab.js
@@ -53,7 +53,7 @@ class NamespacesTab extends React.Component {
       const api = await KoreApi.client()
       let [ namespaceClaims, serviceKinds, serviceCredentials ] = await Promise.all([
         api.ListNamespaces(team.metadata.name),
-        api.ListServiceKinds(team),
+        featureEnabled(KoreFeatures.SERVICES) ? api.ListServiceKinds(team) : Promise.resolve({ items: [] }),
         featureEnabled(KoreFeatures.SERVICES) ? api.ListServiceCredentials(team.metadata.name, cluster.metadata.name) : Promise.resolve({ items: [] }),
       ])
       namespaceClaims = namespaceClaims.items.filter(ns => ns.spec.cluster.name === cluster.metadata.name)


### PR DESCRIPTION
## Summary

Fixing namespaces not appearing on the cluster page

**Which issue(s) this PR resolves**:

Resolves #1016 

## Changes

* a feature gate check was missing which broke the data fetching for the component
* meaning the namespace data was not fetched and therefore not shown
* this fix ensures we only request the service kind data when the services feature gate is enabled

## Testing

Please provide detailed instructions about how to test this feature. This should include:
 * creating a namespace and checking it appears after navigating away and coming back to the cluster page

I've tested creating a namespace with feature gates disabled, namespace was not showing. Once I applied this fix and reloaded the page, the namespace appeared as expected.