### PR TITLE
Fixup: handle nil tags from AWS API

### DIFF
--- a/pkg/utils/cloud/aws/eks.go
+++ b/pkg/utils/cloud/aws/eks.go
@@ -210,7 +210,7 @@ func (c *Client) Update(ctx context.Context) (bool, error) {
 		ResourceArn: state.Arn,
 	}
 	for k, v := range c.cluster.Spec.Tags {
-		if *state.Tags[k] != v {
+		if state.Tags == nil || *state.Tags[k] != v {
 			tagsUpdate.Tags[k] = aws.String(v)
 		}
 	}


### PR DESCRIPTION
## Summary

On QA, the AWS api returns nil for the tags where no tags exist on the cluster. Handle this.