### PR TITLE
Increase the retry count for AKS deletion check in E2E

### DIFF
--- a/test/e2e/integration/aks-deletion.bats
+++ b/test/e2e/integration/aks-deletion.bats
@@ -45,7 +45,7 @@ setup() {
 @test "We should see the aks resource be deleted" {
   ${KORE} get cluster ${CLUSTER} -t ${TEAM} || skip
 
-  retry 360 "${KORE} get aks ${CLUSTER} -t ${TEAM} 2>&1 | grep 'not found$'"
+  retry 720 "${KORE} get aks ${CLUSTER} -t ${TEAM} 2>&1 | grep 'not found$'"
   [[ "$status" -eq 0 ]]
 }
 


### PR DESCRIPTION
It seems 30 minutes is not always enough for an AKS cluster to be deleted.