### PR TITLE
Throw error if ctx is missing from server-side KoreApi client

### DIFF
--- a/ui/__mocks__/requestInterceptorMock.js
+++ b/ui/__mocks__/requestInterceptorMock.js
@@ -1,0 +1,5 @@
+/**
+ * No need to for request interceptor logic when running tests
+ * just return the request untouched
+ */
+module.exports = () => (req) => req

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     '<rootDir>/__tests__/e2e/page-objects'
   ],
   moduleNameMapper: {
-    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js'
+    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
+    './request-interceptor': '<rootDir>/__mocks__/requestInterceptorMock.js'
   }
 }

--- a/ui/lib/kore-api/index.js
+++ b/ui/lib/kore-api/index.js
@@ -3,6 +3,7 @@ const url = require('url')
 
 const config = require('../../config')
 const KoreApiClient = require('./kore-api-client')
+const requestInterceptor = require('./request-interceptor')
 
 class KoreApi {
   static spec = null
@@ -21,28 +22,7 @@ class KoreApi {
 
     const api = await Swagger(
       KoreApi.swaggerUrl,
-      {
-        spec: spec,
-        requestInterceptor: (req) => {
-          // If we're running on the server, we need to layer in the user's identity to 
-          // the request. When running in the browser, this is handled by the cookie-based
-          // session.
-          if (!process.browser && !ctx) {
-            throw new Error('KoreApi client requires ctx containing id_token OR passport session data')
-          }
-          if (!process.browser && ctx) {
-            if (ctx.id_token || ctx.req) {
-              req.headers['Authorization'] = `Bearer ${ctx.id_token || ctx.req.session.passport.user.id_token}`
-            }
-            // optionally override the auth with a username/password
-            // used when authenticating local users
-            if (ctx.basicAuth) {
-              req.headers['Authorization'] = `Basic ${ctx.basicAuth}`
-            }
-          }
-          return req
-        }
-      }
+      { spec, requestInterceptor: requestInterceptor(ctx) }
     )
 
     return new KoreApiClient(api, KoreApi.basePath)

--- a/ui/lib/kore-api/index.js
+++ b/ui/lib/kore-api/index.js
@@ -27,6 +27,9 @@ class KoreApi {
           // If we're running on the server, we need to layer in the user's identity to 
           // the request. When running in the browser, this is handled by the cookie-based
           // session.
+          if (!process.browser && !ctx) {
+            throw new Error('KoreApi client requires ctx containing id_token OR passport session data')
+          }
           if (!process.browser && ctx) {
             if (ctx.id_token || ctx.req) {
               req.headers['Authorization'] = `Bearer ${ctx.id_token || ctx.req.session.passport.user.id_token}`

--- a/ui/lib/kore-api/request-interceptor.js
+++ b/ui/lib/kore-api/request-interceptor.js
@@ -1,0 +1,19 @@
+module.exports = (ctx) => (req) => {
+  // If we're running on the server, we need to layer in the user's identity to
+  // the request. When running in the browser, this is handled by the cookie-based
+  // session.
+  if (!process.browser && !ctx) {
+    throw new Error('KoreApi client requires ctx containing id_token OR passport session data')
+  }
+  if (!process.browser && ctx) {
+    if (ctx.id_token || ctx.req) {
+      req.headers['Authorization'] = `Bearer ${ctx.id_token || ctx.req.session.passport.user.id_token}`
+    }
+    // optionally override the auth with a username/password
+    // used when authenticating local users
+    if (ctx.basicAuth) {
+      req.headers['Authorization'] = `Basic ${ctx.basicAuth}`
+    }
+  }
+  return req
+}


### PR DESCRIPTION
## Summary

Throw a meaningful error if the `ctx` is missing from the KoreApi client for a server-side call.
