### PR TITLE
Correct enum for clusteruser roles

### DIFF
--- a/ui/lib/components/plans/custom/PlanOptionClusterUsers.js
+++ b/ui/lib/components/plans/custom/PlanOptionClusterUsers.js
@@ -111,7 +111,7 @@ export default class PlanOptionClusterUsers extends PlanOptionBase {
   render() {
     const { name, editable, property } = this.props
     const { displayName, valueOrDefault, help } = this.prepCommonProps(this.props, [])
-    const roles = property.enum
+    const roles = property.items.properties.roles.items.enum
     const columns = [
       { title: 'User', dataIndex: 'username', key: 'username', width: '45%' },
       { title: 'Roles', dataIndex: 'roles', key: 'tags', width: '45%', render: function renderRoles(userRoles, r) { 


### PR DESCRIPTION
## Summary

Incorrect property being used to determine enum of roles when editing cluster users.

**Which issue(s) this PR resolves**:
Resolves #1101 

## Testing
The following testing **has been performed**:
* Edit an existing cluster with no cluster users specified:
  * Adding user with role works correctly.
* Edit an existing cluster with cluster users specified:
  * Web page doesn't explode.
  * Adding/editing users and roles works correctly.
