### PR TITLE
Kore CLI Profile Context Flag

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -87,33 +87,27 @@ func (c *Config) ListProfiles() []string {
 	return list
 }
 
-// GetCurrentProfile returns the current profile
-func (c *Config) GetCurrentProfile() *Profile {
-	profile, found := c.Profiles[c.CurrentProfile]
-	if !found {
+// GetProfile returns the profile
+func (c *Config) GetProfile(name string) *Profile {
+	if !c.HasProfile(name) {
 		return &Profile{}
 	}
 
-	return profile
+	return c.Profiles[name]
 }
 
-// GetCurrentServer returns the server in the context
-func (c *Config) GetCurrentServer() *Server {
-	ct := c.Profiles[c.CurrentProfile]
-	if ct == nil {
-		return &Server{}
-	}
-	s := c.Servers[ct.Server]
-	if s == nil {
+// GetServer returns the endpoint for the profile
+func (c *Config) GetServer(name string) *Server {
+	if !c.HasProfile(name) {
 		return &Server{}
 	}
 
-	return s
+	return c.Servers[c.Profiles[name].Server]
 }
 
-// GetCurrentAuthInfo returns the current auth
-func (c *Config) GetCurrentAuthInfo() *AuthInfo {
-	ct := c.Profiles[c.CurrentProfile]
+// GetAuthInfo returns the auth for a profile
+func (c *Config) GetAuthInfo(name string) *AuthInfo {
+	ct := c.Profiles[name]
 	if ct == nil {
 		return &AuthInfo{}
 	}
@@ -152,11 +146,11 @@ func (c *Config) AddAuthInfo(name string, auth *AuthInfo) {
 }
 
 // HasValidProfile checks we have a current context
-func (c *Config) HasValidProfile() error {
-	if c.CurrentProfile == "" {
+func (c *Config) HasValidProfile(name string) error {
+	if name == "" {
 		return errors.New("no profile selected")
 	}
-	if !c.HasServer(c.GetCurrentProfile().Server) {
+	if !c.HasServer(c.Profiles[name].Server) {
 		return errors.New("profile does not have a server endpoint")
 	}
 

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -28,7 +28,7 @@ import (
 const (
 	testConfig = `
 current-profile: local
-profiles: 
+profiles:
   local:
     server: local
     team: kore
@@ -77,9 +77,9 @@ func TestCurrentProfile(t *testing.T) {
 	assert.Equal(t, "local", c.CurrentProfile)
 }
 
-func TestGetCurrentProfile(t *testing.T) {
+func TestGetProfile(t *testing.T) {
 	c := newTestConfig(t)
-	profile := c.GetCurrentProfile()
+	profile := c.GetProfile("local")
 
 	require.NotNil(t, profile)
 	assert.Equal(t, "local", profile.Server)
@@ -89,7 +89,7 @@ func TestGetCurrentProfile(t *testing.T) {
 
 func TestGetCurrentServer(t *testing.T) {
 	c := newTestConfig(t)
-	current := c.GetCurrentServer()
+	current := c.GetServer("local")
 
 	require.NotNil(t, current)
 	assert.Equal(t, "http://127.0.0.1:10080", current.Endpoint)
@@ -97,7 +97,7 @@ func TestGetCurrentServer(t *testing.T) {
 
 func TestGetCurrentAuthInfo(t *testing.T) {
 	c := newTestConfig(t)
-	current := c.GetCurrentAuthInfo()
+	current := c.GetAuthInfo("local")
 
 	require.NotNil(t, current)
 	require.NotNil(t, current.OIDC)

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -36,6 +36,16 @@ func (f *fake) HTTPClient(*http.Client) client.Interface {
 	return f
 }
 
+// OverrideProfile does nothing here
+func (f *fake) OverrideProfile(string) client.Interface {
+	return f
+}
+
+// CurrentProfile returns the current profile
+func (f *fake) CurrentProfile() string {
+	return ""
+}
+
 // Body returns the body if any
 func (f *fake) Body() io.Reader {
 	b := &bytes.Buffer{}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -28,6 +28,10 @@ type Interface interface {
 	HTTPClient(*http.Client) Interface
 	// Request creates a request instance
 	Request() RestInterface
+	// CurrentProfile returns the current profile
+	CurrentProfile() string
+	// OverrideProfile allows you set the selected profile
+	OverrideProfile(string) Interface
 }
 
 // Plugin provides an interface for plugins

--- a/pkg/cmd/kore/kore.go
+++ b/pkg/cmd/kore/kore.go
@@ -86,7 +86,7 @@ func NewKoreCommand(streams cmdutil.Streams) (*cobra.Command, error) {
 				profile = cmdutil.GetFlagString(root, "profile")
 				// we only need to set the flag if the --team has not been set
 				if !cmd.Flags().Changed("team") {
-					cmd.Flags().Set("team", cfg.GetProfile(profile).Team)
+					_ = cmd.Flags().Set("team", cfg.GetProfile(profile).Team)
 				}
 				client.OverrideProfile(profile)
 			}

--- a/pkg/cmd/kore/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kore/kubeconfig/kubeconfig.go
@@ -115,7 +115,7 @@ func (o *KubeConfigOptions) WriteConfig(clusters *clustersv1.ClusterList, path s
 		return err
 	}
 
-	auth := o.Config().GetCurrentAuthInfo()
+	auth := o.Config().GetAuthInfo(o.Client().CurrentProfile())
 	if auth.OIDC == nil {
 		return errors.New("you must be using a context backed by an idp")
 	}

--- a/pkg/cmd/kore/profiles/list.go
+++ b/pkg/cmd/kore/profiles/list.go
@@ -17,6 +17,8 @@
 package profiles
 
 import (
+	"sort"
+
 	cmdutil "github.com/appvia/kore/pkg/cmd/utils"
 	"github.com/appvia/kore/pkg/utils/render"
 
@@ -53,12 +55,17 @@ func (o *ListOptions) Run() error {
 	}
 	var list []profile
 
-	for k, v := range o.Config().Profiles {
-		if o.Config().HasServer(v.Server) {
+	// @step: we should order the list as they come from a map
+	profiles := o.Config().ListProfiles()
+	sort.Strings(profiles)
+
+	for _, x := range profiles {
+		p := o.Config().GetProfile(x)
+		if o.Config().HasServer(p.Server) {
 			list = append(list, profile{
-				Name:   k,
-				Server: o.Config().Servers[v.Server].Endpoint,
-				Team:   v.Team,
+				Name:   x,
+				Server: o.Config().GetServer(p.Server).Endpoint,
+				Team:   p.Team,
 			})
 		}
 	}

--- a/pkg/cmd/kore/profiles/show.go
+++ b/pkg/cmd/kore/profiles/show.go
@@ -62,7 +62,7 @@ func (o ShowOptions) Run() error {
 	}
 
 	o.Println("Profile:  %s", name)
-	o.Println("Endpoint: %s", config.GetCurrentServer().Endpoint)
+	o.Println("Endpoint: %s", config.GetServer(o.Config().CurrentProfile).Endpoint)
 
 	return nil
 }

--- a/pkg/cmd/utils/factory.go
+++ b/pkg/cmd/utils/factory.go
@@ -55,7 +55,7 @@ func NewFactory(client client.Interface, streams Streams, config *config.Config)
 }
 
 func (f *factory) refreshToken() {
-	auth := f.cfg.GetCurrentAuthInfo()
+	auth := f.cfg.GetAuthInfo(f.client.CurrentProfile())
 	if auth.OIDC != nil {
 		// @step: has the access token expired
 		token, err := utils.NewClaimsFromRawToken(auth.OIDC.IDToken)
@@ -81,6 +81,11 @@ func (f *factory) refreshToken() {
 			}
 		}
 	}
+}
+
+// Client returns the underlying client
+func (f *factory) Client() client.Interface {
+	return f.client
 }
 
 // ClientWithEndpoint returns the api client with a specific endpoint

--- a/pkg/cmd/utils/types.go
+++ b/pkg/cmd/utils/types.go
@@ -60,6 +60,8 @@ type Streams struct {
 type Factory interface {
 	// CheckError handles the cli errors for us
 	CheckError(error)
+	// Client returns the underlying client
+	Client() client.Interface
 	// ClientWithEndpoint returns the api client with a specific endpoint
 	ClientWithEndpoint(endpoint string) client.RestInterface
 	// ClientWithResource returns the api client with a specific resource


### PR DESCRIPTION
## Summary

Adding the ability to explicitly set the profile on the current line.

**Which issue(s) this PR resolves**: 

Resolves #1095 

## Checklist

 - [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): NA

## Changes

Nothing major has changed, we've simply added the ability in the client to override the current profile 

### Additional changes

NA

## Screenshots

NA

## Examples

`kore --profile kore-qa get teams`
`kore --profile kore-demo login`

You should never switch to the `--profile <name>` profile - just use it for those requests

## Testing

See above

## Follow-up stories

NA
