### PR TITLE
Account automation bugfix

### DIFF
--- a/ui/__tests__/unit/lib/components/plans/ManageClusterPlanForm.test.js
+++ b/ui/__tests__/unit/lib/components/plans/ManageClusterPlanForm.test.js
@@ -20,6 +20,7 @@ describe('ManageClusterPlanForm', () => {
     apiScope = (ApiTestHelpers.getScope())
       .get(`${ApiTestHelpers.basePath}/planschemas/GKE`).reply(200, schema)
       .get(`${ApiTestHelpers.basePath}/accountmanagements`).reply(200, { items: [] })
+      .get(`${ApiTestHelpers.basePath}/plans?kind=GKE`).reply(200, { items: [] })
 
     props = {
       form: {

--- a/ui/lib/components/plans/ManageClusterPlanForm.js
+++ b/ui/lib/components/plans/ManageClusterPlanForm.js
@@ -61,7 +61,7 @@ class ManageClusterPlanForm extends ManagePlanForm {
               currentRule.plans = currentRule.plans.filter(p => p !== values.name)
             }
             await api.UpdateAccount(accountMgtResource.metadata.name, accountMgtResource)
-            planResult.append = { automatedCloudAccount: addedToRule }
+            planResult.amend = { automatedCloudAccount: addedToRule }
           } else {
             console.error(`Error occurred setting automated ${this.cloudInfo.accountNoun}, could not find rule with name`, values.automatedCloudAccount)
           }
@@ -70,7 +70,7 @@ class ManageClusterPlanForm extends ManagePlanForm {
           if (currentRule) {
             currentRule.plans = currentRule.plans.filter(p => p !== values.name)
             await api.UpdateAccount(accountMgtResource.metadata.name, accountMgtResource)
-            planResult.append = { automatedCloudAccount: false }
+            planResult.amend = { automatedCloudAccount: false }
           }
         }
       }

--- a/ui/lib/components/resources/ResourceList.js
+++ b/ui/lib/components/resources/ResourceList.js
@@ -71,7 +71,7 @@ class ResourceList extends React.Component {
                 status: {
                   ...resource.status, status: 'Pending'
                 },
-                ...updated.append
+                ...updated.amend
               }
             }
             return resource
@@ -83,15 +83,17 @@ class ResourceList extends React.Component {
   }
 
   handleAddSave = async (created) => {
-    const newItems = this.state.resources.items.concat([ created ])
-    this.setState({
-      add: false,
-      resources: {
-        items: newItems
+    this.setState(state => {
+      return {
+        add: false,
+        resources: {
+          items: [ ...state.resources.items, { ...created, ...created.amend } ]
+        }
       }
+    }, () => {
+      this.props.getResourceItemList && this.props.getResourceItemList(this.state.resources.items)
+      successMessage(this.createdMessage)
     })
-    this.props.getResourceItemList && this.props.getResourceItemList(newItems)
-    successMessage(this.createdMessage)
   }
 }
 

--- a/ui/lib/components/setup/CloudAccountAutomationSettings.js
+++ b/ui/lib/components/setup/CloudAccountAutomationSettings.js
@@ -18,6 +18,7 @@ import asyncForEach from '../../utils/async-foreach'
 import { errorMessage, successMessage } from '../../utils/message'
 import KoreTeamCloudIntegration from './radio-groups/KoreTeamCloudIntegration'
 import CloudAccountAutomationType from './radio-groups/CloudAccountAutomationType'
+import { filterCloudAccountList } from '../../utils/cloud'
 
 class CloudAccountAutomationSettings extends React.Component {
   static propTypes = {
@@ -124,13 +125,7 @@ class CloudAccountAutomationSettings extends React.Component {
       // each cloud org will use the same settings
       await asyncForEach(this.state.cloudOrgList, async (cloudOrg) => {
         let cloudAccountList = this.state.cloudAccountAutomationType === 'CUSTOM' ? copy(this.state.cloudAccountList) : false
-        cloudAccountList = cloudAccountList
-          // remove rules with no plans associated
-          .filter(cloudAccount => cloudAccount.plans.length > 0)
-          // remove non-existent plans from rules
-          .map(cloudAccount => {
-            return { ...cloudAccount, plans: cloudAccount.plans.filter(p => this.state.plans.map(p => p.metadata.name).includes(p)) }
-          })
+        cloudAccountList = filterCloudAccountList(cloudAccountList, this.state.plans)
         const resourceVersion = this.state.accountManagement && this.state.accountManagement.metadata.resourceVersion
         const resourceName = `am-${this.props.cloud.toLowerCase()}`
         const accountMgtResource = KoreApi.resources().generateAccountManagementResource(resourceName, this.props.provider, cloudOrg, cloudAccountList, resourceVersion)

--- a/ui/lib/utils/cloud.js
+++ b/ui/lib/utils/cloud.js
@@ -4,3 +4,18 @@ const { publicRuntimeConfig } = getConfig()
 export function getProviderCloudInfo(planKind) {
   return publicRuntimeConfig.clusterProviderCloudMap[planKind]
 }
+
+/**
+ * Remove redundant rules and rule plans from the automated cloud account list
+ * @param cloudAccountList the list of automated account rules for a provider eg GKE
+ * @param plans Plans specific to the provider eg GKE
+ */
+export function filterCloudAccountList(cloudAccountList, plans) {
+  return cloudAccountList
+    // remove rules with no plans associated
+    .filter(cloudAccount => cloudAccount.plans.length > 0)
+    // remove non-existent plans from rules
+    .map(cloudAccount => {
+      return { ...cloudAccount, plans: cloudAccount.plans.filter(p => plans.map(p => p.metadata.name).includes(p)) }
+    })
+}


### PR DESCRIPTION
## Summary

Fixing bug when associating a new plan with account automation
Fixing issue when saving account management from plan form

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1071 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~

## Changes

Fixing bug when associating a new plan with account automation
* this was just a display issue
* when a new plan is saved, ensure the appended `automatedCloudAccount` rule is persisted in the state of the `PlanList` component

Fixing issue when saving account management from plan form
* this is related to the issue fixed by #1086, but happens when saving from the plan form
* the fix is to filter down the rules in the `AccountManagement` when loading the plan
* if the plan is saved the correctly filtered rules for the `AccountManagement` will also be saved

## Testing

* create a plan with an association to an automated account
* after creation you should not see the warning about the plan not being associated with any automated accounts
* add multiple custom plans to an automated account, eg notprod, delete one of the plans, then try to edit and save a different plan associated with the same automated account

