### PR TITLE
Kore contact for teams to request cloud account credentials

### DIFF
--- a/pkg/persistence/configs.go
+++ b/pkg/persistence/configs.go
@@ -55,7 +55,7 @@ func (v configImpl) Delete(ctx context.Context, config *model.Config) (*model.Co
 
 	q := v.conn
 
-	return config, q.Delete(&model.Config{}).Error
+	return config, q.Delete(config).Error
 }
 
 // Exists check if config exists

--- a/ui/lib/components/setup/forms/RequestCredentialAccessForm.js
+++ b/ui/lib/components/setup/forms/RequestCredentialAccessForm.js
@@ -6,11 +6,10 @@ const { Paragraph } = Typography
 import { patterns } from '../../../utils/validation'
 
 class RequestCredentialAccessForm extends React.Component {
-  static ENABLED = false
-
   static propTypes = {
     form: PropTypes.object.isRequired,
     cloud: PropTypes.oneOf(['GCP', 'AWS']).isRequired,
+    data: PropTypes.object,
     onChange: PropTypes.func,
     helpInModal: PropTypes.bool
   }
@@ -18,35 +17,25 @@ class RequestCredentialAccessForm extends React.Component {
   cloudContent = {
     'GCP': {
       accountNoun: 'Project',
-      help: RequestCredentialAccessForm.ENABLED ? (
+      help: (
         <div>
           <p>When using Kore with existing GCP projects, you must allocate the project credentials to teams in order for them to provision clusters within those projects.</p>
           <p style={{ marginBottom: '0' }}>When a new team is created they may not have access to any project credentials, here you can provide an email address which will be displayed to a team in this situation, in order to request access to a GCP project through Kore.</p>
-        </div>
-      ) : (
-        <div>
-          <p>When using Kore with existing GCP projects, you must allocate the project credentials to teams in order for them to provision clusters within those projects.</p>
-          <p style={{ marginBottom: '0' }}>When a new team is created they may not have access to any project credentials. In this case, the user will be asked to contact the Kore administrator to setup the required access.</p>
         </div>
       )
     },
     'AWS': {
       accountNoun: 'Account',
-      help: RequestCredentialAccessForm.ENABLED ? (
+      help: (
         <div>
           <p>When using Kore with existing AWS accounts, you must allocate the account credentials to teams in order for them to provision clusters within those accounts.</p>
           <p style={{ marginBottom: '0' }}>When a new team is created they may not have access to any account credentials, here you can provide an email address which will be displayed to a team in this situation, in order to request access to an AWS account through Kore.</p>
-        </div>
-      ) : (
-        <div>
-          <p>When using Kore with existing AWS accounts, you must allocate the account credentials to teams in order for them to provision clusters within those accounts.</p>
-          <p style={{ marginBottom: '0' }}>When a new team is created they may not have access to any account credentials. In this case, the user will be asked to contact the Kore administrator to setup the required access.</p>
         </div>
       )
     }
   }
 
-  onChange = () => this.props.onChange && this.props.onChange(this.props.form.getFieldError('email'))
+  onChange = () => this.props.onChange && this.props.onChange(this.props.form.getFieldValue('email'), this.props.form.getFieldError('email'))
 
   projectCredentialAccessHelp = () => {
     Modal.info({
@@ -58,7 +47,7 @@ class RequestCredentialAccessForm extends React.Component {
   }
 
   render() {
-    const { form, helpInModal } = this.props
+    const { form, helpInModal, data } = this.props
     const { getFieldDecorator, isFieldTouched, getFieldError } = form
     const content = this.cloudContent[this.props.cloud]
 
@@ -80,23 +69,24 @@ class RequestCredentialAccessForm extends React.Component {
             />
           </>
         )}
-        {RequestCredentialAccessForm.ENABLED && (
-          <Form>
-            <Form.Item
-              labelAlign="left"
-              labelCol={{ span: 2 }}
-              wrapperCol={{ span: 8 }}
-              label="Email"
-              validateStatus={emailError ? 'error' : ''}
-              help={emailError || `Email for teams who need access to ${content.accountNoun.toLowerCase()} credentials`}
-              onChange={this.onChange}
-            >
-              {getFieldDecorator('email', { rules: [{ required: true, message: 'Please enter the email!' }, { ...patterns.email }] })(
-                <Input type="email" placeholder="Email address" />
-              )}
-            </Form.Item>
-          </Form>
-        )}
+        <Form>
+          <Form.Item
+            labelAlign="left"
+            labelCol={{ span: 2 }}
+            wrapperCol={{ span: 8 }}
+            label="Email"
+            validateStatus={emailError ? 'error' : ''}
+            help={emailError || `Email for teams who need access to ${content.accountNoun.toLowerCase()} credentials`}
+            onChange={this.onChange}
+          >
+            {getFieldDecorator('email', {
+              rules: [{ required: true, message: 'Please enter the email!' }, { ...patterns.email }],
+              initialValue: data && data.email
+            })(
+              <Input type="email" placeholder="Email address" />
+            )}
+          </Form.Item>
+        </Form>
       </>
     )
   }

--- a/ui/lib/components/teams/cluster/MissingCredential.js
+++ b/ui/lib/components/teams/cluster/MissingCredential.js
@@ -1,48 +1,74 @@
+import React from 'react'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
-import { Alert, Button, Typography } from 'antd'
+import { Alert, Button, Icon, Typography } from 'antd'
 const { Paragraph, Text } = Typography
+import { pluralize } from 'inflect'
 
-const MissingCredential = ({ team, cloud }) => {
-  const message = {
-    'GCP': 'GCP project access not found',
-    'AWS': 'AWS account access not found'
+import KoreApi from '../../../kore-api'
+
+class MissingCredential extends React.Component {
+  static propTypes = {
+    team: PropTypes.string.isRequired,
+    cloud: PropTypes.oneOf(['GCP', 'AWS']).isRequired,
   }
-  const description = {
-    'GCP': (
+
+  state = {
+    dataLoading: true
+  }
+
+  accountNoun = () => ({ 'GCP' : 'project', 'AWS': 'account' }[this.props.cloud])
+
+  async fetchComponentData() {
+    const cloudConfig = await (await KoreApi.client()).GetConfig(this.props.cloud)
+    const email = cloudConfig && cloudConfig.spec.values.requestAccessEmail
+    return { email }
+  }
+
+  componentDidMount() {
+    this.fetchComponentData()
+      .then(data => this.setState({ ...data, dataLoading: false }))
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.cloud !== this.props.cloud) {
+      this.setState({ dataLoading: true })
+      this.fetchComponentData()
+        .then(data => this.setState({ ...data, dataLoading: false }))
+    }
+  }
+
+  render() {
+    const { dataLoading, email } = this.state
+
+    if (dataLoading) {
+      return <Icon type="loading" />
+    }
+
+    return (
       <>
-        <Paragraph>This team does not have access to create clusters in any GCP projects. Please use the contact below to grant this team access to a GCP project.</Paragraph>
-        <Text strong>Kore administrator</Text>
-      </>
-    ),
-    'AWS': (
-      <>
-        <Paragraph>This team does not have access to create clusters in any AWS accounts. Please use the contact below to grant this team access to an AWS account.</Paragraph>
-        <Text strong>Kore administrator</Text>
+        <Alert
+          message={`${this.props.cloud} ${this.accountNoun()} access not found`}
+          description={
+            <>
+              <Paragraph>This team does not have access to create clusters in any {this.props.cloud} {pluralize(this.accountNoun())}. Please use the contact below to grant this team access to a {this.props.cloud} {this.accountNoun()}.</Paragraph>
+              <Text strong>
+                {email ? <a style={{ textDecoration: 'underline' }} href={`mailto: ${this.state.email}`}>{this.state.email}</a> : 'Kore administrator'}
+              </Text>
+            </>
+          }
+          type="warning"
+          showIcon
+          style={{ marginBottom: '30px' }}
+        />
+        <Button type="primary">
+          <Link href="/teams/[name]" as={`/teams/${this.props.team}`}>
+            <a>Team dashboard</a>
+          </Link>
+        </Button>
       </>
     )
   }
-  return (
-    <div>
-      <Alert
-        message={message[cloud]}
-        description={description[cloud]}
-        type="warning"
-        showIcon
-        style={{ marginBottom: '20px' }}
-      />
-      <Button type="primary">
-        <Link href="/teams/[name]" as={`/teams/${team}`}>
-          <a>Team dashboard</a>
-        </Link>
-      </Button>
-    </div>
-  )
-}
-
-MissingCredential.propTypes = {
-  team: PropTypes.string.isRequired,
-  cloud: PropTypes.string.isRequired,
 }
 
 export default MissingCredential

--- a/ui/lib/kore-api/kore-api-client.js
+++ b/ui/lib/kore-api/kore-api-client.js
@@ -83,6 +83,12 @@ class KoreApiClient {
   ListUserTeams = (user) => this.apis.default.ListUserTeams({ user })
   UpdateUser = (user, userSpec) => this.apis.default.UpdateUser({ user, body: JSON.stringify(userSpec) })
 
+  // Config
+  ListConfig = () => this.apis.default.ListConfig()
+  GetConfig = (config) => this.apis.default.GetConfig({ config })
+  UpdateConfig = (config, body) => this.apis.default.UpdateConfig({ config, body: JSON.stringify(body) })
+  RemoveConfig = (config) => this.apis.default.RemoveConfig({ config })
+
   // Plans
   ListPlans = (kind) => this.apis.default.ListPlans({ kind })
   UpdatePlan = (name, plan) => this.apis.default.UpdatePlan({ name, body: JSON.stringify(plan) })

--- a/ui/lib/kore-api/kore-api-resources.js
+++ b/ui/lib/kore-api/kore-api-resources.js
@@ -178,6 +178,20 @@ export default class KoreApiResources {
     return resource
   }
 
+  generateConfigResource(name, values) {
+    const resource = this.newResource({
+      type: 'V1Config',
+      apiVersion: 'config.kore.appvia.io/v1',
+      kind: 'Config',
+      name
+    })
+
+    const spec = new models.V1ConfigSpec()
+    spec.setValues(values)
+    resource.setSpec(spec)
+    return resource
+  }
+
   team(team) {
     return {
       generateSecretResource: (name, secretType, description, data) => this.generateSecretResource(team, name, secretType, description, data),

--- a/ui/lib/utils/validation.js
+++ b/ui/lib/utils/validation.js
@@ -13,7 +13,8 @@ export const patterns = {
     message: 'Must consist of lower case alphanumeric characters or "-", it must start with a letter and end with an alphanumeric and must be no longer than 63 characters'
   },
   email: {
-    pattern: '^[^\s@]+@[^\s@]+\.[^\s@]+$',
+    // double backslash as it seems to be escaped otherwise
+    pattern: '^[^\\s@]+@[^\\s@]+\.[^\\s@]+$',
     message: 'Must be a valid email address'
   }
 }


### PR DESCRIPTION
## Summary

Configure and display email for requesting cloud account credentials

Please provide a short summary about the changes in this PR.

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1052 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~ _NA_

## Changes

* this is used when admins want to manage cloud accounts outside of Kore
* admins can set an email address which will be displayed to teams who do not have a credential allocated
* separate email addresses can be set for each cloud, GCP and AWS at this stage
* teams are shown this email address when they try to request a new cluster and do not have any allocated credentials

## Screenshots

<img width="922" alt="Screen Shot 2020-07-13 at 16 37 49" src="https://user-images.githubusercontent.com/1334068/87326909-4465a880-c52b-11ea-881c-f8f1e1333724.png">

<img width="1152" alt="Screen Shot 2020-07-13 at 16 38 04" src="https://user-images.githubusercontent.com/1334068/87326917-4596d580-c52b-11ea-9455-ce5593f5fe5e.png">

## Testing

* adding email address during setup
* adding from configure/cloud pages
* viewing the email when creating new clusters with no allocated credentials

