### PR TITLE
Add E2E tests for AKS, add controller for AKS credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ parameters:
     type: boolean
     default: false
 
+  enable_aks_e2e:
+    type: boolean
+    default: false
+
 #
 # Templates ---
 #
@@ -100,6 +104,9 @@ e2e_job_template: &E2E_JOB_TEMPLATE
     enable_gke:
       type: boolean
       default: false
+    enable_aks:
+      type: boolean
+      default: false
     host:
       type: string
       default: http://127.0.0.1:10080
@@ -107,6 +114,7 @@ e2e_job_template: &E2E_JOB_TEMPLATE
   environment:
     ENABLE_EKS_E2E: << parameters.enable_eks >>
     ENABLE_GKE_E2E: << parameters.enable_gke >>
+    ENABLE_AKS_E2E: << parameters.enable_aks >>
     KORE_ADMIN_TOKEN: "password"
     KORE_API_PUBLIC_URL_QA: << parameters.host >>
 
@@ -154,7 +162,8 @@ e2e_job_template: &E2E_JOB_TEMPLATE
           test/e2e/check-suite.sh \
             --enable-e2e-user ${KORE_E2E_USER} \
             --enable-gke ${ENABLE_GKE_E2E} \
-            --enable-eks ${ENABLE_EKS_E2E}
+            --enable-eks ${ENABLE_EKS_E2E} \
+            --enable-aks ${ENABLE_AKS_E2E}
     - slack/notify-on-failure:
         only_for_branches: master
 #
@@ -498,6 +507,9 @@ jobs:
   e2e_eks:
     <<: *E2E_JOB_TEMPLATE
 
+  e2e_aks:
+    <<: *E2E_JOB_TEMPLATE
+
 workflows:
   version: 2.1
   workflow:
@@ -565,6 +577,15 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+)|-beta([0-9]+)|-alpha([0-9]+))$/
+      - e2e_aks:
+          enable_aks: true
+          requires:
+            - e2e-images
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+)|-beta([0-9]+)|-alpha([0-9]+))$/
       - publish-release:
           requires:
             - check
@@ -575,6 +596,7 @@ workflows:
             - check-release-notes
             - e2e_eks
             - e2e_gke
+            - e2e_aks
           filters:
             branches:
               ignore: /.*/
@@ -640,6 +662,16 @@ workflows:
           enable_eks: true
           requires:
             - e2e-images
+
+  e2e_aks:
+    when: << pipeline.parameters.enable_aks_e2e >>
+    jobs:
+      - e2e-images
+      - e2e_aks:
+          enable_aks: true
+          requires:
+            - e2e-images
+
   nightly:
     triggers:
       - schedule:
@@ -656,5 +688,9 @@ workflows:
             - e2e-images
       - e2e_eks:
           enable_eks: true
+          requires:
+            - e2e-images
+      - e2e_aks:
+          enable_aks: true
           requires:
             - e2e-images

--- a/examples/aks-credentials.yml
+++ b/examples/aks-credentials.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: aks.compute.kore.appvia.io/v1alpha1
+kind: AKSCredentials
+metadata:
+  name: example-aks
+  namespace: kore-admin
+spec:
+  subscriptionID: <SUBSCRIPTION ID>
+  tenantID: <TENANT ID>
+  clientID: <CLIENT ID>
+  credentialsRef:
+    name: example-aks
+    namespace: kore-admin
+
+---
+apiVersion: config.kore.appvia.io/v1
+kind: Secret
+metadata:
+  name: example-aks
+  namespace: kore-admin
+spec:
+  data:
+    subscription_id: <BASE64-ENCODED SUBSCRIPTION ID>
+    tenant_id: <BASE64-ENCODED TENANT ID>
+    client_id: <BASE64-ENCODED CLIENT ID>
+    client_secret: <BASE64-ENCODED CLIENT SECRET>
+  description: Example credentials
+  type: azure-credentials
+
+---
+apiVersion: config.kore.appvia.io/v1
+kind: Allocation
+metadata:
+  name: akscredentials-example-aks
+  namespace: kore-admin
+spec:
+  name: example-aks
+  resource:
+    group: aks.compute.kore.appvia.io
+    kind: AKSCredentials
+    name: example-aks
+    namespace: kore-admin
+    version: v1alpha1
+  summary: Default Credentials for building an AKS Cluster
+  teams:
+    - '*'

--- a/pkg/apis/aks/v1alpha1/akscredentials_types.go
+++ b/pkg/apis/aks/v1alpha1/akscredentials_types.go
@@ -72,6 +72,14 @@ type AKSCredentials struct {
 	Status AKSCredentialsStatus `json:"status,omitempty"`
 }
 
+func (in *AKSCredentials) GetStatus() (status corev1.Status, message string) {
+	return in.Status.Status, ""
+}
+
+func (in *AKSCredentials) SetStatus(status corev1.Status, _ string) {
+	in.Status.Status = status
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AKSCredentialsList contains a list of AKSCredentials

--- a/pkg/controllers/cloud/azure/akscredentials/controller.go
+++ b/pkg/controllers/cloud/azure/akscredentials/controller.go
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akscredentials
+
+import (
+	"context"
+	"time"
+
+	aksv1alpha1 "github.com/appvia/kore/pkg/apis/aks/v1alpha1"
+
+	"github.com/appvia/kore/pkg/controllers"
+	"github.com/appvia/kore/pkg/kore"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var _ controllers.Interface2 = &Controller{}
+
+type Controller struct {
+	kore.Interface
+	name   string
+	logger log.FieldLogger
+	mgr    manager.Manager
+	ctrl   controller.Controller
+}
+
+func init() {
+	ctrl := NewController(log.StandardLogger())
+	if err := controllers.Register(ctrl); err != nil {
+		log.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Fatalf("failed to register the %s controller", ctrl.Name())
+	}
+}
+
+// NewController creates and returns an AKS credentials controller
+func NewController(logger log.FieldLogger) *Controller {
+	name := "akscredentials"
+	return &Controller{
+		name: name,
+		logger: logger.WithFields(log.Fields{
+			"controller": name,
+		}),
+	}
+}
+
+// Name returns the name of the controller
+func (c *Controller) Name() string {
+	return c.name
+}
+
+// ManagerOptions returns the manager options for the controller
+func (c *Controller) ManagerOptions() manager.Options {
+	return controllers.DefaultManagerOptions(c)
+}
+
+// ControllerOptions returns the controllers options
+func (c *Controller) ControllerOptions() controller.Options {
+	return controllers.DefaultControllerOptions(c)
+}
+
+func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
+	c.mgr = mgr
+	c.ctrl = ctrl
+	c.Interface = hi
+
+	c.logger.Debug("controller has been started")
+
+	// @step: setup watches for the resources
+	if err := c.ctrl.Watch(
+		&source.Kind{Type: &aksv1alpha1.AKSCredentials{}},
+		&handler.EnqueueRequestForObject{},
+		predicate.GenerationChangedPredicate{},
+	); err != nil {
+		c.logger.WithError(err).Error("failed to create watcher on AKSCredentials resource")
+
+		return err
+	}
+
+	var stopCh chan struct{}
+
+	go func() {
+		c.logger.Info("starting the controller loop")
+
+		for {
+			stopCh = make(chan struct{})
+
+			if err := c.mgr.Start(stopCh); err != nil {
+				c.logger.WithError(err).Error("failed to start the controller")
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	// @step: use a routine to catch the stop channel
+	go func() {
+		<-ctx.Done()
+
+		c.logger.Info("stopping the controller")
+
+		if stopCh != nil {
+			close(stopCh)
+		}
+	}()
+
+	return nil
+}
+
+// Run is called when the controller is started
+func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
+	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+}
+
+// Stop is responsible for calling a halt on the controller
+func (c *Controller) Stop(context.Context) error {
+	c.logger.Info("attempting to stop the controller")
+
+	return nil
+}

--- a/pkg/controllers/cloud/azure/akscredentials/reconcile.go
+++ b/pkg/controllers/cloud/azure/akscredentials/reconcile.go
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akscredentials
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/appvia/kore/pkg/utils"
+
+	aksv1alpha1 "github.com/appvia/kore/pkg/apis/aks/v1alpha1"
+	"github.com/appvia/kore/pkg/controllers"
+	cc "github.com/appvia/kore/pkg/controllers/components"
+	"github.com/appvia/kore/pkg/kore"
+
+	log "github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	finalizerName = "aks.compute.kore.appvia.io"
+)
+
+// Reconcile is the entrypoint for the reconciliation logic
+func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	logger := log.WithFields(log.Fields{
+		"name":      request.NamespacedName.Name,
+		"namespace": request.NamespacedName.Namespace,
+	})
+	ctx := kore.NewContext(context.Background(), logger, c.mgr.GetClient(), c)
+
+	logger.Debug("attempting to reconcile the AKS cluster")
+
+	aksCredentials := &aksv1alpha1.AKSCredentials{}
+	if err := c.mgr.GetClient().Get(ctx, request.NamespacedName, aksCredentials); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+
+		return reconcile.Result{}, fmt.Errorf("failed to retrieve AKS cluster: %w", err)
+	}
+	original := aksCredentials.DeepCopyObject()
+
+	components := controllers.Components{
+		cc.NewFinalizer(finalizerName, aksCredentials),
+	}
+
+	res, err := components.Reconcile(ctx, aksCredentials)
+	if err != nil {
+		logger.WithError(err).Error("failed to reconcile the AKS cluster")
+	}
+
+	// TODO: implement AKS credentials verification
+	aksCredentials.Status.Verified = utils.BoolPtr(true)
+
+	if err := c.mgr.GetClient().Status().Patch(ctx, aksCredentials, client.MergeFrom(original)); err != nil {
+		logger.WithError(err).Error("failed to update the status of the AKS cluster")
+
+		return reconcile.Result{}, fmt.Errorf("failed to update the status of the AKS cluster: %w", err)
+	}
+
+	return res, err
+}

--- a/pkg/controllers/register/register.go
+++ b/pkg/controllers/register/register.go
@@ -36,6 +36,7 @@ import (
 
 	// import the azure controllers
 	_ "github.com/appvia/kore/pkg/controllers/cloud/azure/aks"
+	_ "github.com/appvia/kore/pkg/controllers/cloud/azure/akscredentials"
 
 	// importing the management controller
 	_ "github.com/appvia/kore/pkg/controllers/management/cluster"

--- a/pkg/utils/kubernetes/types.go
+++ b/pkg/utils/kubernetes/types.go
@@ -37,6 +37,10 @@ type ObjectWithStatus interface {
 	Object
 	GetStatus() (status corev1.Status, message string)
 	SetStatus(status corev1.Status, message string)
+}
+
+type ObjectWithStatusComponents interface {
+	Object
 	StatusComponents() *corev1.Components
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -9,8 +9,10 @@
 
 You must have some valid credentials in the e2e folder
 
-- e2eci/gke-credentials.yml (containing a gkecredentials{} and allocation called gke for all teams).
-  A example can be found in the examples/gcp-credentials.yml
+ * e2eci/gke-credentials.yml (containing a GKECredentials object and Allocation called gke for all teams).
+   A example can be found in the examples/gcp-credentials.yml
+ * e2eci/aks-credentials.yml (containing an AKSCredentials object and Allocation called aks for all teams).
+   A example can be found in the examples/aks-credentials.yml
 
 ##  **Running the suite locally**
 

--- a/test/e2e/check-suite.sh
+++ b/test/e2e/check-suite.sh
@@ -34,6 +34,7 @@ export TEAM="${TEAM:-"e2e"}"
 ENABLE_CONFORMANCE=${ENABLE_CONFORMANCE:-false}
 ENABLE_EKS_E2E=${ENABLE_EKS_E2E:-"false"}
 ENABLE_GKE_E2E=${ENABLE_GKE_E2E:-"false"}
+ENABLE_AKS_E2E=${ENABLE_AKS_E2E:-"false"}
 ENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS:-true}
 PATH=$PATH:${GOPATH}/bin
 KORE_CONFIG=${HOME}/.kore/config
@@ -48,6 +49,7 @@ usage() {
   --enable-e2e-user      : indicates we should provision a test user
   --enable-gke           : indicates we should run the GKE (default: ${ENABLE_GKE_E2E})
   --enable-eks           : indicates we should run E2E on EKS (default: ${ENABLE_EKS_E2E})
+  --enable-aks           : indicates we should run E2E on AKS (default: ${ENABLE_AKS_E2E})
   --e2e-team             : is the name of the team to use
   -h|--help              : display this usage menu
 EOF
@@ -86,9 +88,9 @@ EOF
 }
 
 create-aws-profile() {
-  aws configure --profile ${AWS_KORE_PROFILE} set aws_access_key_id ${AWS_ACCESS_KEY_ID}
-  aws configure --profile ${AWS_KORE_PROFILE} set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY}
-  aws configure --profile ${AWS_KORE_PROFILE} set default.region ${AWS_DEFAULT_REGION}
+  aws configure --profile "${AWS_KORE_PROFILE}" set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
+  aws configure --profile "${AWS_KORE_PROFILE}" set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
+  aws configure --profile "${AWS_KORE_PROFILE}" set default.region "${AWS_DEFAULT_REGION}"
 }
 
 enable-admin-user() {
@@ -134,6 +136,7 @@ while [[ $# -gt 0 ]]; do
   --enable-unit-tests)  ENABLE_UNIT_TESTS="true";  shift 1; ;;
   --enable-gke)         ENABLE_GKE_E2E=${2};       shift 2; ;;
   --enable-eks)         ENABLE_EKS_E2E=${2};       shift 2; ;;
+  --enable-aks)         ENABLE_AKS_E2E=${2};       shift 2; ;;
   --enable-e2e-user)    ADMIN_USER=$2;             shift 2; ;;
   --e2e-team)           TEAM=$2;                   shift 2; ;;
   -h|--help)            usage;                              ;;
@@ -154,11 +157,24 @@ if [[ "${ENABLE_UNIT_TESTS}" == "true" ]]; then
   if [[ -n "${EKS_SA_QA}" ]]; then
     echo -n ${EKS_SA_QA} | base64 -d > ${E2E_DIR}/eks-credentials.yml 2>/dev/null
   fi
+  if [[ -n "${AKS_SA_QA}" ]]; then
+    echo -n ${AKS_SA_QA} | base64 -d > ${E2E_DIR}/aks-credentials.yml 2>/dev/null
+  fi
 
-  if [[ ! -f "${E2E_DIR}/gke-credentials.yml" ]]; then
-    error "you need to have the ${E2E_DIR}/gke-credentials.yml containing real credentials for gke"
-    error "you can copy an template from: examples/gke.yml"
-    exit 1
+  if [[ "${ENABLE_GKE_E2E}" == "true" ]]; then
+    if [[ ! -f "${E2E_DIR}/gke-credentials.yml" ]]; then
+      error "you need to have the ${E2E_DIR}/gke-credentials.yml containing real credentials for gke"
+      error "you can copy an template from: examples/gcp-credentials.yml"
+      exit 1
+    fi
+  fi
+
+  if [[ "${ENABLE_AKS_E2E}" == "true" ]]; then
+    if [[ ! -f "${E2E_DIR}/aks-credentials.yml" ]]; then
+      error "you need to have the ${E2E_DIR}/aks-credentials.yml containing real credentials for aks"
+      error "you can copy an template from: examples/aks-credentials.yml"
+      exit 1
+    fi
   fi
 
   if ! create-korectl-config; then
@@ -173,7 +189,8 @@ if [[ "${ENABLE_UNIT_TESTS}" == "true" ]]; then
 
   if ! test/e2e/check-suite-units.sh \
     --enable-gke ${ENABLE_GKE_E2E} \
-    --enable-eks ${ENABLE_EKS_E2E}; then
+    --enable-eks ${ENABLE_EKS_E2E} \
+    --enable-aks ${ENABLE_AKS_E2E}; then
     error "failed trying on unit tests"
     exit 1
    fi

--- a/test/e2e/integration/aks-credentials.bats
+++ b/test/e2e/integration/aks-credentials.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+#
+# Copyright 2020 Appvia Ltd <info@appvia.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load helper
+
+@test "We should not have any AKS credentials existing" {
+  runit "${KORE} delete akscredentials aks -t kore-admin || true"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should not be able to list any aks credentials" {
+  runit "${KORE} get akscredentials aks -t kore-admin || true"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should be able to apply the aks credentials" {
+  runit "${KORE} apply -f ${BASE_DIR}/e2eci/aks-credentials.yml -t kore-admin 2>&1 >/dev/null"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should be able to view the credentials via the cli now" {
+  run ${KORE} get akscredentials aks -t kore-admin
+  [[ "$status" -eq 0 ]]
+}
+
+@test "The AKS credentials should come back as verified" {
+  retry 5 "${KORE} get akscredentials aks -t kore-admin -o json | jq '.status.verified' | grep -i true"
+  [[ "$status" -eq 0 ]]
+  retry 5 "${KORE} get akscredentials aks -t kore-admin -o json | jq '.status.status' | grep -i success"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should be able to see the aks allocations in the ${TEAM} team" {
+  runit "${KORE} get allocations akscredentials-aks -t ${TEAM}"
+  [[ "$status" -eq 0 ]]
+  runit "${KORE} get allocations akscredentials-aks -o json -t ${TEAM} | jq '.status.status' | grep -i success"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "If we delete the allocation, the ${TEAM} should no longer see the aks credentials" {
+  runit "${KORE} get allocations akscredentials-aks -t kore-admin"
+  [[ "$status" -eq 0 ]]
+  runit "${KORE} delete allocations akscredentials-aks -t kore-admin"
+  [[ "$status" -eq 0 ]]
+  retry 5 "${KORE} get allocations -t ${TEAM} | grep ^akscredentials-aks || true"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should reapply the credentials and get back the allocation in the ${TEAM} team" {
+  runit "${KORE} apply -f ${BASE_DIR}/e2eci/aks-credentials.yml -t kore-admin 2>&1 >/dev/null"
+  [[ "$status" -eq 0 ]]
+  retry 5 "${KORE} get akscredentials aks -t kore-admin -o json | jq '.status.verified' | grep -i true"
+  [[ "$status" -eq 0 ]]
+  retry 5 "${KORE} get akscredentials aks -t kore-admin -o json | jq '.status.status' | grep -i success"
+  [[ "$status" -eq 0 ]]
+  retry 5 "${KORE} get allocations akscredentials-aks -t ${TEAM}"
+  [[ "$status" -eq 0 ]]
+}

--- a/test/e2e/integration/aks-deletion.bats
+++ b/test/e2e/integration/aks-deletion.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+#
+# Copyright 2020 Appvia Ltd <info@appvia.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load helper
+
+setup() {
+  ${KORE} get allocation akscredentials-aks -t ${TEAM} | grep AKS || skip && true
+}
+
+@test "We should be able to delete the aks cluster" {
+  ${KORE} get cluster ${CLUSTER} -t ${TEAM} || skip
+
+  retry 10 "${KORE} delete cluster ${CLUSTER} -t ${TEAM} --no-wait"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "The status of the cluster should change to deleting" {
+  ${KORE} get cluster ${CLUSTER} -t ${TEAM} || skip
+
+  retry 10 "${KORE} get cluster ${CLUSTER} -t ${TEAM} -o json | jq '.status.status' | grep -i deleting"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should see the status of the aks cluster change to deleting" {
+  ${KORE} get cluster ${CLUSTER} -t ${TEAM} || skip
+
+  retry 20 "${KORE} get aks ${CLUSTER} -t ${TEAM} -o json | jq '.status.status' | grep -i deleting"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should see the aks resource be deleted" {
+  ${KORE} get cluster ${CLUSTER} -t ${TEAM} || skip
+
+  retry 360 "${KORE} get aks ${CLUSTER} -t ${TEAM} 2>&1 | grep 'not found$'"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should see the cluster resource be deleted" {
+  ${KORE} get cluster ${CLUSTER} -t ${TEAM} || skip
+
+  retry 120 "${KORE} get clusters ${CLUSTER} -t ${TEAM} 2>&1 | grep 'does not exist$'"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "We should able to delete the ${TEAM} aks credentials" {
+  runit "${KORE} delete -f ${BASE_DIR}/${E2E_DIR}/aks-credentials.yml -t kore-admin"
+  [[ "$status" -eq 0 ]]
+}
+

--- a/test/e2e/integration/aks.bats
+++ b/test/e2e/integration/aks.bats
@@ -16,16 +16,16 @@
 #
 load helper
 
-@test "Ensuring we have an allocation to build a cluster in GKE" {
-  runit "${KORE} get allocations -t ${TEAM} | grep ^gkecredentials-gke"
+@test "Ensuring we have an allocation to build a cluster in AKS" {
+  runit "${KORE} get allocations -t ${TEAM} | grep ^akscredentials-aks"
   [[ "$status" -eq 0 ]]
 }
 
-@test "We should be able to build a cluster ${CLUSTER} in GKE" {
+@test "We should be able to build a cluster ${CLUSTER} in AKS" {
   if runit "${KORE} get clusters ${CLUSTER} -t ${TEAM}"; then
     skip
   else
-    runit "${KORE} create cluster -p gke-development -a gkecredentials-gke ${CLUSTER} --show-time -t ${TEAM}"
+    runit "${KORE} create cluster -p aks-development -a akscredentials-aks ${CLUSTER} --show-time -t ${TEAM}"
     [[ "$status" -eq 0 ]]
   fi
 }
@@ -40,10 +40,10 @@ load helper
   [[ "$status" -eq 0 ]]
 }
 
-@test "We should be able to see the gkes cloud provider in the team" {
-  runit "${KORE} get gkes ${CLUSTER} -t ${TEAM}"
+@test "We should be able to see the aks cloud provider in the team" {
+  runit "${KORE} get aks ${CLUSTER} -t ${TEAM}"
   [[ "$status" -eq 0 ]]
-  runit "${KORE} get gkes ${CLUSTER} -t ${TEAM} | grep -i success"
+  runit "${KORE} get aks ${CLUSTER} -t ${TEAM} | grep -i success"
   [[ "$status" -eq 0 ]]
 }
 
@@ -76,11 +76,6 @@ load helper
 
 @test "You should be able to retrieve the nodes of the cluster" {
   runit "${KUBECTL} --context=${CLUSTER} get nodes"
-  [[ "$status" -eq 0 ]]
-}
-
-@test "We need to ensure the default psp has been created" {
-  runit "${KUBECTL} --context=${CLUSTER} get psp kore.default"
   [[ "$status" -eq 0 ]]
 }
 

--- a/test/e2e/integration/plan-policies.bats
+++ b/test/e2e/integration/plan-policies.bats
@@ -16,18 +16,22 @@
 #
 load helper
 
-@test "We should find polcies for eks and gke" {
+@test "We should find policies for all custer providers" {
   runit "${KORE} get planpolicies"
   [[ "$status" -eq 0 ]]
   runit "${KORE} get planpolicies gke-default"
   [[ "$status" -eq 0 ]]
   runit "${KORE} get planpolicies eks-default"
   [[ "$status" -eq 0 ]]
+  runit "${KORE} get planpolicies aks-default"
+  [[ "$status" -eq 0 ]]
 }
 
 @test "We should see the default policies are allocated to all teams" {
-  runit "${KORE} get allocations planpolicy-default-eks -t ${TEAM}"  
+  runit "${KORE} get allocations planpolicy-default-eks -t ${TEAM}"
   [[ "$status" -eq 0 ]]
-  runit "${KORE} get allocations planpolicy-default-gke -t ${TEAM}"  
+  runit "${KORE} get allocations planpolicy-default-gke -t ${TEAM}"
+  [[ "$status" -eq 0 ]]
+  runit "${KORE} get allocations planpolicy-default-aks -t ${TEAM}"
   [[ "$status" -eq 0 ]]
 }

--- a/test/e2e/plan-policies.bats
+++ b/test/e2e/plan-policies.bats
@@ -31,6 +31,11 @@ load helper
   [[ "$status" -eq 0 ]]
 }
 
+@test "We should have a plan policy for aks" {
+  runit "${KORE} get planpolicies default-aks"
+  [[ "$status" -eq 0 ]]
+}
+
 @test "We should be not able to create a cluster from a parameter not permitted" {
   runit "${KORE} create cluster ${CLUSTER} --plan-param '{\"enableIstio\": \"true\"}' -t ${TEAM}"
   [[ "$status" -eq 0 ]]

--- a/test/trigger-e2e.sh
+++ b/test/trigger-e2e.sh
@@ -20,6 +20,7 @@
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 ENABLE_GKE_E2E="false"
 ENABLE_EKS_E2E="false"
+ENABLE_AKS_E2E="false"
 
 usage() {
   cat <<EOF
@@ -27,6 +28,7 @@ usage() {
   --branch <name>   : the branch to run the e2e on (defaults: ${BRANCH})
   --enable-gke      : indicates we should run e2e on gke builds (defaults: ${ENABLE_GKE_E2E})
   --enable-eks      : indicates we should run e2e on eks (defaults: ${ENABLE_EKS_E2E})
+  --enable-aks      : indicates we should run e2e on aks (defaults: ${ENABLE_AKS_E2E})
   -h|--help         : display this usage menu
 EOF
   if [[ -n $@ ]]; then
@@ -41,6 +43,7 @@ while [[ $# -gt 0 ]]; do
   --branch)     BRANCH=${2};         shift 2; ;;
   --enable-gke) ENABLE_GKE_E2E=true; shift 1; ;;
   --enable-eks) ENABLE_EKS_E2E=true; shift 1; ;;
+  --enable-aks) ENABLE_AKS_E2E=true; shift 1; ;;
   -h|--help)    usage;                        ;;
   *)                                 shift 1; ;;
   esac
@@ -49,6 +52,7 @@ done
 echo "Attempting to trigger the E2E, branch: ${BRANCH}"
 echo "Enable GKE: ${ENABLE_GKE_E2E}"
 echo "Enable EKS: ${ENABLE_EKS_E2E}"
+echo "Enable AKS: ${ENABLE_AKS_E2E}"
 
 JOB=$(curl -s -u ${CIRCLECI_TOKEN}: -X POST \
   --header "Accept: application/json" \
@@ -57,7 +61,8 @@ JOB=$(curl -s -u ${CIRCLECI_TOKEN}: -X POST \
     \"parameters\": {
       \"enable_e2e\": true,
       \"enable_gke_e2e\": ${ENABLE_GKE_E2E},
-      \"enable_eks_e2e\": ${ENABLE_EKS_E2E}
+      \"enable_eks_e2e\": ${ENABLE_EKS_E2E},
+      \"enable_aks_e2e\": ${ENABLE_AKS_E2E}
     }
   }" \
   https://circleci.com/api/v2/project/github/appvia/kore/pipeline)


### PR DESCRIPTION
## Summary

This PR adds E2E tests for AKS.

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1083 

### Additional changes

 * A small amendment to the reconciler components, that objects are not required to have component statuses (see AKSCredentials as an example).
 * I forgot to add a controller for the AKS credentials, so I've added a no-op for now. There is an other issue for implementing the proper creds verification: https://github.com/appvia/kore/issues/1089

## Testing

```
CIRCLECI_TOKEN="..." test/trigger-e2e.sh --enable-aks true
```
## Follow-up stories

 * Verify credentials: https://github.com/appvia/kore/issues/1089