### PR TITLE
Restricting AWS account automation to custom only

### DIFF
--- a/ui/lib/components/setup/CloudAccountAutomationSettings.js
+++ b/ui/lib/components/setup/CloudAccountAutomationSettings.js
@@ -25,7 +25,8 @@ class CloudAccountAutomationSettings extends React.Component {
     provider: PropTypes.oneOf(['GKE', 'EKS']).isRequired,
     cloudOrgsApiMethod: PropTypes.string.isRequired,
     cloud: PropTypes.oneOf(['GCP', 'AWS']).isRequired,
-    accountNoun: PropTypes.string.isRequired
+    accountNoun: PropTypes.string.isRequired,
+    cloudAccountAutomationType: PropTypes.oneOf(['CLUSTER', 'CUSTOM'])
   }
 
   state = {
@@ -50,7 +51,7 @@ class CloudAccountAutomationSettings extends React.Component {
     const accountManagement = accountManagementList.items.find(a => a.spec.provider === this.props.provider)
     const cloudManagementType = accountManagement ? 'KORE' : 'EXISTING'
 
-    let cloudAccountAutomationType = false
+    let cloudAccountAutomationType = this.props.cloudAccountAutomationType || false
     let cloudAccountList = []
 
     if (accountManagement) {
@@ -217,6 +218,7 @@ class CloudAccountAutomationSettings extends React.Component {
         value={this.state.cloudAccountAutomationType}
         onChange={this.selectCloudAccountAutomationType}
         inlineHelp={true}
+        valuesFilter={this.props.cloudAccountAutomationType ? [this.props.cloudAccountAutomationType] : undefined}
       />
 
       {this.state.cloudAccountAutomationType === 'CUSTOM' && (

--- a/ui/lib/components/setup/radio-groups/CloudAccountAutomationType.js
+++ b/ui/lib/components/setup/radio-groups/CloudAccountAutomationType.js
@@ -4,7 +4,7 @@ import { pluralize, titleize } from 'inflect'
 
 import RadioGroup from '../../utils/RadioGroup'
 
-const CloudAccountAutomationType = ({ cloud, accountNoun, value, onChange, disabled, inlineHelp }) => {
+const CloudAccountAutomationType = ({ cloud, accountNoun, value, onChange, disabled, inlineHelp, valuesFilter }) => {
   const accountAutomationClusterHelp = () => {
     Modal.info({
       title: `${titleize(accountNoun)} automation: One per cluster`,
@@ -41,13 +41,14 @@ const CloudAccountAutomationType = ({ cloud, accountNoun, value, onChange, disab
     className: 'automated-accounts-custom',
     extra: inlineHelp ? <Icon style={{ marginTop: '28px' }} type="info-circle" theme="twoTone" onClick={accountAutomationClusterHelp}/> : undefined
   }]
+  const filteredOptions = options.filter(o => valuesFilter ? valuesFilter.includes(o.value) : true)
 
   return (
     <RadioGroup
       heading={`How do you want Kore to automate ${cloud} ${pluralize(accountNoun)} for teams?`}
       onChange={onChange}
-      options={options}
-      value={value}
+      options={filteredOptions}
+      value={value || ''}
       disabled={disabled}
       style={{ marginBottom: '15px' }}
     />
@@ -57,10 +58,11 @@ const CloudAccountAutomationType = ({ cloud, accountNoun, value, onChange, disab
 CloudAccountAutomationType.propTypes = {
   cloud: PropTypes.oneOf(['GCP', 'AWS']),
   accountNoun: PropTypes.string.isRequired,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
-  inlineHelp: PropTypes.bool
+  inlineHelp: PropTypes.bool,
+  valuesFilter: PropTypes.arrayOf(PropTypes.oneOf(['CLUSTER', 'CUSTOM']))
 }
 
 export default CloudAccountAutomationType

--- a/ui/pages/configure/cloud/[...cloud].js
+++ b/ui/pages/configure/cloud/[...cloud].js
@@ -96,7 +96,7 @@ export default class ConfigureCloudPage extends React.Component {
                 <CredentialsList provider="EKS" />
               </Tabs.TabPane>
               <Tabs.TabPane tab="Account automation" key="account-automation">
-                <CloudAccountAutomationSettings provider="EKS" cloudOrgsApiMethod="ListAWSOrganizations" cloud="AWS" accountNoun="account" />
+                <CloudAccountAutomationSettings provider="EKS" cloudOrgsApiMethod="ListAWSOrganizations" cloud="AWS" accountNoun="account" cloudAccountAutomationType="CUSTOM" />
               </Tabs.TabPane>
               <Tabs.TabPane tab="Cluster plans" key="plans">
                 <PlanList kind="EKS" />


### PR DESCRIPTION
## Summary

As title, for AWS account automation only. GCP project automation remains unchanged.

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1133

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~

## Changes

* this prevents the one-account-per-cluster option from being selected
* this is because account provisioning is not suitable for this option

## Screenshots

**Custom** is the only option and is selected by default

<img width="1274" alt="Screen Shot 2020-08-03 at 17 02 45" src="https://user-images.githubusercontent.com/1334068/89202751-53c89680-d5ab-11ea-8663-c694a388d29e.png">

## Testing

Configuring AWS account automation