### PR TITLE
Kore Up Release Flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/sirupsen/logrus v1.5.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/steveyen/gtreap v0.0.0-20150807155958-0abe01ef9be2 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0 // indirect

--- a/pkg/cmd/kore/local/helm.go
+++ b/pkg/cmd/kore/local/helm.go
@@ -56,7 +56,7 @@ func (o *UpOptions) UpdateHelmValues(path string) error {
 	}
 
 	if !bytes.Equal(current, updated) {
-		return ioutil.WriteFile(path, updated, os.FileMode(0750))
+		return ioutil.WriteFile(path, updated, valueFilePerms)
 	}
 
 	return nil

--- a/pkg/cmd/kore/local/helm.go
+++ b/pkg/cmd/kore/local/helm.go
@@ -55,7 +55,7 @@ func (o *UpOptions) UpdateHelmValues(path string) error {
 		return err
 	}
 
-	if bytes.Compare(current, updated) != 0 {
+	if !bytes.Equal(current, updated) {
 		return ioutil.WriteFile(path, updated, os.FileMode(0750))
 	}
 

--- a/pkg/cmd/kore/local/helm.go
+++ b/pkg/cmd/kore/local/helm.go
@@ -40,9 +40,9 @@ func (o *UpOptions) UpdateHelmValues(path string) error {
 
 	// @step: iterate through any changes
 	updated, err := func() ([]byte, error) {
-		if utils.Contains("release", o.FlagsChanged) {
+		if utils.Contains("version", o.FlagsChanged) {
 			for _, x := range []string{"api.version", "ui.version"} {
-				values, err = UpdateYAML(values, x, o.Release)
+				values, err = UpdateYAML(values, x, o.Version)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/cmd/kore/local/up.go
+++ b/pkg/cmd/kore/local/up.go
@@ -372,9 +372,18 @@ func (o *UpOptions) EnsureKoreRelease(ctx context.Context) error {
 	}
 
 	return (&Task{
-		Header:      fmt.Sprintf("Attempting to deploy the Kore release %s", o.Release),
+		Header:      fmt.Sprintf("Attempting to deploy the Kore release %s", o.Version),
 		Description: "Deployed the Kore release into the cluster",
 		Handler: func(ctx context.Context) error {
+			logger := newProviderLogger(o.Factory)
+
+			switch o.Release == version.Tag {
+			case true:
+				logger.Info("Using the official helm chart for deployment")
+			default:
+				logger.Infof("Using the helm release: %s for deployment", o.Release)
+			}
+
 			release, err := func() (string, error) {
 				if strings.HasPrefix(o.Release, "http") {
 					return o.Release, nil

--- a/pkg/cmd/kore/local/up.go
+++ b/pkg/cmd/kore/local/up.go
@@ -47,6 +47,8 @@ import (
 const (
 	// helmVersion is the version of helm to download
 	helmVersion = "v3.2.1"
+	// valueFilePerms is the file permissions on the values.yaml
+	valueFilePerms = os.FileMode(0600)
 )
 
 // UpOptions are the options for bootstrapping
@@ -183,7 +185,7 @@ func (o *UpOptions) EnsureHelmValues(ctx context.Context) error {
 					return err
 				}
 
-				return ioutil.WriteFile(o.ValuesFile, content, os.FileMode(0750))
+				return ioutil.WriteFile(o.ValuesFile, content, valueFilePerms)
 			},
 		}).Run(ctx, o.Writer()); err != nil {
 			return err

--- a/pkg/cmd/kore/local/up.go
+++ b/pkg/cmd/kore/local/up.go
@@ -66,6 +66,8 @@ type UpOptions struct {
 	EnableDeploy bool
 	// Force indicates we should force any changes
 	Force bool
+	// FlagsChanged is a list of flags which changed
+	FlagsChanged []string
 	// HelmPath is the path to the helm binary
 	HelmPath string
 	// Wait indicates we wait for the deployment to finish

--- a/pkg/cmd/utils/handler.go
+++ b/pkg/cmd/utils/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/appvia/kore/pkg/utils"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // RunHandler is the run hanler
@@ -71,6 +72,18 @@ func DefaultRunFunc(o RunHandler) func(*cobra.Command, []string) {
 			utils.SetReflectedField("Name", cmd.Flags().Arg(1), o)
 		} else if utils.HasReflectField("Name", o) {
 			utils.SetReflectedField("Name", cmd.Flags().Arg(0), o)
+		}
+
+		// @step: some handler require they know the diff between flags set and defaults
+		if utils.HasReflectField("FlagsChanged", o) {
+			var changed []string
+
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				if f.Changed {
+					changed = append(changed, f.Name)
+				}
+			})
+			utils.SetReflectedField("FlagsChanged", changed, o)
 		}
 
 		o.CheckError(o.Validate())


### PR DESCRIPTION
## Summary

Fixing up the flag to do what is expected i.e. set the release version to what i selected. At the moment this is only used when no values.yaml exist

**Which issue(s) this PR resolves**:

Resolves https://github.com/appvia/kore/issues/1033

## Checklist

 - [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): None required

## Changes

When the `kore alpha local up --version <version>` is used the value is never ignored. 

### Additional changes

I'v added an optional FlagsChanged which is actioned in the DefaultHandler; if the field exists a list of flags changed i.e. user defined flags are included. This allows you to know if the value is the default value or an actual value set on the command line.

## Examples

`kore alpha local up`
`kore alpha local up --version <version>`

## Testing

Just run with a `--version` with and without i.e perhaps latest or v0.2.4 and you ca verify the changes are done in the `~/.kore/values.yaml`

