### PR TITLE
Team context header

### DIFF
--- a/ui/lib/components/teams/TeamHeader.js
+++ b/ui/lib/components/teams/TeamHeader.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Col, Row, Typography } from 'antd'
+const { Text } = Typography
+
+import Breadcrumb from '../layout/Breadcrumb'
+import TeamSettings from './TeamSettings'
+
+const TeamHeader = ({ team, breadcrumbExt, teamRemoved }) => (
+  <>
+    <Row gutter={[0, 16]}>
+      <Col span={20} style={{ marginTop: '8px' }}>
+        <Breadcrumb items={[{ text: team.spec.summary, href: '/teams/[name]', link: `/teams/${team.metadata.name}` }, ...(breadcrumbExt || [])]} />
+      </Col>
+      <Col span={4} style={{ textAlign: 'right' }}>
+        <TeamSettings team={team} teamRemoved={teamRemoved} />
+      </Col>
+    </Row>
+    <Row style={{ marginBottom: '30px' }}>
+      <Col span={12}>
+        {team.spec.description ? <Text strong>{team.spec.description}</Text> : <Text style={{ fontStyle: 'italic' }} type="secondary">No description</Text>}
+      </Col>
+      <Col span={12} style={{ textAlign: 'right' }}>
+        <Text><Text strong>Team ID: </Text>{team.metadata.name}</Text>
+      </Col>
+    </Row>
+  </>
+)
+
+TeamHeader.propTypes = {
+  team: PropTypes.object.isRequired,
+  breadcrumbExt: PropTypes.array,
+  teamRemoved: PropTypes.func.isRequired
+}
+
+export default TeamHeader

--- a/ui/lib/components/teams/TeamSettings.js
+++ b/ui/lib/components/teams/TeamSettings.js
@@ -1,0 +1,89 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import Router from 'next/router'
+import { Button, Dropdown, Icon, List, Menu, Modal, Typography } from 'antd'
+const { Paragraph } = Typography
+
+import KoreApi from '../../kore-api'
+import redirect from '../../utils/redirect'
+import { errorMessage, successMessage } from '../../utils/message'
+
+class TeamSettings extends React.Component {
+
+  static propTypes = {
+    team: PropTypes.object.isRequired,
+    teamRemoved: PropTypes.func.isRequired
+  }
+
+  deleteTeam = async () => {
+    try {
+      const team = this.props.team.metadata.name
+      await (await KoreApi.client()).RemoveTeam(team)
+      this.props.teamRemoved(team)
+      successMessage(`Team "${team}" deleted`)
+      return redirect({ router: Router, path: '/' })
+    } catch (err) {
+      if (err.statusCode === 409 && err.dependents) {
+        return Modal.warning({
+          title: 'The team cannot be deleted',
+          content: (
+            <>
+              <Paragraph strong>Error: {err.message}</Paragraph>
+              <List
+                size="small"
+                dataSource={err.dependents}
+                renderItem={d => <List.Item>{d.kind}: {d.name}</List.Item>}
+              />
+            </>
+          ),
+          onOk() {}
+        })
+      }
+      console.log('Error deleting team', err)
+      errorMessage('Team could not be deleted, please try again later')
+    }
+  }
+
+  deleteTeamConfirm = () => {
+    Modal.confirm({
+      title: 'Are you sure you want to delete this team?',
+      content: 'This cannot be undone',
+      okText: 'Yes',
+      okType: 'danger',
+      cancelText: 'No',
+      onOk: this.deleteTeam
+    })
+  }
+
+  render() {
+    const team = this.props.team
+    const menu = (
+      <Menu>
+        <Menu.Item key="audit">
+          <Link href="/teams/[name]/audit" as={`/teams/${team.metadata.name}/audit`}>
+            <a>
+              <Icon type="table" style={{ marginRight: '5px' }} />
+              Team audit viewer
+            </a>
+          </Link>
+        </Menu.Item>
+        <Menu.Item key="delete" className="ant-btn-danger" onClick={this.deleteTeamConfirm}>
+          <Icon type="delete" style={{ marginRight: '5px' }} />
+          Delete team
+        </Menu.Item>
+      </Menu>
+    )
+    return (
+      <Dropdown overlay={menu}>
+        <Button>
+          <Icon type="setting" style={{ marginRight: '10px' }} />
+          <Icon type="down" />
+        </Button>
+      </Dropdown>
+    )
+  }
+
+}
+
+export default TeamSettings

--- a/ui/lib/components/utils/TextWithCount.js
+++ b/ui/lib/components/utils/TextWithCount.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Badge } from 'antd'
+
+const TextWithCount = ({ title, count, icon }) => (
+  <span>
+    {title}
+    {count !== undefined && count !== -1 && <Badge showZero={true} style={{ marginLeft: '10px', backgroundColor: '#1890ff' }} count={count} />}
+    {icon}
+  </span>
+)
+
+TextWithCount.propTypes = {
+  title: PropTypes.string.isRequired,
+  count: PropTypes.number,
+  icon: PropTypes.node
+}
+
+export default TextWithCount

--- a/ui/pages/teams/[name]/[tab].js
+++ b/ui/pages/teams/[name]/[tab].js
@@ -1,20 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Link from 'next/link'
 import Router from 'next/router'
 import Error from 'next/error'
-import { Typography, Button, Badge, Alert, Icon, Modal, Dropdown, Menu, Tabs, List } from 'antd'
-const { Paragraph, Text } = Typography
+import { Alert, Tabs } from 'antd'
 const { TabPane } = Tabs
 
-import Breadcrumb from '../../../lib/components/layout/Breadcrumb'
-import redirect from '../../../lib/utils/redirect'
 import KoreApi from '../../../lib/kore-api'
 import ClustersTab from '../../../lib/components/teams/cluster/ClustersTab'
 import MembersTab from '../../../lib/components/teams/members/MembersTab'
 import SecurityTab from '../../../lib/components/teams/security/SecurityTab'
 import SecurityStatusIcon from '../../../lib/components/security/SecurityStatusIcon'
-import { successMessage, errorMessage } from '../../../lib/utils/message'
+import TeamHeader from '../../../lib/components/teams/TeamHeader'
+import TextWithCount from '../../../lib/components/utils/TextWithCount'
 
 class TeamDashboardTabPage extends React.Component {
   static propTypes = {
@@ -75,102 +72,16 @@ class TeamDashboardTabPage extends React.Component {
     Router.push('/teams/[name]/[tab]', `/teams/${this.props.team.metadata.name}/${key}`)
   }
 
-  deleteTeam = async () => {
-    try {
-      const team = this.props.team.metadata.name
-      await (await KoreApi.client()).RemoveTeam(team)
-      this.props.teamRemoved(team)
-      successMessage(`Team "${team}" deleted`)
-      return redirect({ router: Router, path: '/' })
-    } catch (err) {
-      if (err.statusCode === 409 && err.dependents) {
-        return Modal.warning({
-          title: 'The team can not be deleted',
-          content: (
-            <div>
-              <Paragraph strong>Error: {err.message}</Paragraph>
-              <List
-                size="small"
-                dataSource={err.dependents}
-                renderItem={d => <List.Item>{d.kind}: {d.name}</List.Item>}
-              />
-            </div>
-          ),
-          onOk() {}
-        })
-      }
-      console.log('Error deleting team', err)
-      errorMessage('Team could not be deleted, please try again later')
-    }
-  }
-
-  deleteTeamConfirm = () => {
-    Modal.confirm({
-      title: 'Are you sure you want to delete this team?',
-      content: 'This cannot be undone',
-      okText: 'Yes',
-      okType: 'danger',
-      cancelText: 'No',
-      onOk: this.deleteTeam
-    })
-  }
-
-  settingsMenu = ({ team }) => {
-    const menu = (
-      <Menu>
-        <Menu.Item key="audit">
-          <Link href="/teams/[name]/audit" as={`/teams/${team.metadata.name}/audit`}>
-            <a>
-              <Icon type="table" style={{ marginRight: '5px' }} />
-              Team audit viewer
-            </a>
-          </Link>
-        </Menu.Item>
-        <Menu.Item key="delete" className="ant-btn-danger" onClick={this.deleteTeamConfirm}>
-          <Icon type="delete" style={{ marginRight: '5px' }} />
-          Delete team
-        </Menu.Item>
-      </Menu>
-    )
-    return (
-      <Dropdown overlay={menu}>
-        <Button>
-          <Icon type="setting" style={{ marginRight: '10px' }} />
-          <Icon type="down" />
-        </Button>
-      </Dropdown>
-    )
-  }
-
-  getTabTitle = ({ title, count, icon }) => (
-    <span>
-      {title}
-      {count !== undefined && count !== -1 && <Badge showZero={true} style={{ marginLeft: '10px', backgroundColor: '#1890ff' }} count={count} />}
-      {icon}
-    </span>
-  )
-
   render() {
-    const { team, invitation } = this.props
+    const { team, invitation, teamRemoved } = this.props
 
     if (!team) {
       return <Error statusCode={404} />
     }
 
     return (
-      <div>
-        <div style={{ display: 'inline-block', width: '100%' }}>
-          <div style={{ float: 'left', marginTop: '8px' }}>
-            <Breadcrumb items={[{ text: team.spec.summary }]} />
-          </div>
-          <div style={{ float: 'right' }}>
-            {this.settingsMenu({ team })}
-          </div>
-        </div>
-        <Paragraph>
-          {team.spec.description ? <Text strong>{team.spec.description}</Text> : <Text style={{ fontStyle: 'italic' }} type="secondary">No description</Text> }
-          <Text style={{ float: 'right' }}><Text strong>Team ID: </Text>{team.metadata.name}</Text>
-        </Paragraph>
+      <>
+        <TeamHeader team={team} teamRemoved={teamRemoved} />
 
         {invitation ? (
           <Alert
@@ -182,20 +93,20 @@ class TeamDashboardTabPage extends React.Component {
         ) : null}
 
         <Tabs activeKey={this.state.tabActiveKey} onChange={(key) => this.handleTabChange(key)} tabBarStyle={{ marginBottom: '20px' }}>
-          <TabPane key="clusters" tab={this.getTabTitle({ title: 'Clusters', count: this.state.clusterCount })} forceRender={true}>
+          <TabPane key="clusters" tab={<TextWithCount title="Clusters" count={this.state.clusterCount} />} forceRender={true}>
             <ClustersTab user={this.props.user} team={this.props.team} getClusterCount={(count) => this.setState({ clusterCount: count })} />
           </TabPane>
 
-          <TabPane key="members" tab={this.getTabTitle({ title: 'Members', count: this.state.memberCount })} forceRender={true}>
+          <TabPane key="members" tab={<TextWithCount title="Members" count={this.state.memberCount} />} forceRender={true}>
             <MembersTab user={this.props.user} team={this.props.team} getMemberCount={(count) => this.setState({ memberCount: count })} />
           </TabPane>
 
-          <TabPane key="security" tab={this.getTabTitle({ title: 'Security', icon: <SecurityStatusIcon status="Compliant" size="small" style={{ verticalAlign: 'middle' }} /> })} forceRender={true}>
+          <TabPane key="security" tab={<TextWithCount title="Security" icon={<SecurityStatusIcon status="Compliant" size="small" style={{ verticalAlign: 'middle' }} />} />} forceRender={true}>
             <SecurityTab team={this.props.team} getOverviewStatus={(status) => this.setState({ securityStatus: status })} />
           </TabPane>
         </Tabs>
 
-      </div>
+      </>
     )
   }
 }

--- a/ui/pages/teams/[name]/audit.js
+++ b/ui/pages/teams/[name]/audit.js
@@ -2,14 +2,15 @@ import React from 'react'
 import axios from 'axios'
 import PropTypes from 'prop-types'
 
-import Breadcrumb from '../../../lib/components/layout/Breadcrumb'
 import AuditViewer from '../../../lib/components/common/AuditViewer'
+import TeamHeader from '../../../lib/components/teams/TeamHeader'
 import KoreApi from '../../../lib/kore-api'
 
 class TeamAuditPage extends React.Component {
   static propTypes = {
     team: PropTypes.object.isRequired,
     events: PropTypes.array.isRequired,
+    teamRemoved: PropTypes.func.isRequired
   }
 
   state = {
@@ -45,18 +46,13 @@ class TeamAuditPage extends React.Component {
   }
 
   render() {
-    const teamName = this.props.team.metadata.name
+    const { team, teamRemoved } = this.props
 
     return (
-      <div>
-        <Breadcrumb
-          items={[
-            { text: this.props.team.spec.summary, href: '/teams/[name]', link: `/teams/${teamName}` },
-            { text: 'Team Audit Viewer' }
-          ]}
-        />
+      <>
+        <TeamHeader team={team} breadcrumbExt={[{ text: 'Team Audit Viewer' }]} teamRemoved={teamRemoved} />
         <AuditViewer items={this.state.events} />
-      </div>
+      </>
     )
   }
 }

--- a/ui/pages/teams/[name]/clusters/[cluster]/services/[service].js
+++ b/ui/pages/teams/[name]/clusters/[cluster]/services/[service].js
@@ -5,7 +5,7 @@ import { Typography, Collapse, Icon, Row, Col, List, Button, Form, Divider, Card
 const { Text } = Typography
 
 import KoreApi from '../../../../../../lib/kore-api/index'
-import Breadcrumb from '../../../../../../lib/components/layout/Breadcrumb'
+import TeamHeader from '../../../../../../lib/components/teams/TeamHeader'
 import UsePlanForm from '../../../../../../lib/components/plans/UsePlanForm'
 import ComponentStatusTree from '../../../../../../lib/components/common/ComponentStatusTree'
 import ResourceStatusTag from '../../../../../../lib/components/resources/ResourceStatusTag'
@@ -24,6 +24,7 @@ class ServicePage extends React.Component {
     user: PropTypes.object.isRequired,
     service: PropTypes.object.isRequired,
     serviceKind: PropTypes.object.isRequired,
+    teamRemoved: PropTypes.func.isRequired
   }
 
   constructor(props) {
@@ -209,7 +210,7 @@ class ServicePage extends React.Component {
   }
 
   render = () => {
-    const { team, cluster, user, serviceKind } = this.props
+    const { team, cluster, user, serviceKind, teamRemoved } = this.props
     const { service, serviceCredentials, createServiceCredential } = this.state
     const created = moment(service.metadata.creationTimestamp).fromNow()
     const deleted = service.metadata.deletionTimestamp ? moment(service.metadata.deletionTimestamp).fromNow() : false
@@ -222,19 +223,16 @@ class ServicePage extends React.Component {
     const hasServiceCredentials = serviceCredentials && Boolean(serviceCredentials.length)
 
     return (
-      <div>
-        <Breadcrumb
-          items={[
-            { text: team.spec.summary, href: '/teams/[name]', link: `/teams/${team.metadata.name}` },
-            { text: 'Clusters', href: '/teams/[name]/[tab]', link: `/teams/${team.metadata.name}/clusters` },
-            { text: cluster.metadata.name, href: '/teams/[name]/clusters/[cluster]/[tab]', link: `/teams/${team.metadata.name}/clusters/${cluster.metadata.name}/namespaces` },
-            { text: 'Services', href: '/teams/[name]/clusters/[cluster]/[tab]', link: `/teams/${team.metadata.name}/clusters/${cluster.metadata.name}/services` },
-            { text: service.metadata.name }
-          ]}
-        />
+      <>
+        <TeamHeader team={team} breadcrumbExt={[
+          { text: 'Clusters', href: '/teams/[name]/[tab]', link: `/teams/${team.metadata.name}/clusters` },
+          { text: cluster.metadata.name, href: '/teams/[name]/clusters/[cluster]/[tab]', link: `/teams/${team.metadata.name}/clusters/${cluster.metadata.name}/namespaces` },
+          { text: 'Services', href: '/teams/[name]/clusters/[cluster]/[tab]', link: `/teams/${team.metadata.name}/clusters/${cluster.metadata.name}/services` },
+          { text: service.metadata.name }
+        ]} teamRemoved={teamRemoved} />
 
         <Row type="flex" gutter={[16,16]}>
-          <Col span={24} xl={12} style={{ marginTop: '18px' }}>
+          <Col span={24} xl={12}>
             <List.Item>
               <List.Item.Meta
                 className="large-list-item"
@@ -253,7 +251,7 @@ class ServicePage extends React.Component {
               />
             </List.Item>
           </Col>
-          <Col span={24} xl={12} style={{ marginTop: '14px' }}>
+          <Col span={24} xl={12}>
             <Collapse style={{ marginTop: '12px' }}>
               <Collapse.Panel header="Detailed Service Status" extra={(<ResourceStatusTag resourceStatus={service.status} />)}>
                 <ComponentStatusTree team={team} user={user} component={service} />
@@ -349,7 +347,7 @@ class ServicePage extends React.Component {
           </Collapse.Panel>
         </Collapse>
 
-      </div>
+      </>
     )
   }
 }

--- a/ui/pages/teams/[name]/clusters/new.js
+++ b/ui/pages/teams/[name]/clusters/new.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Typography } from 'antd'
-const { Title } = Typography
 
-import Breadcrumb from '../../../../lib/components/layout/Breadcrumb'
+import TeamHeader from '../../../../lib/components/teams/TeamHeader'
 import ClusterBuildForm from '../../../../lib/components/teams/cluster/ClusterBuildForm'
 import KoreApi from '../../../../lib/kore-api'
 
@@ -11,7 +9,8 @@ class NewTeamClusterPage extends React.Component {
   static propTypes = {
     user: PropTypes.object.isRequired,
     team: PropTypes.object.isRequired,
-    clusters: PropTypes.object.isRequired
+    clusters: PropTypes.object.isRequired,
+    teamRemoved: PropTypes.func.isRequired
   }
 
   static staticProps = {
@@ -38,26 +37,22 @@ class NewTeamClusterPage extends React.Component {
   }
 
   render() {
-    const teamName = this.props.team.metadata.name
-    const teamClusters = this.props.clusters.items
+    const { user, team, teamRemoved, clusters } = this.props
 
     return (
-      <div>
-        <Breadcrumb
-          items={[
-            { text: this.props.team.spec.summary, href: '/teams/[name]', link: `/teams/${teamName}` },
-            { text: 'Clusters', href: '/teams/[name]/[tab]', link: `/teams/${teamName}/clusters` },
-            { text: 'New cluster' }
-          ]}
-        />
-        <Title style={{ marginBottom: '40px' }}>New Cluster for {this.props.team.spec.summary}</Title>
+      <>
+        <TeamHeader team={team} breadcrumbExt={[
+          { text: 'Clusters', href: '/teams/[name]/[tab]', link: `/teams/${team.metadata.name}/clusters` },
+          { text: 'New cluster' }
+        ]} teamRemoved={teamRemoved} />
+
         <ClusterBuildForm
-          user={this.props.user}
-          team={this.props.team}
-          teamClusters={teamClusters}
+          user={user}
+          team={team}
+          teamClusters={clusters.items}
           skipButtonText="Cancel"
         />
-      </div>
+      </>
     )
   }
 }

--- a/ui/server/controllers/apiproxy.js
+++ b/ui/server/controllers/apiproxy.js
@@ -23,7 +23,7 @@ function apiProxy(koreApiUrl) {
       const status = (err.response && err.response.status) || 500
       if (status === 400 || status === 409) {
         console.log(`Validation error for ${apiUrlPath}`, err.response.data)
-        res.status(status).json(err.response.data).send()
+        return res.status(status).json(err.response.data).send()
       }
       const message = (err.response && err.response.data && err.response.data.message) || err.message
       console.error(`Error making request to API with path ${apiUrlPath}`, status, message)


### PR DESCRIPTION
## Summary

Adding a team header for all team scopes pages

* this was previously only shown on the main team page
* this includes the cluster page, new cluster page, service page and team audit page

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #586 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~ _NA_

## Changes

Please detail any major changes and provide the minimal documentation about how these work or do alter the current behaviour.
Anyone who reads this should understand the intention of this PR without reading the code.

### Additional changes

* adding a utils component for tab titles, or more generally titles with badges showing a count
* removing unnecessary div elements in favour or react fragments on the team scoped pages
* fixing bug with apiproxy not returning response when 400/409 found

## Screenshots

**Example from the new cluster page**

<img width="1068" alt="Screen Shot 2020-06-30 at 13 55 58" src="https://user-images.githubusercontent.com/1334068/86128607-7f062480-bad9-11ea-893f-a85b364d7119.png">

## Testing

 * check the header appears on the relevant page
 * check the links/settings all work as expected

