### PR TITLE
Bugfix: pass request context to kore client, otherwise /configure/users throws an error

### DIFF
--- a/ui/pages/configure/users.js
+++ b/ui/pages/configure/users.js
@@ -26,8 +26,8 @@ class ConfigureUsersPage extends React.Component {
     adminOnly: true
   }
 
-  static getInitialProps = async () => {
-    const api = await KoreApi.client()
+  static getInitialProps = async (ctx) => {
+    const api = await KoreApi.client(ctx)
     let [ users, admins ] = await Promise.all([
       api.ListUsers(),
       api.ListTeamMembers(publicRuntimeConfig.koreAdminTeamName)


### PR DESCRIPTION
## Summary

This is a trivial bugfix for the /configure/users page.

If you navigate to the /configure/users page, you'll get a 500 error page, which is a 401 Unauthorized under the hood - caused by a missing passed request context.