### PR TITLE
Fixup: Ensure identifier persisted for team

### DIFF
--- a/pkg/persistence/teams.go
+++ b/pkg/persistence/teams.go
@@ -151,6 +151,7 @@ func (t teamImpl) Update(ctx context.Context, team *model.Team) error {
 			Name:        team.Name,
 			Description: team.Description,
 			Summary:     team.Summary,
+			Identifier:  team.Identifier,
 		}).
 		FirstOrCreate(team).
 		Error


### PR DESCRIPTION
## Summary

The identifier for unidentified existing teams wasn't being persisted.

## Testing
Completed:
* Checked in a new kore instance that teams are correctly having identifiers assigned where they previously existed without them.