### PR TITLE
Fixup: Handle nil tags from AWS API (fix 2)

### DIFF
--- a/pkg/utils/cloud/aws/eks.go
+++ b/pkg/utils/cloud/aws/eks.go
@@ -210,7 +210,7 @@ func (c *Client) Update(ctx context.Context) (bool, error) {
 		ResourceArn: state.Arn,
 	}
 	for k, v := range c.cluster.Spec.Tags {
-		if state.Tags == nil || *state.Tags[k] != v {
+		if state.Tags == nil || state.Tags[k] == nil || *state.Tags[k] != v {
 			tagsUpdate.Tags[k] = aws.String(v)
 		}
 	}


### PR DESCRIPTION
## Summary

Second fix for nil pointers in the map of tags coming back from AWS... should address the panics in the QA env.