### PR TITLE
Fix for saving of account automation settings

### DIFF
--- a/ui/lib/components/plans/PlanViewer.js
+++ b/ui/lib/components/plans/PlanViewer.js
@@ -39,7 +39,7 @@ class PlanViewer extends React.Component {
       if (!this.props.hideCostEstimate) {
         try {
           costEstimate = await api.costestimates.EstimateClusterPlanCost(this.props.plan)
-        } catch {
+        } catch (err) {
           // Ignore failure to get a cost estimate, we just won't display it.
         }
       }


### PR DESCRIPTION
## Summary

Fix for saving of account automation settings

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1070 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~ _NA_

## Changes

* adding a couple of checks when saving an `AccountManagement` CRD
    - remove any rules which have no plans
    - removing any rule plans which no longer exist
* set the filtered rules back to the state once saving

## Testing

As per the bug detailed in #1070 

