### PR TITLE
Cluster plan versions from the metadata service

### DIFF
--- a/ui/__tests__/e2e/page-objects/configure/cloud/AWS/cluster-plans.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/AWS/cluster-plans.js
@@ -9,7 +9,7 @@ export class ConfigureCloudAWSClusterPlans extends ConfigureCloudClusterPlansBas
 
   async openTab() {
     await this.selectCloud('aws')
-    await this.selectSubTab('Cluster Plans', 'AWS/plans')
+    await this.selectSubTab('Cluster plans', 'AWS/plans')
   }
 
   async populatePlan({ description, name, planDescription, region, version }) {
@@ -18,6 +18,8 @@ export class ConfigureCloudAWSClusterPlans extends ConfigureCloudClusterPlansBas
     await clearFillTextInput(this.p, 'plan_description', name)
     await clearFillTextInput(this.p, 'plan_input_description', planDescription)
     await setCascader(this.p, 'plan_input_region', region)
+    // wait for version control to be enabled after selecting the region
+    await this.p.waitForSelector('#plan_input_version.ant-select-disabled', { hidden: true })
     await clearFillTextInput(this.p, 'plan_input_version', version)
   }
 

--- a/ui/__tests__/e2e/page-objects/configure/cloud/AWS/cluster-policies.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/AWS/cluster-policies.js
@@ -8,6 +8,6 @@ export class ConfigureCloudAWSClusterPolicies extends ConfigureCloudClusterPolic
 
   async openTab() {
     await this.selectCloud('aws')
-    await this.selectSubTab('Cluster Policies', 'AWS/policies')
+    await this.selectSubTab('Cluster policies', 'AWS/policies')
   }
 }

--- a/ui/__tests__/e2e/page-objects/configure/cloud/Azure/cluster-plans.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/Azure/cluster-plans.js
@@ -9,7 +9,7 @@ export class ConfigureCloudAzureClusterPlans extends ConfigureCloudClusterPlansB
 
   async openTab() {
     await this.selectCloud('azure')
-    await this.selectSubTab('Cluster Plans', 'Azure/plans')
+    await this.selectSubTab('Cluster plans', 'Azure/plans')
   }
 
   async populatePlan({ description, name, planDescription, region, version, dnsPrefix, networkPlugin }) {
@@ -18,6 +18,8 @@ export class ConfigureCloudAzureClusterPlans extends ConfigureCloudClusterPlansB
     await clearFillTextInput(this.p, 'plan_description', name)
     await clearFillTextInput(this.p, 'plan_input_description', planDescription)
     await clearFillTextInput(this.p, 'plan_input_region', region)
+    // wait for version control to be enabled after selecting the region
+    await this.p.waitForSelector('#plan_input_version.ant-select-disabled', { hidden: true })
     await clearFillTextInput(this.p, 'plan_input_version', version)
     await clearFillTextInput(this.p, 'plan_input_dnsPrefix', dnsPrefix)
     await setSelect(this.p, 'plan_input_networkPlugin', networkPlugin)

--- a/ui/__tests__/e2e/page-objects/configure/cloud/Azure/cluster-policies.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/Azure/cluster-policies.js
@@ -8,6 +8,6 @@ export class ConfigureCloudAzureClusterPolicies extends ConfigureCloudClusterPol
 
   async openTab() {
     await this.selectCloud('azure')
-    await this.selectSubTab('Cluster Policies', 'Azure/policies')
+    await this.selectSubTab('Cluster policies', 'Azure/policies')
   }
 }

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-plans.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-plans.js
@@ -9,7 +9,7 @@ export class ConfigureCloudGCPClusterPlans extends ConfigureCloudClusterPlansBas
 
   async openTab() {
     await this.selectCloud('gcp')
-    await this.selectSubTab('Cluster Plans', 'GCP/plans')
+    await this.selectSubTab('Cluster plans', 'GCP/plans')
   }
 
   async populatePlan({ description, name, planDescription, region }) {

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-policies.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/cluster-policies.js
@@ -8,6 +8,6 @@ export class ConfigureCloudGCPClusterPolicies extends ConfigureCloudClusterPolic
 
   async openTab() {
     await this.selectCloud('gcp')
-    await this.selectSubTab('Cluster Policies', 'GCP/policies')
+    await this.selectSubTab('Cluster policies', 'GCP/policies')
   }
 }

--- a/ui/lib/components/plans/PlanList.js
+++ b/ui/lib/components/plans/PlanList.js
@@ -22,7 +22,8 @@ class PlanList extends ResourceList {
 
   infoDescription = {
     GKE: 'These plans define the specification of the clusters that can be created using the Google Kubernetes Engine (GKE) on GCP. These help to give teams an easy way to provision clusters which match the requirements of the organization.',
-    EKS: 'These plans define the specification of the clusters that can be created using the Elastic Kubernetes Service (EKS) on AWS. These help to give teams an easy way to provision clusters which match the requirements of the organization.'
+    EKS: 'These plans define the specification of the clusters that can be created using the Elastic Kubernetes Service (EKS) on AWS. These help to give teams an easy way to provision clusters which match the requirements of the organization.',
+    AKS: 'These plans define the specification of the clusters that can be created using the Azure Kubernetes Service (AKS) on Microsoft Azure. These help to give teams an easy way to provision clusters which match the requirements of the organization.'
   }
 
   async fetchComponentData() {

--- a/ui/lib/components/plans/custom/PlanOptionGKEVersion.js
+++ b/ui/lib/components/plans/custom/PlanOptionGKEVersion.js
@@ -1,16 +1,16 @@
 import * as React from 'react'
-import { Form, Typography, Input } from 'antd'
+import { Typography } from 'antd'
 const { Paragraph } = Typography
 
-import PlanOptionBase from '../PlanOptionBase'
+import PlanOptionVersion from './PlanOptionVersion'
 
-export default class PlanOptionGKEVersion extends PlanOptionBase {
+export default class PlanOptionGKEVersion extends PlanOptionVersion {
+
   render() {
-    const { name, editable, property, plan } = this.props
-    const { onChange, displayName, valueOrDefault, id } = this.prepCommonProps(this.props)
+    const releaseChannel = this.props.plan.releaseChannel
 
     // Drop the version control all together if release channel set.
-    if (plan.releaseChannel && plan.releaseChannel !== '') {
+    if (releaseChannel && releaseChannel !== '') {
       return null
     }
 
@@ -23,11 +23,6 @@ export default class PlanOptionGKEVersion extends PlanOptionBase {
       </>
     )
 
-    return (
-      <Form.Item label={displayName} help={help}>
-        <Input id={id} value={valueOrDefault} readOnly={!editable} pattern={property.pattern} onChange={(e) => onChange(name, e.target.value)} />
-        {this.validationErrors(name)}
-      </Form.Item>
-    )
+    return this.renderControl({ help })
   }
 }

--- a/ui/lib/components/plans/custom/PlanOptionVersion.js
+++ b/ui/lib/components/plans/custom/PlanOptionVersion.js
@@ -1,0 +1,100 @@
+import * as React from 'react'
+import PropTypes from 'prop-types'
+import { Form, Icon } from 'antd'
+import { uniq } from 'lodash'
+
+import PlanOptionBase from '../PlanOptionBase'
+import ConstrainedDropdown from './ConstrainedDropdown'
+import PlanOption from '../PlanOption'
+import KoreApi from '../../../kore-api'
+
+export default class PlanOptionVersion extends PlanOptionBase {
+  static propTypes = {
+    expandVersions: PropTypes.bool
+  }
+
+  state = {
+    loadingVersions: true,
+    versions: null
+  }
+
+  fetchVersions = async () => {
+    this.setState({ loadingVersions: true })
+    const provider = this.props.kind
+    const region = this.props.plan.region
+    if (!region) {
+      return this.setState({ loadingVersions: false, versions: null })
+    }
+    try {
+      let versions = await (await KoreApi.client()).metadata.GetKubernetesVersions(provider, region)
+      if (this.props.expandVersions) {
+        versions = this.expandVersions(versions)
+      }
+      this.setState({ loadingVersions: false, versions })
+    } catch (err) {
+      console.warn('Error loading versions - will use plain text entry instead', err)
+      this.setState({ loadingVersions: false, versions: null })
+    }
+  }
+
+  componentDidMountComplete = null
+  componentDidMount = () => {
+    this.componentDidMountComplete = Promise.resolve().then(async() => await this.fetchVersions())
+  }
+
+  componentDidUpdateComplete = null
+  componentDidUpdate = (prevProps) => {
+    // refresh the list of versions when the region is changed
+    if (prevProps.plan.region !== this.props.plan.region) {
+      this.componentDidUpdateComplete = Promise.resolve().then(async() => await this.fetchVersions())
+    }
+  }
+
+  expandVersions = (versions) => {
+    const minorVersions = []
+    versions.forEach(v => {
+      const versionParts = v.split('.')
+      // eg 1.16.10, add 1.16 as an available version
+      if (versionParts.length === 3) {
+        minorVersions.push(v.split('.').filter((e, i) => i <= 1).join('.'))
+      }
+      // eg 1.16.10-gke.1, add 1.16 and 1.16.10 as available versions
+      if (versionParts.length > 3) {
+        minorVersions.push(v.split('.').filter((e, i) => i <= 1).join('.'))
+        minorVersions.push(v.split('.').filter((e, i) => i <= 2).join('.').replace(/[^0-9.]+/g, ''))
+      }
+    })
+    console.log('expanding versions', minorVersions)
+    return uniq([ ...minorVersions, ...versions ]).sort()
+  }
+
+  renderControl = (overrides) => {
+    overrides = overrides || {}
+    const { name, editable, plan } = this.props
+    const { onChange, displayName, valueOrDefault, id, help } = this.prepCommonProps(this.props)
+    const { versions, loadingVersions } = this.state
+
+    const readOnly = !editable || !plan.region
+    const value = plan.region ? valueOrDefault : 'Choose region first'
+
+    return (
+      <Form.Item label={displayName} help={overrides.help || help}>
+        {loadingVersions ? <Icon type="loading" /> : null}
+        {!loadingVersions ? <ConstrainedDropdown id={id} readOnly={readOnly} allowedValues={versions || []} value={value} onChange={(v) => onChange(name, v)} /> : null}
+        {this.validationErrors(name)}
+      </Form.Item>
+    )
+  }
+
+  render() {
+    const region = this.props.plan.region
+    const versions = this.state.versions
+
+    // If we have selected a region and have no versions from the metadata service, just use the default text control
+    if (!versions && region) {
+      return <PlanOption {...this.props} disableCustom={true} />
+    }
+
+    return this.renderControl()
+  }
+}

--- a/ui/lib/components/plans/custom/index.js
+++ b/ui/lib/components/plans/custom/index.js
@@ -5,6 +5,7 @@ import PlanOptionGKEReleaseChannel from './PlanOptionGKEReleaseChannel'
 import PlanOptionGKEVersion from './PlanOptionGKEVersion'
 import PlanOptionClusterRegion from './PlanOptionClusterRegion'
 import PlanOptionAKSNodePools from './PlanOptionAKSNodePools'
+import PlanOptionVersion from './PlanOptionVersion'
 
 export default class CustomPlanOptionRegistry {
   static controls = {
@@ -20,7 +21,7 @@ export default class CustomPlanOptionRegistry {
           return <PlanOptionGKEReleaseChannel {...props} />
         },
         'version': function version(props) {
-          return <PlanOptionGKEVersion {...props} />
+          return <PlanOptionGKEVersion {...props} expandVersions={true} />
         },
         'region': function region(props) {
           return <PlanOptionClusterRegion {...props} />
@@ -35,6 +36,9 @@ export default class CustomPlanOptionRegistry {
         },
         'region': function region(props) {
           return <PlanOptionClusterRegion {...props} />
+        },
+        'version': function version(props) {
+          return <PlanOptionVersion {...props} expandVersions={true} />
         }
       },
       'AKS': {
@@ -43,6 +47,9 @@ export default class CustomPlanOptionRegistry {
         },
         'region': function region(props) {
           return <PlanOptionClusterRegion {...props} />
+        },
+        'version': function version(props) {
+          return <PlanOptionVersion {...props} />
         }
       }
     }

--- a/ui/pages/configure/cloud/[...cloud].js
+++ b/ui/pages/configure/cloud/[...cloud].js
@@ -78,10 +78,10 @@ export default class ConfigureCloudPage extends React.Component {
               <Tabs.TabPane tab="Project automation" key="project_automation">
                 <CloudAccountAutomationSettings provider="GKE" cloudOrgsApiMethod="ListGCPOrganizations" cloud="GCP" accountNoun="project" />
               </Tabs.TabPane>
-              <Tabs.TabPane tab="Cluster Plans" key="plans">
+              <Tabs.TabPane tab="Cluster plans" key="plans">
                 <PlanList kind="GKE" />
               </Tabs.TabPane>
-              <Tabs.TabPane tab="Cluster Policies" key="policies">
+              <Tabs.TabPane tab="Cluster policies" key="policies">
                 <PolicyList kind="GKE"/>
               </Tabs.TabPane>
             </Tabs>
@@ -97,14 +97,14 @@ export default class ConfigureCloudPage extends React.Component {
               <Tabs.TabPane tab="Account automation" key="account-automation">
                 <CloudAccountAutomationSettings provider="EKS" cloudOrgsApiMethod="ListAWSOrganizations" cloud="AWS" accountNoun="account" />
               </Tabs.TabPane>
-              <Tabs.TabPane tab="Cluster Plans" key="plans">
+              <Tabs.TabPane tab="Cluster plans" key="plans">
                 <PlanList kind="EKS" />
               </Tabs.TabPane>
-              <Tabs.TabPane tab="Cluster Policies" key="policies">
+              <Tabs.TabPane tab="Cluster policies" key="policies">
                 <PolicyList kind="EKS" />
               </Tabs.TabPane>
               {!featureEnabled(KoreFeatures.SERVICES) ? null :
-                <Tabs.TabPane tab="Cloud Services" key="services">
+                <Tabs.TabPane tab="Cloud services" key="services">
                   <CloudServiceAdmin cloud="AWS" />
                 </Tabs.TabPane>
               }
@@ -115,10 +115,10 @@ export default class ConfigureCloudPage extends React.Component {
               <Tabs.TabPane tab="Subscription credentials" key="subscriptions">
                 <CredentialsList provider="AKS" />
               </Tabs.TabPane>
-              <Tabs.TabPane tab="Cluster Plans" key="plans">
+              <Tabs.TabPane tab="Cluster plans" key="plans">
                 <PlanList kind="AKS" />
               </Tabs.TabPane>
-              <Tabs.TabPane tab="Cluster Policies" key="policies">
+              <Tabs.TabPane tab="Cluster policies" key="policies">
                 <PolicyList kind="AKS" />
               </Tabs.TabPane>
             </Tabs>


### PR DESCRIPTION
## Summary

Use metadata service to constrain Kubernetes versions on the UI

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1049

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~

## Changes

* once a region is chosen, pull the available kubernetes versions from the metadata services
* expand the list of versions for GKE and EKS to include minor and patch versions, where appropriate
* maintain current functionality for GKE version, ie. only show if no release channel is selected

### Additional changes

* lower case second words in cloud configure vertical tabs, for consistency
* adding alert description for AKS on plan list

## Screenshots

**Choose region first**

<img width="828" alt="Screen Shot 2020-07-22 at 10 25 33" src="https://user-images.githubusercontent.com/1334068/88161502-f6763200-cc07-11ea-8aaa-88f497ef6281.png">

**Expanded versions**

<img width="833" alt="Screen Shot 2020-07-22 at 10 20 44" src="https://user-images.githubusercontent.com/1334068/88161508-f8d88c00-cc07-11ea-8c4a-71b2dff148ac.png">

## Examples

Please provide some CLI and/or manifest examples if relevant. This will help understand the changes and/or how to use new features.

## Testing

* be able to create cluster plans using the constrained kubernetes versions.
* must choose the region first

## Follow-up stories
