### PR TITLE
Make the new controllers stateless, remove a lot of duplicated code

### DIFF
--- a/pkg/controllers/cloud/aws/awsaccount/controller.go
+++ b/pkg/controllers/cloud/aws/awsaccount/controller.go
@@ -42,9 +42,7 @@ type awsCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&awsCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&awsCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/aws/awsaccountclaims/controller.go
+++ b/pkg/controllers/cloud/aws/awsaccountclaims/controller.go
@@ -18,127 +18,51 @@ package awsaccountclaims
 
 import (
 	"context"
-	"time"
 
 	aws "github.com/appvia/kore/pkg/apis/aws/v1alpha1"
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var _ controllers.Interface2 = &Controller{}
 
-// Controller is the controller for the projectclaims
-type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
-}
-
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
+	controllers.Register(&Controller{})
 }
 
-// NewController creates and returns a serviceproviders controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "aws-account-claims"
-
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+type Controller struct {
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "aws-account-claims"
 }
 
-// ManagerOptions returns the manager options for the controller
-func (c *Controller) ManagerOptions() manager.Options {
-	return controllers.DefaultManagerOptions(c)
-}
-
-// ControllerOptions returns the controller options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-// RunWithDependencies will start the controller and dependencies
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	c.mgr = mgr
-	c.ctrl = ctrl
-	c.Interface = hi
-
-	c.logger.Debug("controller has been started")
-
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
 	// @step: setup watches for the resources
-	if err := c.ctrl.Watch(
+	if err := ctrl.Watch(
 		&source.Kind{Type: &aws.AWSAccountClaim{}},
 		&handler.EnqueueRequestForObject{},
 		&predicate.GenerationChangedPredicate{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on resource")
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		c.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			if ctx.Err() != nil {
-				// Context was cancelled
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		c.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/cloud/aws/awsaccountclaims/reconcile.go
+++ b/pkg/controllers/cloud/aws/awsaccountclaims/reconcile.go
@@ -17,7 +17,6 @@
 package awsaccountclaims
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/utils/kubernetes"
 
-	log "github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,22 +38,16 @@ const (
 )
 
 // Reconcile is the entrypoint for the reconciliation logic
-func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	ctx := context.Background()
-
-	logger := c.logger.WithFields(log.Fields{
-		"name":      request.NamespacedName.Name,
-		"namespace": request.NamespacedName.Namespace,
-	})
-	logger.Debug("attempting to reconcile the service provider")
+func (c *Controller) Reconcile(ctx kore.Context, request reconcile.Request) (reconcile.Result, error) {
+	ctx.Logger().Debug("attempting to reconcile the service provider")
 
 	// @step: retrieve the object from the api
 	claim := &aws.AWSAccountClaim{}
-	if err := c.mgr.GetClient().Get(ctx, request.NamespacedName, claim); err != nil {
+	if err := ctx.Client().Get(ctx, request.NamespacedName, claim); err != nil {
 		if kerrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
-		logger.WithError(err).Error("trying to retrieve service provider from api")
+		ctx.Logger().WithError(err).Error("trying to retrieve service provider from api")
 
 		return reconcile.Result{}, err
 	}
@@ -63,12 +55,11 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	// @step: are we deleting the claim?
 	if !claim.GetDeletionTimestamp().IsZero() {
-		return c.Delete(request)
+		return c.Delete(ctx, request)
 	}
 
-	koreCtx := kore.NewContext(ctx, logger, c.mgr.GetClient(), c)
 	result, err := func() (reconcile.Result, error) {
-		return controllers.DefaultEnsureHandler.Run(koreCtx,
+		return controllers.DefaultEnsureHandler.Run(ctx,
 			[]controllers.EnsureFunc{
 				c.EnsureFinalizer(claim),
 				c.EnsurePending(claim),
@@ -79,7 +70,7 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}()
 
 	if err != nil {
-		logger.WithError(err).Error("failed to reconcile the gcp project claim")
+		ctx.Logger().WithError(err).Error("failed to reconcile the gcp project claim")
 
 		claim.Status.Status = corev1.ErrorStatus
 
@@ -88,8 +79,8 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 		}
 	}
 
-	if err := controllers.PatchStatus(ctx, c.mgr.GetClient(), claim, original); err != nil {
-		logger.WithError(err).Error("failed to update the service provider status")
+	if err := controllers.PatchStatus(ctx, ctx.Client(), claim, original); err != nil {
+		ctx.Logger().WithError(err).Error("failed to update the service provider status")
 
 		return reconcile.Result{}, err
 	}
@@ -135,13 +126,11 @@ func (c *Controller) EnsurePending(claim *aws.AWSAccountClaim) controllers.Ensur
 
 // EnsureAccountUnclaimed is responsible for checking the name is unique
 func (c *Controller) EnsureAccountUnclaimed(claim *aws.AWSAccountClaim) controllers.EnsureFunc {
-	cc := c.mgr.GetClient()
-
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		// @step: ensure no claim exists outside of the team
 		list := &aws.AWSAccountList{}
-		if err := cc.List(ctx, list, client.InNamespace("")); err != nil {
-			c.logger.WithError(err).Error("trying to retrieve all the projects")
+		if err := ctx.Client().List(ctx, list, client.InNamespace("")); err != nil {
+			ctx.Logger().WithError(err).Error("trying to retrieve all the projects")
 
 			return reconcile.Result{}, err
 		}
@@ -177,7 +166,7 @@ func (c *Controller) EnsureAccount(claim *aws.AWSAccountClaim) controllers.Ensur
 
 		found, err := kubernetes.GetIfExists(ctx, ctx.Client(), account)
 		if err != nil {
-			c.logger.WithError(err).Error("trying to check for account existence")
+			ctx.Logger().WithError(err).Error("trying to check for account existence")
 
 			return reconcile.Result{}, err
 		}
@@ -187,7 +176,7 @@ func (c *Controller) EnsureAccount(claim *aws.AWSAccountClaim) controllers.Ensur
 			account.Spec.Organization = claim.Spec.Organization
 
 			if _, err := kubernetes.CreateOrUpdate(ctx, ctx.Client(), account); err != nil {
-				c.logger.WithError(err).Error("trying to create the account")
+				ctx.Logger().WithError(err).Error("trying to create the account")
 
 				return reconcile.Result{}, err
 			}

--- a/pkg/controllers/cloud/aws/awsorganization/controller.go
+++ b/pkg/controllers/cloud/aws/awsorganization/controller.go
@@ -42,9 +42,7 @@ type awsCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&awsCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&awsCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/aws/credentials/controller.go
+++ b/pkg/controllers/cloud/aws/credentials/controller.go
@@ -45,9 +45,7 @@ type awsCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&awsCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&awsCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/aws/eks/controller.go
+++ b/pkg/controllers/cloud/aws/eks/controller.go
@@ -42,9 +42,7 @@ type eksCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&eksCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&eksCtrl{})
 }
 
 // Run starts the controller

--- a/pkg/controllers/cloud/aws/eks/reconcile.go
+++ b/pkg/controllers/cloud/aws/eks/reconcile.go
@@ -44,14 +44,14 @@ const (
 	ComponentClusterBootstrap = "Cluster Initialize Access"
 )
 
-func (t *eksCtrl) GetLoggerFromReq(request reconcile.Request) log.FieldLogger {
+func (t *eksCtrl) GetLoggerFromReq(request reconcile.Request) log.Ext1FieldLogger {
 	return log.WithFields(log.Fields{
 		"name":      request.NamespacedName.Name,
 		"namespace": request.NamespacedName.Namespace,
 	})
 }
 
-func (t *eksCtrl) GetLoggerFromRes(resource *eksv1alpha1.EKS) log.FieldLogger {
+func (t *eksCtrl) GetLoggerFromRes(resource *eksv1alpha1.EKS) log.Ext1FieldLogger {
 	return log.WithFields(log.Fields{
 		"name":      resource.Name,
 		"namespace": resource.Namespace,

--- a/pkg/controllers/cloud/aws/eksnodegroup/controller.go
+++ b/pkg/controllers/cloud/aws/eksnodegroup/controller.go
@@ -42,9 +42,7 @@ type ctrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&ctrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&ctrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/aws/eksvpc/controller.go
+++ b/pkg/controllers/cloud/aws/eksvpc/controller.go
@@ -42,9 +42,7 @@ type eksvpcCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&eksvpcCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&eksvpcCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/azure/aks/controller.go
+++ b/pkg/controllers/cloud/azure/aks/controller.go
@@ -18,122 +18,53 @@ package aks
 
 import (
 	"context"
-	"time"
 
 	aksv1alpha1 "github.com/appvia/kore/pkg/apis/aks/v1alpha1"
 
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var _ controllers.Interface2 = &Controller{}
 
-type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
-}
-
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
+	controllers.Register(&Controller{})
 }
 
-// NewController creates and returns an AKS cluster controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "aks"
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+type Controller struct {
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "aks"
 }
 
-// ManagerOptions returns the manager options for the controller
-func (c *Controller) ManagerOptions() manager.Options {
-	return controllers.DefaultManagerOptions(c)
-}
-
-// ControllerOptions returns the controllers options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	c.mgr = mgr
-	c.ctrl = ctrl
-	c.Interface = hi
-
-	c.logger.Debug("controller has been started")
-
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
 	// @step: setup watches for the resources
-	if err := c.ctrl.Watch(
+	if err := ctrl.Watch(
 		&source.Kind{Type: &aksv1alpha1.AKS{}},
 		&handler.EnqueueRequestForObject{},
 		predicate.GenerationChangedPredicate{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on AKS resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on AKS resource")
 
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		c.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		c.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/cloud/azure/aks/resourcegroup.go
+++ b/pkg/controllers/cloud/azure/aks/resourcegroup.go
@@ -105,6 +105,12 @@ func (c resourceGroupComponent) Delete(ctx kore.Context) (reconcile.Result, erro
 
 	ctx.Logger().WithField("provisioningState", to.String(existing.Properties.ProvisioningState)).Debug("current state of the Resource Group")
 
+	switch to.String(existing.Properties.ProvisioningState) {
+	case "Deleting":
+		// Deleting a resource group can take a long time (>1 hour), so we don't wait for it to go away
+		return reconcile.Result{}, nil
+	}
+
 	_, err = client.Delete(ctx, c.ResourceGroupName)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to delete Resource Group: %w", err)

--- a/pkg/controllers/cloud/azure/akscredentials/controller.go
+++ b/pkg/controllers/cloud/azure/akscredentials/controller.go
@@ -18,122 +18,53 @@ package akscredentials
 
 import (
 	"context"
-	"time"
 
 	aksv1alpha1 "github.com/appvia/kore/pkg/apis/aks/v1alpha1"
 
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var _ controllers.Interface2 = &Controller{}
 
-type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
-}
-
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
+	controllers.Register(&Controller{})
 }
 
-// NewController creates and returns an AKS credentials controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "akscredentials"
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+type Controller struct {
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "akscredentials"
 }
 
-// ManagerOptions returns the manager options for the controller
-func (c *Controller) ManagerOptions() manager.Options {
-	return controllers.DefaultManagerOptions(c)
-}
-
-// ControllerOptions returns the controllers options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	c.mgr = mgr
-	c.ctrl = ctrl
-	c.Interface = hi
-
-	c.logger.Debug("controller has been started")
-
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
 	// @step: setup watches for the resources
-	if err := c.ctrl.Watch(
+	if err := ctrl.Watch(
 		&source.Kind{Type: &aksv1alpha1.AKSCredentials{}},
 		&handler.EnqueueRequestForObject{},
 		predicate.GenerationChangedPredicate{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on AKSCredentials resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on AKSCredentials resource")
 
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		c.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		c.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/cloud/azure/akscredentials/reconcile.go
+++ b/pkg/controllers/cloud/azure/akscredentials/reconcile.go
@@ -17,7 +17,6 @@
 package akscredentials
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/appvia/kore/pkg/utils"
@@ -27,7 +26,6 @@ import (
 	cc "github.com/appvia/kore/pkg/controllers/components"
 	"github.com/appvia/kore/pkg/kore"
 
-	log "github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,17 +36,11 @@ const (
 )
 
 // Reconcile is the entrypoint for the reconciliation logic
-func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	logger := log.WithFields(log.Fields{
-		"name":      request.NamespacedName.Name,
-		"namespace": request.NamespacedName.Namespace,
-	})
-	ctx := kore.NewContext(context.Background(), logger, c.mgr.GetClient(), c)
-
-	logger.Debug("attempting to reconcile the AKS cluster")
+func (c *Controller) Reconcile(ctx kore.Context, request reconcile.Request) (reconcile.Result, error) {
+	ctx.Logger().Debug("attempting to reconcile the AKS cluster")
 
 	aksCredentials := &aksv1alpha1.AKSCredentials{}
-	if err := c.mgr.GetClient().Get(ctx, request.NamespacedName, aksCredentials); err != nil {
+	if err := ctx.Client().Get(ctx, request.NamespacedName, aksCredentials); err != nil {
 		if kerrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
@@ -63,14 +55,14 @@ func (c *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	res, err := components.Reconcile(ctx, aksCredentials)
 	if err != nil {
-		logger.WithError(err).Error("failed to reconcile the AKS cluster")
+		ctx.Logger().WithError(err).Error("failed to reconcile the AKS cluster")
 	}
 
 	// TODO: implement AKS credentials verification
 	aksCredentials.Status.Verified = utils.BoolPtr(true)
 
-	if err := c.mgr.GetClient().Status().Patch(ctx, aksCredentials, client.MergeFrom(original)); err != nil {
-		logger.WithError(err).Error("failed to update the status of the AKS cluster")
+	if err := ctx.Client().Status().Patch(ctx, aksCredentials, client.MergeFrom(original)); err != nil {
+		ctx.Logger().WithError(err).Error("failed to update the status of the AKS cluster")
 
 		return reconcile.Result{}, fmt.Errorf("failed to update the status of the AKS cluster: %w", err)
 	}

--- a/pkg/controllers/cloud/gcp/gke/controller.go
+++ b/pkg/controllers/cloud/gcp/gke/controller.go
@@ -42,9 +42,7 @@ type gkeCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&gkeCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&gkeCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/gcp/gkecredentials/controller.go
+++ b/pkg/controllers/cloud/gcp/gkecredentials/controller.go
@@ -45,9 +45,7 @@ type gkeCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&gkeCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&gkeCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/gcp/organization/controller.go
+++ b/pkg/controllers/cloud/gcp/organization/controller.go
@@ -42,9 +42,7 @@ type gcpCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&gcpCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&gcpCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/gcp/projectclaims/delete.go
+++ b/pkg/controllers/cloud/gcp/projectclaims/delete.go
@@ -17,8 +17,6 @@
 package projectclaims
 
 import (
-	"context"
-
 	"github.com/appvia/kore/pkg/kore"
 
 	corev1 "github.com/appvia/kore/pkg/apis/core/v1"
@@ -26,41 +24,33 @@ import (
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/utils/kubernetes"
 
-	log "github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // Delete is responsible for deleting the claim
-func (c *Controller) Delete(request reconcile.Request) (reconcile.Result, error) {
-	ctx := context.Background()
-
-	logger := c.logger.WithFields(log.Fields{
-		"name":      request.NamespacedName.Name,
-		"namespace": request.NamespacedName.Namespace,
-	})
-	logger.Debug("attempting to reconcile the service provider")
+func (c *Controller) Delete(ctx kore.Context, request reconcile.Request) (reconcile.Result, error) {
+	ctx.Logger().Debug("attempting to reconcile the service provider")
 
 	// @step: retrieve the object from the api
 	claim := &gcp.ProjectClaim{}
-	if err := c.mgr.GetClient().Get(ctx, request.NamespacedName, claim); err != nil {
+	if err := ctx.Client().Get(ctx, request.NamespacedName, claim); err != nil {
 		if kerrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
-		c.logger.WithError(err).Error("trying to retrieve claim from api")
+		ctx.Logger().WithError(err).Error("trying to retrieve claim from api")
 
 		return reconcile.Result{}, err
 	}
 	original := claim.DeepCopy()
 
-	f := kubernetes.NewFinalizer(c.mgr.GetClient(), finalizerName)
+	f := kubernetes.NewFinalizer(ctx.Client(), finalizerName)
 	if !f.IsDeletionCandidate(claim) {
 		return reconcile.Result{}, nil
 	}
 
-	koreCtx := kore.NewContext(ctx, logger, c.mgr.GetClient(), c)
 	result, err := func() (reconcile.Result, error) {
-		return controllers.DefaultEnsureHandler.Run(koreCtx,
+		return controllers.DefaultEnsureHandler.Run(ctx,
 			[]controllers.EnsureFunc{
 				c.EnsureDeleting(claim),
 				c.EnsureFinalizerRemoved(claim),
@@ -68,7 +58,7 @@ func (c *Controller) Delete(request reconcile.Request) (reconcile.Result, error)
 		)
 	}()
 	if err != nil {
-		logger.WithError(err).Error("trying to reconcile the gcp project claim")
+		ctx.Logger().WithError(err).Error("trying to reconcile the gcp project claim")
 
 		claim.Status.Status = corev1.ErrorStatus
 
@@ -77,8 +67,8 @@ func (c *Controller) Delete(request reconcile.Request) (reconcile.Result, error)
 		}
 	}
 
-	if err := controllers.PatchStatus(ctx, c.mgr.GetClient(), claim, original); err != nil {
-		logger.WithError(err).Error("trying to update the status")
+	if err := controllers.PatchStatus(ctx, ctx.Client(), claim, original); err != nil {
+		ctx.Logger().WithError(err).Error("trying to update the status")
 
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllers/cloud/gcp/projects/controller.go
+++ b/pkg/controllers/cloud/gcp/projects/controller.go
@@ -42,9 +42,7 @@ type ctrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&ctrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&ctrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/cloud/gcp/projectsweeper/controller.go
+++ b/pkg/controllers/cloud/gcp/projectsweeper/controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/appvia/kore/pkg/utils"
 
 	"github.com/patrickmn/go-cache"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -36,113 +35,52 @@ import (
 
 var _ controllers.Interface2 = &Controller{}
 
-// Controller is the controller for the projects
-type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
-	cache  *cache.Cache
-}
-
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
+	controllers.Register(NewController())
 }
 
-// NewController creates and returns a serviceproviders controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "projectsweeper"
+type Controller struct {
+	cache *cache.Cache
+}
 
+// NewController creates and returns a projectsweeper controller
+func NewController() *Controller {
 	return &Controller{
-		cache:  cache.New(30*time.Minute, 1*time.Minute),
-		logger: logger.WithFields(log.Fields{"controller": name}),
-		name:   name,
+		cache: cache.New(30*time.Minute, 1*time.Minute),
 	}
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "projectsweeper"
 }
 
 // ManagerOptions returns the manager options for the controller
 func (c *Controller) ManagerOptions() manager.Options {
 	options := controllers.DefaultManagerOptions(c)
 	options.SyncPeriod = utils.DurationPtr(2 * time.Minute)
-
 	return options
 }
 
-// ControllerOptions returns the controller options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-// RunWithDependencies is responsible for starting up the controller
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	c.mgr = mgr
-	c.ctrl = ctrl
-	c.Interface = hi
-
-	c.logger.Debug("controller has been started")
-
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
 	// @step: setup watches for the resources
-	if err := c.ctrl.Watch(
+	if err := ctrl.Watch(
 		&source.Kind{Type: &gcp.Project{}},
 		&handler.EnqueueRequestForObject{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on resource")
 
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		c.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			if ctx.Err() != nil {
-				// Context was cancelled
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		c.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/korefeatures/controller.go
+++ b/pkg/controllers/korefeatures/controller.go
@@ -20,125 +20,58 @@ import (
 	"context"
 	"time"
 
+	"github.com/appvia/kore/pkg/utils"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	configv1 "github.com/appvia/kore/pkg/apis/config/v1"
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
-	"github.com/appvia/kore/pkg/utils"
-
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var _ controllers.Interface2 = &Controller{}
 
-// Controller is the features controller
 type Controller struct {
-	kore   kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
 }
 
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
-}
-
-// NewController creates and returns a new features controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "korefeatures"
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+	controllers.Register(&Controller{})
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "korefeatures"
 }
 
-// ManagerOptions are the manager options
+// ManagerOptions returns the manager options for the controller
 func (c *Controller) ManagerOptions() manager.Options {
 	options := controllers.DefaultManagerOptions(c)
 	options.SyncPeriod = utils.DurationPtr(3 * time.Hour)
-
 	return options
 }
 
-// ControllerOptions are the controller options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-// RunWithDependencies provisions the controller
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, ki kore.Interface) error {
-	c.kore = ki
-	c.mgr = mgr
-	c.ctrl = ctrl
-
-	c.logger.Debug("controller has been started")
-
-	if err := c.ctrl.Watch(
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
+	if err := ctrl.Watch(
 		&source.Kind{Type: &configv1.KoreFeature{}},
 		&handler.EnqueueRequestForObject{},
 		&predicate.GenerationChangedPredicate{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on resource")
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	// Start a loop to repeatedly start the manager until the context is cancelled.
-	go func() {
-		c.logger.Info("starting the controller loop")
-		for {
-			stopCh = make(chan struct{})
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			if ctx.Err() != nil {
-				// Context was cancelled
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// Monitor for the context completing and, on completion, send the stop signal to the
-	// manager by closing the current stopCh.
-	go func() {
-		<-ctx.Done()
-		c.logger.Info("stopping the controller")
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/korefeatures/costsfeature.go
+++ b/pkg/controllers/korefeatures/costsfeature.go
@@ -28,8 +28,8 @@ import (
 	"github.com/appvia/kore/pkg/serviceproviders/application"
 )
 
-func (c *Controller) getCostsServices(koreCtx kore.Context, config *configv1.KoreFeature) ([]v1.Service, error) {
-	servicePlan, err := c.kore.ServicePlans().Get(koreCtx, "app-kore-costs")
+func (c *Controller) getCostsServices(ctx kore.Context, config *configv1.KoreFeature) ([]v1.Service, error) {
+	servicePlan, err := ctx.Kore().ServicePlans().Get(ctx, "app-kore-costs")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service plan app-kore-costs: %w", err)
 	}

--- a/pkg/controllers/management/cluster/controller.go
+++ b/pkg/controllers/management/cluster/controller.go
@@ -18,17 +18,14 @@ package cluster
 
 import (
 	"context"
-	"time"
 
 	clustersv1 "github.com/appvia/kore/pkg/apis/clusters/v1"
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
-
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -36,104 +33,35 @@ import (
 var _ controllers.Interface2 = &Controller{}
 
 type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
 }
 
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
-}
-
-// NewController creates and returns a clusters controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "cluster"
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+	controllers.Register(&Controller{})
 }
 
 // Name returns the name of the controller
-func (a *Controller) Name() string {
-	return a.name
+func (c *Controller) Name() string {
+	return "cluster"
 }
 
-// ManagerOptions returns the manager options for the controller
-func (a *Controller) ManagerOptions() manager.Options {
-	return controllers.DefaultManagerOptions(a)
-}
-
-// ControllerOptions returns the controllers options
-func (a *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(a)
-}
-
-func (a *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	a.mgr = mgr
-	a.ctrl = ctrl
-	a.Interface = hi
-
-	a.logger.Debug("controller has been started")
-
-	// @step: setup watches for the resources
-	if err := a.ctrl.Watch(
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
+	if err := ctrl.Watch(
 		&source.Kind{Type: &clustersv1.Cluster{}},
 		&handler.EnqueueRequestForObject{},
 		predicate.GenerationChangedPredicate{},
 	); err != nil {
-
-		a.logger.WithError(err).Error("failed to create watcher on Cluster resource")
-
+		ctx.Logger().WithError(err).Error("failed to create watcher on Cluster resource")
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		a.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := a.mgr.Start(stopCh); err != nil {
-				a.logger.WithError(err).Error("failed to start the controller")
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		a.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (a *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
-func (a *Controller) Stop(context.Context) error {
-	a.logger.Info("attempting to stop the controller")
-
-	return nil
+func (c *Controller) Stop(context.Context) error {
+	panic("deprecated")
 }

--- a/pkg/controllers/management/cluster/controller_test.go
+++ b/pkg/controllers/management/cluster/controller_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Cluster Controller", func() {
 
 	BeforeEach(func() {
 		test = controllerstest.NewTest(context.Background())
-		controller = clusterctrl.NewController(test.Logger)
+		controller = &clusterctrl.Controller{}
 		provider = &korefakes.FakeClusterProvider{}
 		provider.TypeReturns("TEST")
 
@@ -289,14 +289,14 @@ var _ = Describe("Cluster Controller", func() {
 	})
 
 	JustBeforeEach(func() {
-		test.Run(controller)
+		test.Initialize(controller)
 
 		if clusterConfig != nil {
 			configJson, _ := json.Marshal(clusterConfig)
 			cluster.Spec.Configuration = v1beta1.JSON{Raw: configJson}
 		}
 
-		reconcileResult, reconcileErr = controller.Reconcile(reconcile.Request{NamespacedName: name})
+		reconcileResult, reconcileErr = controller.Reconcile(test.Context, reconcile.Request{NamespacedName: name})
 	})
 
 	AfterEach(func() {

--- a/pkg/controllers/management/cluster/ensure.go
+++ b/pkg/controllers/management/cluster/ensure.go
@@ -17,7 +17,6 @@
 package cluster
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/appvia/kore/pkg/kore"
@@ -36,7 +35,7 @@ import (
 )
 
 // Load is responsible for loading the expected components
-func (a *Controller) Load(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
+func (c *Controller) Load(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		for _, comp := range *components {
 			comp.Object.SetNamespace(cluster.Namespace)
@@ -50,7 +49,7 @@ func (a *Controller) Load(cluster *clustersv1.Cluster, components *kore.ClusterC
 	}
 }
 
-func (a *Controller) setComponents(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
+func (c *Controller) setComponents(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		kubernetesObj := &clustersv1.Kubernetes{
 			ObjectMeta: metav1.ObjectMeta{
@@ -69,13 +68,13 @@ func (a *Controller) setComponents(cluster *clustersv1.Cluster, components *kore
 			},
 		})
 
-		kubeAppManager, err := a.createService(ctx, cluster, kore.AppAppManager)
+		kubeAppManager, err := c.createService(ctx, cluster, kore.AppAppManager)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		components.Add(kubeAppManager, kubernetesObj)
 
-		fluxHelmOperator, err := a.createService(ctx, cluster, kore.AppHelmOperator)
+		fluxHelmOperator, err := c.createService(ctx, cluster, kore.AppHelmOperator)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -86,7 +85,7 @@ func (a *Controller) setComponents(cluster *clustersv1.Cluster, components *kore
 	}
 }
 
-func (a *Controller) setProviderComponents(provider kore.ClusterProvider, cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
+func (c *Controller) setProviderComponents(provider kore.ClusterProvider, cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		if err := provider.SetComponents(ctx, cluster, components); err != nil {
 			return reconcile.Result{}, err
@@ -100,8 +99,8 @@ func (a *Controller) setProviderComponents(provider kore.ClusterProvider, cluste
 	}
 }
 
-func (a *Controller) createService(ctx context.Context, cluster *clustersv1.Cluster, name string) (*servicesv1.Service, error) {
-	servicePlan, err := a.ServicePlans().Get(ctx, "app-"+name)
+func (c *Controller) createService(ctx kore.Context, cluster *clustersv1.Cluster, name string) (*servicesv1.Service, error) {
+	servicePlan, err := ctx.Kore().ServicePlans().Get(ctx, "app-"+name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service plan %q: %w", "app-"+name, err)
 	}
@@ -114,7 +113,7 @@ func (a *Controller) createService(ctx context.Context, cluster *clustersv1.Clus
 	return &service, nil
 }
 
-func (a *Controller) beforeComponentsUpdate(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
+func (c *Controller) beforeComponentsUpdate(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		providerComponent := components.Find(func(comp kore.ClusterComponent) bool { return comp.IsProvider })
 
@@ -137,7 +136,7 @@ func (a *Controller) beforeComponentsUpdate(cluster *clustersv1.Cluster, compone
 }
 
 // SetClusterStatus is responsible for ensure the status of the cluster
-func (a *Controller) SetClusterStatus(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
+func (c *Controller) SetClusterStatus(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		cluster.Status.Status = corev1.SuccessStatus
 		cluster.Status.Message = "The cluster has been created successfully"

--- a/pkg/controllers/management/cluster/reconcile.go
+++ b/pkg/controllers/management/cluster/reconcile.go
@@ -17,7 +17,6 @@
 package cluster
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"time"
@@ -39,21 +38,16 @@ const (
 )
 
 // Reconcile is the entrypoint for the reconciliation logic
-func (a *Controller) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	ctx := context.Background()
-	logger := a.logger.WithFields(log.Fields{
-		"name":      request.NamespacedName.Name,
-		"namespace": request.NamespacedName.Namespace,
-	})
-	logger.Debug("attempting to reconcile the cluster")
+func (c *Controller) Reconcile(ctx kore.Context, request reconcile.Request) (reconcile.Result, error) {
+	ctx.Logger().Debug("attempting to reconcile the cluster")
 
 	// @step: retrieve the object from the api
 	cluster := &clustersv1.Cluster{}
-	if err := a.mgr.GetClient().Get(ctx, request.NamespacedName, cluster); err != nil {
+	if err := ctx.Client().Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kerrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
-		logger.WithError(err).Error("trying to retrieve cluster from api")
+		ctx.Logger().WithError(err).Error("trying to retrieve cluster from api")
 
 		return reconcile.Result{}, err
 	}
@@ -61,16 +55,16 @@ func (a *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	if cluster.Annotations[kore.AnnotationSystem] == kore.AnnotationValueTrue {
 		cluster.Status.Status = corev1.SuccessStatus
-		if err := a.mgr.GetClient().Status().Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
-			logger.WithError(err).Error("failed to update the cluster status")
+		if err := ctx.Client().Status().Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
+			ctx.Logger().WithError(err).Error("failed to update the cluster status")
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, nil
 	}
 
-	finalizer := kubernetes.NewFinalizer(a.mgr.GetClient(), finalizerName)
+	finalizer := kubernetes.NewFinalizer(ctx.Client(), finalizerName)
 	if finalizer.IsDeletionCandidate(cluster) {
-		return a.Delete(ctx, cluster)
+		return c.Delete(ctx, cluster)
 	}
 
 	// @logic:
@@ -88,30 +82,29 @@ func (a *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 		components := &kore.ClusterComponents{}
 
-		koreCtx := kore.NewContext(ctx, logger, a.mgr.GetClient(), a)
-		return controllers.DefaultEnsureHandler.Run(koreCtx,
+		return controllers.DefaultEnsureHandler.Run(ctx,
 			[]controllers.EnsureFunc{
-				a.AddFinalizer(cluster),
-				a.SetPending(cluster),
-				a.setComponents(cluster, components),
-				a.setProviderComponents(provider, cluster, components),
-				a.Load(cluster, components),
+				c.AddFinalizer(cluster),
+				c.SetPending(cluster),
+				c.setComponents(cluster, components),
+				c.setProviderComponents(provider, cluster, components),
+				c.Load(cluster, components),
 				func(ctx kore.Context) (reconcile.Result, error) {
 					return reconcile.Result{}, provider.BeforeComponentsUpdate(ctx, cluster, components)
 				},
-				a.beforeComponentsUpdate(cluster, components),
-				a.Apply(cluster, components),
+				c.beforeComponentsUpdate(cluster, components),
+				c.Apply(cluster, components),
 				func(ctx kore.Context) (reconcile.Result, error) {
 					return reconcile.Result{}, provider.SetProviderData(ctx, cluster, components)
 				},
-				a.Cleanup(cluster, components),
-				a.SetClusterStatus(cluster, components),
+				c.Cleanup(cluster, components),
+				c.SetClusterStatus(cluster, components),
 			},
 		)
 	}()
 
 	if err != nil {
-		logger.WithError(err).Error("trying to ensure the cluster")
+		ctx.Logger().WithError(err).Error("trying to ensure the cluster")
 
 		if controllers.IsCriticalError(err) {
 			cluster.Status.Status = corev1.FailureStatus
@@ -120,8 +113,8 @@ func (a *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	if !reflect.DeepEqual(cluster, original) {
-		if err := a.mgr.GetClient().Status().Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
-			logger.WithError(err).Error("trying to patch the cluster status")
+		if err := ctx.Client().Status().Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
+			ctx.Logger().WithError(err).Error("trying to patch the cluster status")
 
 			return reconcile.Result{}, err
 		}
@@ -131,12 +124,12 @@ func (a *Controller) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 // AddFinalizer ensures the finalizer is on the resource
-func (a *Controller) AddFinalizer(cluster *clustersv1.Cluster) controllers.EnsureFunc {
+func (c *Controller) AddFinalizer(cluster *clustersv1.Cluster) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
-		finalizer := kubernetes.NewFinalizer(a.mgr.GetClient(), finalizerName)
+		finalizer := kubernetes.NewFinalizer(ctx.Client(), finalizerName)
 		if finalizer.NeedToAdd(cluster) {
 			if err := finalizer.Add(cluster); err != nil {
-				a.logger.WithError(err).Error("trying to add the finalizer")
+				ctx.Logger().WithError(err).Error("trying to add the finalizer")
 
 				return reconcile.Result{}, err
 			}
@@ -149,7 +142,7 @@ func (a *Controller) AddFinalizer(cluster *clustersv1.Cluster) controllers.Ensur
 }
 
 // SetPending ensures the state of the cluster is set to pending if not
-func (a *Controller) SetPending(cluster *clustersv1.Cluster) controllers.EnsureFunc {
+func (c *Controller) SetPending(cluster *clustersv1.Cluster) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		switch cluster.Status.Status {
 		case corev1.DeletingStatus:
@@ -169,7 +162,7 @@ func (a *Controller) SetPending(cluster *clustersv1.Cluster) controllers.EnsureF
 }
 
 // Apply is responsible for applying the component and updating the component status
-func (a *Controller) Apply(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
+func (c *Controller) Apply(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		if cluster.Status.Components == nil {
 			cluster.Status.Components = corev1.Components{}
@@ -183,7 +176,7 @@ func (a *Controller) Apply(cluster *clustersv1.Cluster, components *kore.Cluster
 				continue
 			}
 
-			result, err := a.applyComponent(ctx, cluster, comp)
+			result, err := c.applyComponent(ctx, cluster, comp)
 			if err != nil || result.Requeue || result.RequeueAfter > 0 {
 				return result, err
 			}
@@ -197,7 +190,7 @@ func (a *Controller) Apply(cluster *clustersv1.Cluster, components *kore.Cluster
 	}
 }
 
-func (a *Controller) applyComponent(ctx kore.Context, cluster *clustersv1.Cluster, comp *kore.ClusterComponent) (reconcile.Result, error) {
+func (c *Controller) applyComponent(ctx kore.Context, cluster *clustersv1.Cluster, comp *kore.ClusterComponent) (reconcile.Result, error) {
 	condition, found := cluster.Status.Components.GetComponent(comp.ComponentName())
 	if !found {
 		condition = &corev1.Component{
@@ -211,7 +204,7 @@ func (a *Controller) applyComponent(ctx kore.Context, cluster *clustersv1.Cluste
 
 	ownership := corev1.MustGetOwnershipFromObject(comp.Object)
 	condition.Resource = &ownership
-	logger := a.logger.WithFields(log.Fields{
+	logger := ctx.Logger().WithFields(log.Fields{
 		"component": comp.ComponentName(),
 		"condition": condition.Status,
 		"existing":  comp.Exists(),
@@ -270,7 +263,7 @@ func (a *Controller) applyComponent(ctx kore.Context, cluster *clustersv1.Cluste
 }
 
 // Cleanup is responsible for deleting any components no longer required
-func (a *Controller) Cleanup(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
+func (c *Controller) Cleanup(cluster *clustersv1.Cluster, components *kore.ClusterComponents) controllers.EnsureFunc {
 	return func(ctx kore.Context) (reconcile.Result, error) {
 		// @logic:
 		// - we remove any absent components first in reverse dependency order
@@ -282,7 +275,7 @@ func (a *Controller) Cleanup(cluster *clustersv1.Cluster, components *kore.Clust
 				continue
 			}
 
-			result, err := a.removeComponent(ctx, cluster, components, comp)
+			result, err := c.removeComponent(ctx, cluster, components, comp)
 			if err != nil || result.Requeue || result.RequeueAfter > 0 {
 				return result, err
 			}
@@ -314,7 +307,7 @@ func (a *Controller) Cleanup(cluster *clustersv1.Cluster, components *kore.Clust
 
 			ctx.Logger().WithField("component", comp.ComponentName()).Debug("component is not defined anymore, deleting")
 
-			res, err := a.removeComponent(ctx, cluster, components, comp)
+			res, err := c.removeComponent(ctx, cluster, components, comp)
 			if err != nil || res.Requeue || res.RequeueAfter > 0 {
 				return res, err
 			}

--- a/pkg/controllers/management/clusterbindings/controller.go
+++ b/pkg/controllers/management/clusterbindings/controller.go
@@ -46,9 +46,7 @@ type crCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&crCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register cluster bindings controller")
-	}
+	controllers.Register(&crCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/management/clusterconfig/controller.go
+++ b/pkg/controllers/management/clusterconfig/controller.go
@@ -41,9 +41,7 @@ type ccCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&ccCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register the cluster config controller")
-	}
+	controllers.Register(&ccCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/management/clusterroles/controller.go
+++ b/pkg/controllers/management/clusterroles/controller.go
@@ -50,9 +50,7 @@ type crCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&crCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register cluster roles controller")
-	}
+	controllers.Register(&crCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/management/kubernetes/controller.go
+++ b/pkg/controllers/management/kubernetes/controller.go
@@ -44,11 +44,7 @@ type k8sCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&k8sCtrl{}); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatal("failed to register the kubernetes controller")
-	}
+	controllers.Register(&k8sCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/management/namespaceclaims/controller.go
+++ b/pkg/controllers/management/namespaceclaims/controller.go
@@ -44,9 +44,7 @@ type nsCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&nsCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register namespaceclaim controller")
-	}
+	controllers.Register(&nsCtrl{})
 }
 
 // Run is called when the controller is started

--- a/pkg/controllers/management/podpolicy/controller.go
+++ b/pkg/controllers/management/podpolicy/controller.go
@@ -43,11 +43,7 @@ type pspCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&pspCtrl{}); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatal("failed to register the pod security controller")
-	}
+	controllers.Register(&pspCtrl{})
 }
 
 // Run is called when the controller is started

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -28,13 +28,11 @@ var (
 )
 
 // Register is responsible for registering a controller
-func Register(handler RegisterInterface) error {
+func Register(handler RegisterInterface) {
 	controllerLock.Lock()
 	defer controllerLock.Unlock()
 
 	controllerList = append(controllerList, handler)
-
-	return nil
 }
 
 // GetControllers returns all the registered controllers

--- a/pkg/controllers/secrets/gcp/controller.go
+++ b/pkg/controllers/secrets/gcp/controller.go
@@ -42,9 +42,7 @@ type ctrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&ctrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&ctrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/secrets/generic/controller.go
+++ b/pkg/controllers/secrets/generic/controller.go
@@ -42,9 +42,7 @@ type ctrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&ctrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&ctrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/servicecredentials/controller.go
+++ b/pkg/controllers/servicecredentials/controller.go
@@ -18,7 +18,6 @@ package servicecredentials
 
 import (
 	"context"
-	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -26,11 +25,9 @@ import (
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -42,106 +39,36 @@ const (
 )
 
 type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
 }
 
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
-}
-
-// NewController creates and returns a servicecredentials controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "servicecredentials"
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+	controllers.Register(&Controller{})
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "servicecredentials"
 }
 
-// ManagerOptions returns the manager options for the controller
-func (c *Controller) ManagerOptions() manager.Options {
-	return controllers.DefaultManagerOptions(c)
-}
-
-// ControllerOptions returns the controller options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	c.mgr = mgr
-	c.ctrl = ctrl
-	c.Interface = hi
-
-	c.logger.Debug("controller has been started")
-
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
 	// @step: setup watches for the resources
-	if err := c.ctrl.Watch(
+	if err := ctrl.Watch(
 		&source.Kind{Type: &servicesv1.ServiceCredentials{}},
 		&handler.EnqueueRequestForObject{},
 		&predicate.GenerationChangedPredicate{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on ServiceCredentials resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on ServiceCredentials resource")
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		c.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			if ctx.Err() != nil {
-				// Context was cancelled
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		c.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/serviceproviders/controller.go
+++ b/pkg/controllers/serviceproviders/controller.go
@@ -18,17 +18,14 @@ package serviceproviders
 
 import (
 	"context"
-	"time"
 
 	servicesv1 "github.com/appvia/kore/pkg/apis/services/v1"
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -36,106 +33,36 @@ import (
 var _ controllers.Interface2 = &Controller{}
 
 type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
 }
 
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
-}
-
-// NewController creates and returns a serviceproviders controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "serviceproviders"
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+	controllers.Register(&Controller{})
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "serviceproviders"
 }
 
-// ManagerOptions returns the manager options for the controller
-func (c *Controller) ManagerOptions() manager.Options {
-	return controllers.DefaultManagerOptions(c)
-}
-
-// ControllerOptions returns the controller options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	c.mgr = mgr
-	c.ctrl = ctrl
-	c.Interface = hi
-
-	c.logger.Debug("controller has been started")
-
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
 	// @step: setup watches for the resources
-	if err := c.ctrl.Watch(
+	if err := ctrl.Watch(
 		&source.Kind{Type: &servicesv1.ServiceProvider{}},
 		&handler.EnqueueRequestForObject{},
 		&predicate.GenerationChangedPredicate{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on ServiceProvider resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on ServiceProvider resource")
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		c.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			if ctx.Err() != nil {
-				// Context was cancelled
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		c.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/services/controller.go
+++ b/pkg/controllers/services/controller.go
@@ -18,7 +18,6 @@ package services
 
 import (
 	"context"
-	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -27,117 +26,45 @@ import (
 	"github.com/appvia/kore/pkg/controllers"
 	"github.com/appvia/kore/pkg/kore"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var _ controllers.Interface2 = &Controller{}
 
 type Controller struct {
-	kore.Interface
-	name   string
-	logger log.FieldLogger
-	mgr    manager.Manager
-	ctrl   controller.Controller
 }
 
 func init() {
-	ctrl := NewController(log.StandardLogger())
-	if err := controllers.Register(ctrl); err != nil {
-		log.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Fatalf("failed to register the %s controller", ctrl.Name())
-	}
-}
-
-// NewController creates and returns a services controller
-func NewController(logger log.FieldLogger) *Controller {
-	name := "services"
-	return &Controller{
-		name: name,
-		logger: logger.WithFields(log.Fields{
-			"controller": name,
-		}),
-	}
+	controllers.Register(&Controller{})
 }
 
 // Name returns the name of the controller
 func (c *Controller) Name() string {
-	return c.name
+	return "services"
 }
 
-// ManagerOptions returns the manager options for the controller
-func (c *Controller) ManagerOptions() manager.Options {
-	return controllers.DefaultManagerOptions(c)
-}
-
-// ControllerOptions returns the controller options
-func (c *Controller) ControllerOptions() controller.Options {
-	return controllers.DefaultControllerOptions(c)
-}
-
-func (c *Controller) RunWithDependencies(ctx context.Context, mgr manager.Manager, ctrl controller.Controller, hi kore.Interface) error {
-	c.mgr = mgr
-	c.ctrl = ctrl
-	c.Interface = hi
-
-	c.logger.Debug("controller has been started")
-
+// Initialize registers dependencies and sets up watches
+func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
 	// @step: setup watches for the resources
-	if err := c.ctrl.Watch(
+	if err := ctrl.Watch(
 		&source.Kind{Type: &servicesv1.Service{}},
 		&handler.EnqueueRequestForObject{},
 		&predicate.GenerationChangedPredicate{},
 	); err != nil {
-		c.logger.WithError(err).Error("failed to create watcher on Service resource")
+		ctx.Logger().WithError(err).Error("failed to create watcher on Service resource")
 		return err
 	}
 
-	var stopCh chan struct{}
-
-	go func() {
-		c.logger.Info("starting the controller loop")
-
-		for {
-			stopCh = make(chan struct{})
-
-			if err := c.mgr.Start(stopCh); err != nil {
-				c.logger.WithError(err).Error("failed to start the controller")
-			}
-			if ctx.Err() != nil {
-				// Context was cancelled
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	// @step: use a routine to catch the stop channel
-	go func() {
-		<-ctx.Done()
-
-		c.logger.Info("stopping the controller")
-
-		if stopCh != nil {
-			close(stopCh)
-		}
-	}()
-
 	return nil
 }
 
-// Run is called when the controller is started
-func (c *Controller) Run(ctx context.Context, cfg *rest.Config, hi kore.Interface) error {
-	panic("this controller implements controllers.Interface2 and only RunWithDependencies should be called")
+func (c *Controller) Run(context.Context, *rest.Config, kore.Interface) error {
+	panic("deprecated")
 }
 
-// Stop is responsible for calling a halt on the controller
 func (c *Controller) Stop(context.Context) error {
-	c.logger.Info("attempting to stop the controller")
-
-	return nil
+	panic("deprecated")
 }

--- a/pkg/controllers/types.go
+++ b/pkg/controllers/types.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/appvia/kore/pkg/kore"
-
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -51,10 +50,20 @@ type Interface interface {
 // Interface2 is a temporary interface to introduce a new run function where the dependencies will be injected
 // TODO: migrate all controllers to the new interface
 type Interface2 interface {
-	Interface
+	RegisterInterface
+	Reconcile(kore.Context, reconcile.Request) (reconcile.Result, error)
+	// Initialize registers dependencies and sets up watches
+	Initialize(kore.Context, controller.Controller) error
+}
+
+type ManagerOptionsAware interface {
+	// ManagerOptions returns the manager options
 	ManagerOptions() manager.Options
-	ControllerOptions() controller.Options
-	RunWithDependencies(context.Context, manager.Manager, controller.Controller, kore.Interface) error
+}
+
+type ControllerOptionsAware interface {
+	// ControllerOptions returns the controller options
+	ControllerOptions(kore.Context) controller.Options
 }
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Client

--- a/pkg/controllers/user/allocations/controller.go
+++ b/pkg/controllers/user/allocations/controller.go
@@ -48,9 +48,7 @@ type acCtrl struct {
 }
 
 func init() {
-	if err := controllers.Register(&acCtrl{}); err != nil {
-		log.WithError(err).Fatal("failed to register the allocations controller")
-	}
+	controllers.Register(&acCtrl{})
 }
 
 // Name returns the name of the controller

--- a/pkg/controllers/user/teams/controller.go
+++ b/pkg/controllers/user/teams/controller.go
@@ -42,9 +42,7 @@ type teamController struct {
 }
 
 func init() {
-	if err := controllers.Register(&teamController{}); err != nil {
-		log.WithError(err).Fatal("failed to register controller")
-	}
+	controllers.Register(&teamController{})
 }
 
 // Name returns the name of the controller

--- a/pkg/kore/context.go
+++ b/pkg/kore/context.go
@@ -26,14 +26,15 @@ import (
 
 type Context interface {
 	context.Context
-	Logger() log.FieldLogger
+	Logger() log.Ext1FieldLogger
 	Client() client.Client
 	Kore() Interface
+	WithLogger(log.Ext1FieldLogger) Context
 }
 
 type contextImpl struct {
 	ctx    context.Context
-	logger log.FieldLogger
+	logger log.Ext1FieldLogger
 	client client.Client
 	kore   Interface
 }
@@ -54,7 +55,7 @@ func (s contextImpl) Value(key interface{}) interface{} {
 	return s.ctx.Value(key)
 }
 
-func (s contextImpl) Logger() log.FieldLogger {
+func (s contextImpl) Logger() log.Ext1FieldLogger {
 	return s.logger
 }
 
@@ -66,9 +67,18 @@ func (s contextImpl) Kore() Interface {
 	return s.kore
 }
 
+func (s contextImpl) WithLogger(logger log.Ext1FieldLogger) Context {
+	return contextImpl{
+		ctx:    s.ctx,
+		logger: logger,
+		client: s.client,
+		kore:   s.kore,
+	}
+}
+
 func NewContext(
 	ctx context.Context,
-	logger log.FieldLogger,
+	logger log.Ext1FieldLogger,
 	client client.Client,
 	kore Interface,
 ) Context {

--- a/pkg/security/scanner.go
+++ b/pkg/security/scanner.go
@@ -63,7 +63,7 @@ func NewEmpty() Scanner {
 type scannerImpl struct {
 	rulesLock *sync.RWMutex
 	rules     []Rule
-	logger    log.FieldLogger
+	logger    log.Ext1FieldLogger
 }
 
 func (s *scannerImpl) RegisterRule(rule Rule) {

--- a/test/bin/e2e.sh
+++ b/test/bin/e2e.sh
@@ -129,6 +129,7 @@ build-cluster() {
     --set=api.auth_plugins.1=admintoken \
     --set=api.auth_plugins.2=localjwt \
     --set=api.auth_plugins.3=openid \
+    --set=api.verbose=true \
     --set=idp.client_id=${KORE_IDP_CLIENT_ID} \
     --set=idp.client_secret=${KORE_IDP_CLIENT_SECRET} \
     --set=idp.server_url=${KORE_IDP_SERVER_URL} \


### PR DESCRIPTION
## Summary

Say hello to our new simplified controller:

```
type Controller struct {}

func (c *Controller) Name() string {
	return "cluster"
}

func (c *Controller) Initialize(ctx kore.Context, ctrl controller.Controller) error {
	if err := ctrl.Watch(
		&source.Kind{Type: &clustersv1.Cluster{}},
		&handler.EnqueueRequestForObject{},
		predicate.GenerationChangedPredicate{},
	); err != nil {
		ctx.Logger().WithError(err).Error("failed to create watcher on Cluster resource")
		return err
	}

	return nil
}

// Reconcile is the entrypoint for the reconciliation logic
func (c *Controller) Reconcile(ctx kore.Context, request reconcile.Request) (reconcile.Result, error) {
  [...]
}
```

## Changes

 * Most of the new controllers (implementing controllers.Interface2) will be stateless, which should make testing and reuse easier
 * Most of the run logic was moved to the server (DRY)
 * The controller now has a minimal initialize function where you can register your watches
 * The reconciler function now expectes a kore.Context
 * You can override the manager options by implementing the `ManagerOptionsAware` interface
 * You can override the controller options by implementing the `ControllerOptionsAware` interface

## Additional changes

 * `controllers.Register` never throws (and never should) throw an error, so removed the error returned
 * we use everywhere the log.Ext1FieldLogger interface, which adds Trace* methods

## Out of scope

Converting the controllers using the original interface.