### PR TITLE
Increase the no_output_timeout to 60 minutes for the E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,8 +487,8 @@ jobs:
               --enable-ui false \
               --version ${CIRCLE_SHA1}
       - run:
-          name: Running EKS E2E Suite
-          no_output_timeout: 30m
+          name: Running AKS E2E Suite
+          no_output_timeout: 60m
           command: |
             rm -f ${HOME}/.kore/config
             test/e2e/check-suite.sh \


### PR DESCRIPTION
## Summary

The AKS cluster deletion can take more than 30 minutes, so we need to increase the timeout.
