### PR TITLE
Remove un-required dependencies & run UI E2E directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,27 +279,27 @@ jobs:
             make build
             npm start
       - run:
+          name: Install Headless Chrome dependencies
+          command: ./ui/scripts/install-e2e-deps.sh
+      - run:
           name: Waiting for UI & API
           command: |
-            echo "Waiting to API"
+            echo "`date +"%T"`: Waiting for API"
             timeout 600 bash -c 'until curl http://127.0.0.1:10080/healthz >/dev/null 2>&1; do sleep 5; done'
-            echo "Waiting to UI"
-            timeout 300 bash -c 'until curl http://127.0.0.1:3000 >/dev/null 2>&1; do sleep 5; done'
+            echo "`date +"%T"`: Waiting for UI"
+            timeout 600 bash -c 'until curl http://127.0.0.1:3000 >/dev/null 2>&1; do sleep 5; done'
+            echo "`date +"%T"`: API and UI ready"
       - save_cache:
           paths:
             - ui/node_modules
           key: ui-node-v1-{{ checksum "ui/package-lock.json" }}
       - run:
           name: End-to-end testing UI
+          working_directory: ~/project/ui
           environment:
             NODE_ENV: development
           command: |
-            docker run -ti --rm --net=host \
-              -e NODE_ENV=${NODE_ENV} \
-              -v ${PWD}:/workspace \
-              -w /workspace/ui \
-              circleci/node:12 \
-              bash -c "./scripts/install-e2e-deps.sh; make test-e2e"
+            make test-e2e
 
   release-ui:
     environment:
@@ -574,57 +574,42 @@ workflows:
           filters:
             tags:
               only: /^v.*$/
-          requires:
-            - build-api
-            - check-ui
       - check-linting:
           filters:
             tags:
               only: /^v.*$/
-          requires:
-            - build-api
-            - check-ui
       - check-api-deepcopies:
           filters:
             tags:
               only: /^v.*$/
-          requires:
-            - build-api
-            - check-ui
       - check-api-register:
           filters:
             tags:
               only: /^v.*$/
-          requires:
-            - build-api
-            - check-ui
       - check-api-crds:
           filters:
             tags:
               only: /^v.*$/
-          requires:
-            - build-api
-            - check-ui
       - validate-ui:
           filters:
             tags:
               only: /^v.*$/
           requires:
             - build-api
-            - check-ui
       - validate-api:
           filters:
             tags:
               only: /^v.*$/
           requires:
+            - build-api
+      - release:
+          requires:
+            - validate-api
             - check-api-crds
             - check-api-deepcopies
             - check-api-register
             - check-linting
             - check-units
-      - release:
-          requires:
-            - validate-api
           filters:
             branches:
               only: master
@@ -638,6 +623,7 @@ workflows:
               only: /^v.*$/
           requires:
             - validate-ui
+            - check-ui
       - check-release-notes:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,11 @@ jobs:
               --build-proxy false \
               --version ${CIRCLE_SHA1}
       - run:
+          name: API server logs
+          background: true
+          command: |
+            make kind-apiserver-logs
+      - run:
           name: Checking Swagger
           command: |
             sudo apt-get install jq
@@ -258,6 +263,11 @@ jobs:
               --build-proxy false \
               --enable-ui false \
               --version ${CIRCLE_SHA1}
+      - run:
+          name: API server logs
+          background: true
+          command: |
+            make kind-apiserver-logs
       - run:
           name: Running Redis Service
           background: true

--- a/ui/scripts/install-e2e-deps.sh
+++ b/ui/scripts/install-e2e-deps.sh
@@ -4,7 +4,7 @@
 # See list of packages here: 
 # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
 
-sudo apt-get update && sudo apt-get install -yq \
+sudo apt-get update && sudo apt-get install --no-upgrade -yq \
               jq gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
               libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
               libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \


### PR DESCRIPTION
Remove un-required dependencies and run UI E2E directly instead of inside Docker to speed up the build.

## Changes

* Removes dependencies from all steps other than those which require them.
* Run the UI E2E directly instead of inside docker.