### PR TITLE
UI nightly E2E

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,6 +431,70 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: master
 
+  e2e_ui_gke:
+    environment:
+      <<: *SERVICES_ENV
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-1604:202007-01
+    steps:
+      - checkout
+      - kube-orb/install-kubectl:
+          kubectl-version: latest
+      - run:
+          name: Installing Tools
+          command: |
+            sudo apt-get update
+            sudo apt install -y jq
+      - run:
+          name: Docker Login
+          command: |
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} quay.io
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Provisioning Local Cluster
+          command: |
+            mkdir -p bin
+            # copy the cli from build
+            cp -f /tmp/workspace/* bin/
+            # build the cluster
+            test/bin/e2e.sh \
+              --build-cli false \
+              --build-kore-api false \
+              --build-proxy false \
+              --enable-ui true \
+              --version ${CIRCLE_SHA1}
+      - run:
+          name: Kore API Logs
+          background: true
+          command: |
+            make kind-apiserver-logs
+      - run:
+          name: Kore UI Logs
+          background: true
+          command: |
+            make kind-ui-logs
+      - run:
+          name: Setup environment
+          command: |
+            rm -f ${HOME}/.kore/config
+            test/e2e/create-kore-config.sh
+            test/e2e/check-suite.sh \
+              --enable-unit-tests false \
+              --enable-e2e-user ${KORE_E2E_USER}
+            echo -n ${GKE_SA_QA} | base64 -d > ./gke-credentials.yml 2>/dev/null
+            bin/kore apply -f ./gke-credentials.yml -t kore-admin 2>&1 >/dev/null
+      - run:
+          name: Running UI GKE E2E Suite
+          no_output_timeout: 30m
+          command: |
+            cd ui
+            npm install jest puppeteer jest-puppeteer
+            make test-e2e-nightly-gke
+      - slack/notify-on-failure:
+          only_for_branches: master
+
   e2e_eks:
     environment:
       <<: *SERVICES_ENV
@@ -478,6 +542,70 @@ jobs:
             test/e2e/check-suite.sh \
               --enable-e2e-user ${KORE_E2E_USER} \
               --enable-eks true
+      - slack/notify-on-failure:
+          only_for_branches: master
+
+  e2e_ui_eks:
+    environment:
+      <<: *SERVICES_ENV
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-1604:202007-01
+    steps:
+      - checkout
+      - kube-orb/install-kubectl:
+          kubectl-version: latest
+      - run:
+          name: Installing Tools
+          command: |
+            sudo apt-get update
+            sudo apt install -y jq
+      - run:
+          name: Docker Login
+          command: |
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} quay.io
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Provisioning Local Cluster
+          command: |
+            mkdir -p bin
+            # copy the cli from build
+            cp -f /tmp/workspace/* bin/
+            # build the cluster
+            test/bin/e2e.sh \
+              --build-cli false \
+              --build-kore-api false \
+              --build-proxy false \
+              --enable-ui true \
+              --version ${CIRCLE_SHA1}
+      - run:
+          name: Kore API Logs
+          background: true
+          command: |
+            make kind-apiserver-logs
+      - run:
+          name: Kore UI Logs
+          background: true
+          command: |
+            make kind-ui-logs
+      - run:
+          name: Setup environment
+          command: |
+            rm -f ${HOME}/.kore/config
+            test/e2e/create-kore-config.sh
+            test/e2e/check-suite.sh \
+              --enable-unit-tests false \
+              --enable-e2e-user ${KORE_E2E_USER}
+            echo -n ${EKS_SA_QA} | base64 -d > ./eks-credentials.yml 2>/dev/null
+            bin/kore apply -f ./eks-credentials.yml -t kore-admin 2>&1 >/dev/null
+      - run:
+          name: Running UI EKS E2E Suite
+          no_output_timeout: 30m
+          command: |
+            cd ui
+            npm install jest puppeteer jest-puppeteer
+            make test-e2e-nightly-eks
       - slack/notify-on-failure:
           only_for_branches: master
 
@@ -672,7 +800,23 @@ workflows:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+)|-beta([0-9]+)|-alpha([0-9]+))$/
           requires:
             - build-api
+      - e2e_ui_gke:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+)|-beta([0-9]+)|-alpha([0-9]+))$/
+          requires:
+            - build-api
       - e2e_eks:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+)|-beta([0-9]+)|-alpha([0-9]+))$/
+          requires:
+            - build-api
+      - e2e_ui_eks:
           filters:
             branches:
               ignore: /.*/
@@ -688,14 +832,25 @@ workflows:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+)|-beta([0-9]+)|-alpha([0-9]+))$/
           requires:
             - build-api
+      - e2e_ui_aks:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)($|-rc([0-9]+)|-beta([0-9]+)|-alpha([0-9]+))$/
+          requires:
+            - build-api
       - publish-release:
           requires:
             - check-release-notes
             - release
             - release-ui
             - e2e_gke
+            - e2e_ui_gke
             - e2e_eks
+            - e2e_ui_eks
             - e2e_aks
+            - e2e_ui_aks
           filters:
             branches:
               ignore: /.*/
@@ -727,12 +882,18 @@ workflows:
       - e2e_gke:
           requires:
             - build-api
+      - e2e_ui_gke:
+          requires:
+            - build-api
 
   e2e_eks:
     when: << pipeline.parameters.enable_eks_e2e >>
     jobs:
       - build-api
       - e2e_eks:
+          requires:
+            - build-api
+      - e2e_ui_eks:
           requires:
             - build-api
 
@@ -762,10 +923,19 @@ workflows:
       - e2e_gke:
           requires:
             - build-api
+      - e2e_ui_gke:
+          requires:
+            - build-api
       - e2e_eks:
           requires:
             - build-api
+      - e2e_ui_eks:
+          requires:
+            - build-api
       - e2e_aks:
+          requires:
+            - build-api
+      - e2e_ui_aks:
           requires:
             - build-api
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,6 +659,70 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: master
 
+  e2e_ui_aks:
+    environment:
+      <<: *SERVICES_ENV
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-1604:202007-01
+    steps:
+      - checkout
+      - kube-orb/install-kubectl:
+          kubectl-version: latest
+      - run:
+          name: Installing Tools
+          command: |
+            sudo apt-get update
+            sudo apt install -y jq
+      - run:
+          name: Docker Login
+          command: |
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} quay.io
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Provisioning Local Cluster
+          command: |
+            mkdir -p bin
+            # copy the cli from build
+            cp -f /tmp/workspace/* bin/
+            # build the cluster
+            test/bin/e2e.sh \
+              --build-cli false \
+              --build-kore-api false \
+              --build-proxy false \
+              --enable-ui true \
+              --version ${CIRCLE_SHA1}
+      - run:
+          name: Kore API Logs
+          background: true
+          command: |
+            make kind-apiserver-logs
+      - run:
+          name: Kore UI Logs
+          background: true
+          command: |
+            make kind-ui-logs
+      - run:
+          name: Setup environment
+          command: |
+            rm -f ${HOME}/.kore/config
+            test/e2e/create-kore-config.sh
+            test/e2e/check-suite.sh \
+              --enable-unit-tests false \
+              --enable-e2e-user ${KORE_E2E_USER}
+            echo -n ${AKS_SA_QA} | base64 -d > ./aks-credentials.yml 2>/dev/null
+            bin/kore apply -f ./aks-credentials.yml -t kore-admin 2>&1 >/dev/null
+      - run:
+          name: Running UI AKS E2E Suite
+          no_output_timeout: 30m
+          command: |
+            cd ui
+            npm install jest puppeteer jest-puppeteer
+            make test-e2e-nightly-aks
+      - slack/notify-on-failure:
+          only_for_branches: master
+
   update_e2e:
     parameters:
       from:
@@ -902,6 +966,9 @@ workflows:
     jobs:
       - build-api
       - e2e_aks:
+          requires:
+            - build-api
+      - e2e_ui_aks:
           requires:
             - build-api
 

--- a/Makefile
+++ b/Makefile
@@ -506,6 +506,9 @@ kind-apiserver-reload: kind-apiserver-stop kind-apiserver kind-apiserver-start
 kind-apiserver-logs:
 	@while true; do kubectl --context=kind-kore -n kore logs -f -l name=kore-apiserver || true; sleep 1; done
 
+kind-ui-logs:
+	@while true; do kubectl --context=kind-kore -n kore logs -f -l name=kore-portal || true; sleep 1; done
+
 kind-admintoken:
 	@echo `kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_TOKEN" | base64 --decode`
 

--- a/charts/kore/templates/portal.yml
+++ b/charts/kore/templates/portal.yml
@@ -76,6 +76,10 @@ spec:
         - name: KORE_UI_SHOW_PROTOTYPES
           value: "{{ .Values.ui.show_prototypes }}"
         {{- end }}
+        {{- if .Values.ui.disable_animations }}
+        - name: KORE_UI_DISABLE_ANIMATIONS
+          value: "{{ .Values.ui.disable_animations }}"
+        {{- end }}
         - name: KORE_API_PUBLIC_URL
           {{- if and (eq .Values.api.serviceType "LoadBalancer") .Values.api.endpoint.detect}}
           valueFrom:

--- a/charts/kore/values.yaml
+++ b/charts/kore/values.yaml
@@ -70,5 +70,6 @@ ui:
   version: v0.2.0-rc1
   replicas: 2
   show_prototypes: false
+  disable_animations: false
 kubectl:
   version: 1.16

--- a/test/bin/e2e.sh
+++ b/test/bin/e2e.sh
@@ -73,6 +73,7 @@ build-cluster() {
     args="${args} --set=ui.hostPort=3000"
     args="${args} --set=ui.replicas=01"
     args="${args} --set=ui.serviceType=NodePort"
+    args="${args} --set=ui.disable_animations=true"
 
     if [[ ${BUILD_IMAGES} == true ]]; then
       announce "Building the Kore UI Image"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -4,7 +4,7 @@
 
 - bats (bash tests)
 - jq
-- korectl
+- kore
 - kubectl
 
 You must have some valid credentials in the e2e folder
@@ -19,8 +19,8 @@ You must have some valid credentials in the e2e folder
 - Bring up the dependencies via `make compose` or `make demo`
 - If your not using the `make demo` bring up the kore-apiserver locally via `bin/kore-apiserver --verbose`; sourcing
   in any environment variables you usually do.
-- Login via the `korectl login` command which will provision your user locally
-- Ensure if you are using multiple profiles your pointing to the local instance `korectl profiles ls`
+- Login via the `kore login` command which will provision your user locally
+- Ensure if you are using multiple profiles your pointing to the local instance `kore profiles ls`
 
 You can then run the checks via:
 

--- a/test/e2e/check-suite-units.sh
+++ b/test/e2e/check-suite-units.sh
@@ -25,7 +25,7 @@ CLUSTER="${CLUSTER="ci-${CIRCLE_BUILD_NUM:-$USER}"}"
 usage() {
   cat <<EOF
   Usage: $(basename $0)
-  --enable-gke <bool>  : indicates we should run the GKE (default: ${ENBALE_GKE_E2E})
+  --enable-gke <bool>  : indicates we should run E2E on GKE (default: ${ENBALE_GKE_E2E})
   --enable-eks <bool>  : indicates we should run E2E on EKS (default: ${ENABLE_EKS_E2E})
   --enable-aks <bool>  : indicates we should run E2E on AKS (default: ${ENABLE_AKS_E2E})
   -h|--help      : display this usage menu

--- a/test/e2e/create-kore-config.sh
+++ b/test/e2e/create-kore-config.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2020 Appvia Ltd <info@appvia.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source test/e2e/environment.sh || exit 1
+
+KORE_CONFIG=${HOME}/.kore/config
+KORE_API_URL=${KORE_API_PUBLIC_URL_E2E:-"http://localhost:10080"}
+KORE_IDP_SERVER_URL=${KORE_IDP_SERVER_URL:-"unknown"}
+KORE_IDP_CLIENT_ID=${KORE_IDP_CLIENT_ID:-"unknown"}
+KORE_ID_TOKEN=${KORE_ID_TOKEN_QA:-"unknown"}
+
+[[ -f ${KORE_CONFIG} ]] && exit 0
+
+mkdir -p $(dirname ${KORE_CONFIG}) || {
+  error "unable to create the client configuration directory";
+  exit 1;
+}
+
+announce "Generating a kore configuration: ${KORE_CONFIG}"
+cat << EOF > ${KORE_CONFIG}
+current-profile: local
+profiles:
+  local:
+    server: local
+    user: local
+servers:
+  local:
+    server: ${KORE_API_URL}
+users:
+  local:
+    oidc:
+      authorize-url: ${KORE_IDP_SERVER_URL}
+      client-id: ${KORE_IDP_CLIENT_ID}
+      id-token: ${KORE_ID_TOKEN}
+EOF

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -47,6 +47,14 @@ test-e2e-nightly-eks-debug:
 	@echo "--> Running nightly E2E Tests for EKS (non-headless)"
 	@export SHOW_BROWSER=true && npm run test-e2e-nightly-eks
 
+test-e2e-nightly-aks:
+	@echo "--> Running nightly E2E Tests for AKS (headless)"
+	@export SHOW_BROWSER=false && npm run test-e2e-nightly-aks
+
+test-e2e-nightly-aks-debug:
+	@echo "--> Running nightly E2E Tests for AKS (non-headless)"
+	@export SHOW_BROWSER=true && npm run test-e2e-nightly-aks
+
 kind-e2e:
 	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e
 
@@ -64,6 +72,12 @@ kind-e2e-nightly-eks:
 
 kind-e2e-nightly-eks-debug:
 	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-nightly-eks-debug
+
+kind-e2e-nightly-aks:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-nightly-aks
+
+kind-e2e-nightly-aks-debug:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-nightly-aks-debug
 
 update-swagger:
 	@echo "--> Updating unit test / auto-gen swagger (requires API to be running locally)"

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -31,11 +31,39 @@ test-e2e-debug:
 	@echo "--> Running E2E Tests (non-headless)"
 	@export SHOW_BROWSER=true && npm run test-e2e
 
+test-e2e-nightly-gke:
+	@echo "--> Running nightly E2E Tests for GKE (headless)"
+	@export SHOW_BROWSER=false && npm run test-e2e-nightly-gke
+
+test-e2e-nightly-gke-debug:
+	@echo "--> Running nightly E2E Tests for GKE (non-headless)"
+	@export SHOW_BROWSER=true && npm run test-e2e-nightly-gke
+
+test-e2e-nightly-eks:
+	@echo "--> Running nightly E2E Tests for EKS (headless)"
+	@export SHOW_BROWSER=false && npm run test-e2e-nightly-eks
+
+test-e2e-nightly-eks-debug:
+	@echo "--> Running nightly E2E Tests for EKS (non-headless)"
+	@export SHOW_BROWSER=true && npm run test-e2e-nightly-eks
+
 kind-e2e:
 	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e
 
 kind-e2e-debug:
 	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-debug
+
+kind-e2e-nightly-gke:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-nightly-gke
+
+kind-e2e-nightly-gke-debug:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-nightly-gke-debug
+
+kind-e2e-nightly-eks:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-nightly-eks
+
+kind-e2e-nightly-eks-debug:
+	@export KORE_ADMIN_PASS="$(shell kubectl --context kind-kore -n kore get secret kore-api -o json | jq -r ".data.KORE_ADMIN_PASS" | base64 --decode)" && ${MAKE} test-e2e-nightly-eks-debug
 
 update-swagger:
 	@echo "--> Updating unit test / auto-gen swagger (requires API to be running locally)"

--- a/ui/__tests__/e2e/config.js
+++ b/ui/__tests__/e2e/config.js
@@ -3,6 +3,6 @@ module.exports = {
   adminPass: process.env.KORE_ADMIN_PASS || 'password',
   // Use longer timeout if we're showing the browser:
   timeout: process.env.SHOW_BROWSER !== 'true' ? 15000 : 60000,
-  expectTimeout: 1000,
+  expectTimeout: 3000,
   drawerOpenClosePause: 75
 }

--- a/ui/__tests__/e2e/nightly/aks.test.js
+++ b/ui/__tests__/e2e/nightly/aks.test.js
@@ -1,0 +1,14 @@
+const { TeamCluster } = require('./team-cluster')
+
+describe('AKS end-to-end', () => {
+  new TeamCluster({
+    provider: 'AKS',
+    plan: 'AKS Development Cluster',
+    timeouts: {
+      // 15 minutes
+      create: 15 * 60 * 1000,
+      // 20 minutes
+      delete: 20 * 60 * 1000,
+    }
+  }).run()
+})

--- a/ui/__tests__/e2e/nightly/eks.test.js
+++ b/ui/__tests__/e2e/nightly/eks.test.js
@@ -1,0 +1,14 @@
+const { TeamCluster } = require('./team-cluster')
+
+describe('EKS end-to-end', () => {
+  new TeamCluster({
+    provider: 'EKS',
+    plan: 'EKS Development Cluster',
+    timeouts: {
+      // 30 minutes
+      create: 30 * 60 * 1000,
+      // 20 minutes
+      delete: 20 * 60 * 1000,
+    }
+  }).run()
+})

--- a/ui/__tests__/e2e/nightly/gke.test.js
+++ b/ui/__tests__/e2e/nightly/gke.test.js
@@ -1,0 +1,14 @@
+const { TeamCluster } = require('./team-cluster')
+
+describe('GKE end-to-end', () => {
+  new TeamCluster({
+    provider: 'GKE',
+    plan: 'GKE Development Cluster',
+    timeouts: {
+      // 15 minutes
+      create: 15 * 60 * 1000,
+      // 10 minutes
+      delete: 10 * 60 * 1000,
+    }
+  }).run()
+})

--- a/ui/__tests__/e2e/nightly/team-cluster.js
+++ b/ui/__tests__/e2e/nightly/team-cluster.js
@@ -21,7 +21,8 @@ export class TeamCluster {
   getCloud(provider) {
     return {
       'GKE': 'GCP',
-      'EKS': 'AWS'
+      'EKS': 'AWS',
+      'AKS': 'Azure'
     }[provider.toUpperCase()]
   }
 

--- a/ui/__tests__/e2e/nightly/team-cluster.js
+++ b/ui/__tests__/e2e/nightly/team-cluster.js
@@ -1,0 +1,226 @@
+const { LoginPage } = require('../page-objects/login')
+const { IndexPage } = require('../page-objects/index')
+const { NewTeamPage } = require('../page-objects/teams/new-team')
+const { TeamPage } = require('../page-objects/teams')
+const { NewClusterPage } = require('../page-objects/teams/clusters/new-cluster')
+const { ClusterPage } = require('../page-objects/teams/clusters')
+const canonical = require('../../../lib/utils/canonical')
+const asyncForEach = require('../../../lib/utils/async-foreach')
+
+const page = global.page
+
+export class TeamCluster {
+  constructor({ provider, plan, timeouts }) {
+    this.provider = provider
+    this.cloud = this.getCloud(provider)
+    this.plan = plan
+    this.clusterCreateTimeout = timeouts.create
+    this.clusterDeleteTimeout = timeouts.delete
+  }
+
+  getCloud(provider) {
+    return {
+      'GKE': 'GCP',
+      'EKS': 'AWS'
+    }[provider.toUpperCase()]
+  }
+
+  run() {
+    const testTeam = {
+      // Randomise name of test team
+      name: `${this.provider} test ${Math.random().toString(36).substr(2, 5)}`,
+      description: 'Team created by automation testing'
+    }
+    const teamID = canonical(testTeam.name)
+    const clusterName = teamID
+    const namespaces = ['development', 'staging']
+
+    const loginPage = new LoginPage(page)
+    const indexPage = new IndexPage(page)
+    const newTeamPage = new NewTeamPage(page)
+    const teamPage = new TeamPage(page, teamID)
+    const newClusterPage = new NewClusterPage(page, teamID)
+    const clusterPage = new ClusterPage(page, teamID, clusterName)
+
+    describe('Login', () => {
+      it('logs in as an admin user', async () => {
+        // admin user login
+        await loginPage.visitPage()
+        await loginPage.localUserLogin()
+
+        // main dashboard
+        indexPage.verifyPageURL()
+      })
+    })
+
+    describe('Team with cluster and namespaces', () => {
+      beforeAll(async () => {
+        await indexPage.visitPage()
+        indexPage.verifyPageURL()
+      })
+
+      describe('Creating team', () => {
+        it('navigates to the new team page', async () => {
+          await indexPage.clickMenuLink('New team')
+        })
+
+        it('creates a new team', async () => {
+          await newTeamPage.populate(testTeam)
+          await newTeamPage.save()
+          await expect(page).toMatch('Team created')
+          await newTeamPage.checkTeamID(teamID)
+          await newTeamPage.skipToTeamDashboard()
+          await indexPage.checkForMenuLink(testTeam.name)
+          console.log('Team created', teamID)
+        })
+
+        it('show empty team dashboard', async () => {
+          teamPage.verifyPageURL()
+          await expect(page).toMatch('No clusters found for this team')
+          console.log('No clusters found for team', teamID)
+        })
+      })
+
+      describe('Creating cluster', () => {
+        it('navigates to the new cluster page', async () => {
+          await teamPage.newCluster()
+          newClusterPage.verifyPageURL()
+        })
+
+        it('requests a cluster', async () => {
+          await newClusterPage.populate({
+            cloud: this.cloud,
+            plan: this.plan,
+            name: clusterName
+          })
+          await newClusterPage.save()
+          console.log('Requested cluster with name', clusterName)
+        })
+
+        it('shows the cluster page with cluster status as pending', async () => {
+          clusterPage.verifyPageURL()
+          await clusterPage.checkClusterName()
+          await clusterPage.checkForClusterStatus('Pending')
+          console.log('Cluster found in pending status', clusterName)
+        })
+
+        it('waits for cluster to be successful', async () => {
+          // wait slightly less than the cluster create timeout to give the rest of the test a chance
+          await clusterPage.waitForClusterStatus(['Success', 'Failure'], this.clusterCreateTimeout - 30)
+          await clusterPage.checkForClusterStatus('Success')
+          console.log('Cluster created successfully', clusterName)
+        }, this.clusterCreateTimeout)
+      })
+
+      describe('Creating namespaces', () => {
+        beforeEach(async () => {
+          await clusterPage.closeAllNotifications()
+        })
+
+        it('creates namespaces', async () => {
+          await asyncForEach(namespaces, async (namespace) => {
+            await clusterPage.addNamespace()
+            await clusterPage.populateNamespace(namespace)
+            await clusterPage.saveNamespace()
+            await expect(page).toMatch(`Namespace "${namespace}" requested`)
+            console.log('Requested namespace with name', namespace)
+
+            // wait up to 10 seconds for the namespace to be created
+            await clusterPage.waitForNamespaceStatus(namespace, ['Success', 'Failure'], 10)
+            await clusterPage.checkForNamespace(namespace, 'Success')
+
+            await expect(page).toMatch(`Namespace "${namespace}" created`)
+            console.log('Namespace created successfully', namespace)
+          })
+        })
+      })
+
+      describe('Post-creation checks', () => {
+        it('navigates to the team page and shows the cluster and namespaces', async () => {
+          await teamPage.visitPage()
+          teamPage.verifyPageURL()
+          await teamPage.checkForCluster({ name: clusterName, plan: this.plan, namespaces })
+          console.log('Cluster found as expected on team page')
+        })
+
+        it('navigates to the cluster page and shows the namespaces', async () => {
+          await clusterPage.visitPage()
+          clusterPage.verifyPageURL()
+          await asyncForEach(namespaces, async (namespace) => {
+            await clusterPage.checkForNamespace(namespace)
+          })
+          console.log('Namespaces found as expected on cluster page')
+        })
+      })
+
+      describe('Deleting namespaces', () => {
+        beforeEach(async () => {
+          await clusterPage.closeAllNotifications()
+        })
+
+        it('deletes namespaces', async () => {
+          await asyncForEach(namespaces, async (namespace) => {
+            await clusterPage.deleteNamespace(namespace)
+            await clusterPage.deleteNamespaceConfirm()
+            await expect(page).toMatch(`Namespace deletion requested: ${clusterName}-${namespace}`)
+            console.log('Requested deletion of namespace with name', namespace)
+
+            // wait up to 10 seconds for the namespace to be deleted
+            await clusterPage.waitForNamespaceDeleted(namespace, 10)
+            await expect(page).toMatch(`Namespace "${namespace}" deleted`)
+            console.log('Namespace deleted successfully', namespace)
+          })
+        })
+
+        it('navigates to the cluster page and shows no namespaces', async () => {
+          await clusterPage.visitPage()
+          clusterPage.verifyPageURL()
+          await expect(page).toMatch('No namespaces found for this cluster')
+          console.log('Cluster found as expected on team page')
+        })
+      })
+
+      describe('Deleting cluster', () => {
+        beforeAll(async () => {
+          await teamPage.visitPage()
+          teamPage.verifyPageURL()
+        })
+
+        // overall timeout of 10 minutes
+        it('deletes the cluster', async () => {
+          await teamPage.deleteCluster(clusterName)
+          await teamPage.deleteClusterConfirm()
+          await expect(page).toMatch(`Cluster deletion requested: ${clusterName}`)
+          await teamPage.checkForClusterStatus(clusterName, 'Deleting')
+          console.log('Requested deletion of cluster', clusterName)
+
+          // wait up to 9 minutes for the cluster to be deleted
+          await teamPage.waitForClusterDeleted(clusterName, this.clusterDeleteTimeout - 30)
+          await expect(page).toMatch(`Cluster successfully deleted: ${clusterName}`)
+          console.log('Cluster deleted successfully', clusterName)
+        }, this.clusterDeleteTimeout)
+
+        it('navigates to the team page and shows no cluster', async () => {
+          await teamPage.visitPage()
+          teamPage.verifyPageURL()
+          await expect(page).toMatch('No clusters found for this team')
+          console.log('No clusters found for team', teamID)
+        })
+      })
+
+      describe('Deleting team', () => {
+        it('deletes the team', async () => {
+          await teamPage.deleteTeam()
+          await teamPage.deleteTeamConfirm()
+          await expect(page).toMatch(`Team "${teamID}" deleted`)
+          console.log('Team deleted', teamID)
+        })
+
+        it('shows the index page', async () => {
+          indexPage.verifyPageURL()
+        })
+      })
+
+    })
+  }
+}

--- a/ui/__tests__/e2e/page-objects/configure/cloud/GCP/organizations.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/GCP/organizations.js
@@ -29,7 +29,7 @@ export class ConfigureCloudGCPOrgs extends ConfigureCloudPage {
   }
 
   /**
-   * Checks if an specific org is listed
+   * Checks if a specific org is listed
    */
   async checkOrgListed(name) {
     await expect(this.p).toMatchElement(`#gcporg_${name}`)

--- a/ui/__tests__/e2e/page-objects/index.js
+++ b/ui/__tests__/e2e/page-objects/index.js
@@ -5,4 +5,12 @@ export class IndexPage extends BasePage {
     super(p)
     this.pagePath = '/'
   }
+
+  async checkForMenuLink(text) {
+    await expect(this.p).toMatchElement('#sider a', { text })
+  }
+
+  async clickMenuLink(text) {
+    await expect(this.p).toClick('#sider a', { text })
+  }
 }

--- a/ui/__tests__/e2e/page-objects/teams/clusters/index.js
+++ b/ui/__tests__/e2e/page-objects/teams/clusters/index.js
@@ -1,0 +1,65 @@
+const { BasePage } = require('../../base')
+import { clearFillTextInput, popConfirmYes, waitForDrawerOpenClose } from '../../utils'
+
+export class ClusterPage extends BasePage {
+  constructor(p, teamID, clusterName) {
+    super(p)
+    this.teamID = teamID
+    this.clusterName = clusterName
+    this.pagePath = `/teams/${teamID}/clusters/${clusterName}`
+  }
+
+  async checkClusterName() {
+    await expect(this.p).toMatchElement('#cluster_name', { text: this.clusterName, timeout: 5000 })
+  }
+
+  async checkForNamespace(name, status) {
+    await this.p.waitFor('.namespace')
+    await expect(this.p).toMatchElement(`#namespace_${name}`)
+    if (status) {
+      await expect(this.p).toMatchElement(`#namespace_status_${name}`, { text: status })
+    }
+  }
+
+  async checkForClusterStatus(status) {
+    await expect(this.p).toMatchElement('#cluster_status', { text: status })
+  }
+
+  async waitForClusterStatus(statusList, timeoutSeconds) {
+    const timeout = timeoutSeconds * 1000
+    await Promise.race(statusList.map(s => expect(this.p).toMatchElement('#cluster_status', { text: s, timeout })))
+  }
+
+  async waitForNamespaceStatus(name, statusList, timeoutSeconds) {
+    const timeout = timeoutSeconds * 1000
+    await Promise.race(statusList.map(s => expect(this.p).toMatchElement(`#namespace_status_${name}`, { text: s, timeout })))
+  }
+
+  async addNamespace() {
+    await expect(this.p).toClick('button', { text: 'New namespace' })
+    await waitForDrawerOpenClose(this.p)
+    await expect(this.p).toMatchElement('.ant-drawer-title', { text: 'New namespace' })
+  }
+
+  async populateNamespace(name) {
+    await clearFillTextInput(this.p, 'namespace_claim_name', name)
+  }
+
+  async saveNamespace() {
+    await this.p.click('button#save')
+    await waitForDrawerOpenClose(this.p)
+  }
+
+  async deleteNamespace(name) {
+    await expect(this.p).toClick(`#namespace_delete_${name}`)
+  }
+
+  async deleteNamespaceConfirm() {
+    await popConfirmYes(this.p, 'Are you sure you want to delete this namespace?')
+  }
+
+  async waitForNamespaceDeleted(namespaceName, timeoutSeconds) {
+    await this.p.waitFor(`#namespace_${namespaceName}`, { hidden: true, timeout: timeoutSeconds * 1000 })
+  }
+
+}

--- a/ui/__tests__/e2e/page-objects/teams/clusters/new-cluster.js
+++ b/ui/__tests__/e2e/page-objects/teams/clusters/new-cluster.js
@@ -1,0 +1,35 @@
+const { BasePage } = require('../../base')
+import { clearFillTextInput } from '../../utils'
+
+export class NewClusterPage extends BasePage {
+  constructor(p, teamID) {
+    super(p)
+    this.pagePath = `/teams/${teamID}/clusters/new`
+  }
+
+  /**
+   * Click the cloud selector, cloud can be one of gcp, aws or azure
+   * @param cloud
+   */
+  async selectCloud(cloud) {
+    expect(this.p).toClick(`#${cloud.toLowerCase()}`)
+  }
+
+  async selectPlan(plan) {
+    expect(this.p).toClick('#cluster_options_plan span', { text: plan })
+  }
+
+  async populate({ cloud, plan, name }) {
+    await this.selectCloud(cloud)
+    await this.selectPlan(plan)
+    await clearFillTextInput(this.p, 'cluster_options_clusterName', name)
+  }
+
+  async save() {
+    await Promise.all([
+      this.p.waitForNavigation(),
+      await this.p.click('button#save')
+    ])
+  }
+
+}

--- a/ui/__tests__/e2e/page-objects/teams/index.js
+++ b/ui/__tests__/e2e/page-objects/teams/index.js
@@ -1,0 +1,58 @@
+const { BasePage } = require('../base')
+const asyncForEach = require('../../../../lib/utils/async-foreach')
+import { modalYes, popConfirmYes } from '../utils'
+
+export class TeamPage extends BasePage {
+  constructor(p, teamID) {
+    super(p)
+    this.pagePath = `/teams/${teamID}`
+  }
+
+  async newCluster() {
+    await Promise.all([
+      this.p.waitForNavigation(),
+      expect(this.p).toClick('button', { text: 'New cluster' })
+    ])
+  }
+
+  async checkForCluster({ name, plan, namespaces }) {
+    await this.p.waitFor(`#cluster_${name}`)
+    // check cluster details
+    await expect(this.p).toMatchElement(`#cluster_${name}`)
+    await expect(this.p).toMatchElement(`#cluster_plan_${name}`, { text: plan })
+    await this.checkForClusterStatus(name, 'Success')
+    const namespaceScope = await this.p.$(`#cluster_namespaces_${name}`)
+    await asyncForEach(namespaces, async (namespace) => {
+      await expect(namespaceScope).toMatch(namespace)
+    })
+  }
+
+  async checkForClusterStatus(name, status) {
+    await expect(this.p).toMatchElement(`#cluster_status_${name}`, { text: status } )
+  }
+
+  async deleteCluster(name) {
+    expect(this.p).toClick(`#cluster_delete_${name}`)
+  }
+
+  async deleteClusterConfirm() {
+    await popConfirmYes(this.p, 'Are you sure you want to delete this cluster?')
+  }
+
+  async waitForClusterDeleted(name, timeoutSeconds) {
+    await this.p.waitFor(`#cluster_${name}`, { hidden: true, timeout: timeoutSeconds * 1000 })
+  }
+
+  async deleteTeam() {
+    await expect(this.p).toClick('#team_settings')
+    await expect(this.p).toClick('#delete_team')
+  }
+
+  async deleteTeamConfirm() {
+    await Promise.all([
+      this.p.waitForNavigation(),
+      modalYes(this.p, 'Are you sure you want to delete this team?')
+    ])
+  }
+
+}

--- a/ui/__tests__/e2e/page-objects/teams/new-team.js
+++ b/ui/__tests__/e2e/page-objects/teams/new-team.js
@@ -1,0 +1,31 @@
+const { BasePage } = require('../base')
+import { clearFillTextInput } from '../utils'
+
+export class NewTeamPage extends BasePage {
+  constructor(p) {
+    super(p)
+    this.pagePath = '/teams/new'
+  }
+
+  async populate({ name, description }) {
+    await clearFillTextInput(this.p, 'new_team_teamName', name)
+    await clearFillTextInput(this.p, 'new_team_teamDescription', description)
+  }
+
+  async checkTeamID(id) {
+    await expect(this.p).toMatchElement('#team_id', { text: id })
+  }
+
+  async save() {
+    await this.p.click('button#save')
+    await expect(this.p).toMatchElement('#created_team')
+  }
+
+  async skipToTeamDashboard() {
+    await Promise.all([
+      this.p.waitForNavigation(),
+      expect(this.p).toClick('button', { text: 'Skip to team dashboard' })
+    ])
+  }
+
+}

--- a/ui/__tests__/e2e/page-objects/utils.js
+++ b/ui/__tests__/e2e/page-objects/utils.js
@@ -53,6 +53,16 @@ export async function modalYes(pg, textToCheck) {
   await waitForDrawerOpenClose(pg)
 }
 
+export async function popConfirmYes(pg, textToCheck) {
+  if (textToCheck) {
+    await expect(pg).toMatch(textToCheck)
+  }
+  // tiny wait as otherwise puppeteer thinks the button is too small to click on
+  // see https://github.com/puppeteer/puppeteer/blob/6474edb9ba5ab6637361198b574dc64529eef26b/src/common/JSHandle.ts#L433
+  await pg.waitFor(100)
+  await expect(pg).toClick('.ant-popover-buttons .ant-btn-primary', { text: 'Yes' })
+}
+
 /**
  * The drawer open/close animation can take a short while before elements are clickable. 
  * Call this to wait for the drawer to complete opening/closing.

--- a/ui/lib/components/forms/NewTeamForm.js
+++ b/ui/lib/components/forms/NewTeamForm.js
@@ -114,7 +114,7 @@ class NewTeamForm extends React.Component {
         <Alert
           message={
             <div>
-              <Paragraph>The team ID is: <Text strong>{canonical(getFieldValue('teamName') || '')}</Text></Paragraph>
+              <Paragraph>The team ID is: <Text id="team_id" strong>{canonical(getFieldValue('teamName') || '')}</Text></Paragraph>
               <Paragraph style={{ marginBottom: '0' }}>This is how your team will appear when using the Kore CLI.</Paragraph>
             </div>
           }
@@ -122,7 +122,7 @@ class NewTeamForm extends React.Component {
         />
         {!this.props.team ? (
           <Form.Item style={{ marginTop: '20px' }}>
-            <Button type="primary" htmlType="submit" loading={this.state.submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
+            <Button id="save" type="primary" htmlType="submit" loading={this.state.submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
           </Form.Item>
         ) : null}
       </Form>

--- a/ui/lib/components/layout/SiderMenu.js
+++ b/ui/lib/components/layout/SiderMenu.js
@@ -86,6 +86,7 @@ class SiderMenu extends React.Component {
 
     return (
       <Sider
+        id="sider"
         collapsible
         collapsed={siderCollapsed}
         onCollapse={this.onSiderCollapse}

--- a/ui/lib/components/resources/ResourceStatusTag.js
+++ b/ui/lib/components/resources/ResourceStatusTag.js
@@ -3,12 +3,12 @@ import { statusColorMap, inProgressStatusList } from '../../utils/ui-helpers'
 import { Icon, Tag, Popover, Timeline, Typography } from 'antd'
 const { Text, Paragraph } = Typography
 
-const ResourceStatusTag = ({ resourceStatus }) => {
+const ResourceStatusTag = ({ resourceStatus, id }) => {
   const status = resourceStatus.status || 'Pending'
   const components = resourceStatus.components
   const conditions = resourceStatus.conditions
 
-  const statusTag = <Tag color={statusColorMap[status] || 'red'}>{inProgressStatusList.includes(status) ? <Icon type="loading" /> : null} {status}</Tag>
+  const statusTag = <Tag id={id} color={statusColorMap[status] || 'red'}>{inProgressStatusList.includes(status) ? <Icon type="loading" style={{ marginRight: '5px' }} /> : null}{status}</Tag>
 
   if (components) {
     return (
@@ -53,7 +53,8 @@ const ResourceStatusTag = ({ resourceStatus }) => {
 }
 
 ResourceStatusTag.propTypes = {
-  resourceStatus: PropTypes.object.isRequired
+  resourceStatus: PropTypes.object.isRequired,
+  id: PropTypes.string
 }
 
 export default ResourceStatusTag

--- a/ui/lib/components/teams/TeamSettings.js
+++ b/ui/lib/components/teams/TeamSettings.js
@@ -68,15 +68,15 @@ class TeamSettings extends React.Component {
             </a>
           </Link>
         </Menu.Item>
-        <Menu.Item key="delete" className="ant-btn-danger" onClick={this.deleteTeamConfirm}>
+        <Menu.Item key="delete" id="delete_team" className="ant-btn-danger" onClick={this.deleteTeamConfirm}>
           <Icon type="delete" style={{ marginRight: '5px' }} />
           Delete team
         </Menu.Item>
       </Menu>
     )
     return (
-      <Dropdown overlay={menu}>
-        <Button>
+      <Dropdown trigger={['click']} overlay={menu}>
+        <Button id="team_settings">
           <Icon type="setting" style={{ marginRight: '10px' }} />
           <Icon type="down" />
         </Button>

--- a/ui/lib/components/teams/cluster/Cluster.js
+++ b/ui/lib/components/teams/cluster/Cluster.js
@@ -65,21 +65,26 @@ class Cluster extends AutoRefreshComponent {
             okText="Yes"
             cancelText="No"
           >
-            <a><Tooltip title="Delete this cluster"><Icon type="delete" /></Tooltip></a>
+            <a id={`cluster_delete_${cluster.metadata.name}`}><Tooltip title="Delete this cluster"><Icon type="delete" /></Tooltip></a>
           </Popconfirm>
         )
         actions.push(deleteAction)
       }
 
-      actions.push(<ResourceStatusTag resourceStatus={cluster.status} />)
+      actions.push(<ResourceStatusTag id={`cluster_status_${cluster.metadata.name}`} resourceStatus={cluster.status} />)
       return actions
     }
 
     return (
-      <List.Item key={cluster.metadata.name} actions={actions()} style={{ paddingTop: 0, paddingBottom: '5px' }}>
+      <List.Item id={`cluster_${cluster.metadata.name}`} key={cluster.metadata.name} actions={actions()} style={{ paddingTop: 0, paddingBottom: '5px' }}>
         <List.Item.Meta
           avatar={<img src={clusterProviderIconSrcMap[cluster.spec.kind]} style={{ maxHeight:32, maxWidth: 32 }} />}
-          title={<><Link href="/teams/[name]/clusters/[cluster]/[tab]" as={`/teams/${team}/clusters/${cluster.metadata.name}/namespaces`}><a><Text style={{ marginRight: '15px', fontSize: '16px', textDecoration: 'underline' }}>{cluster.metadata.name}</Text></a></Link>{ plan && <Tag style={{ margin: 0 }}>{plan.spec.description}</Tag> }</>}
+          title={<>
+            <Link href="/teams/[name]/clusters/[cluster]/[tab]" as={`/teams/${team}/clusters/${cluster.metadata.name}/namespaces`}>
+              <a><Text style={{ marginRight: '15px', fontSize: '16px', textDecoration: 'underline' }}>{cluster.metadata.name}</Text></a>
+            </Link>
+            { plan && <Tag id={`cluster_plan_${cluster.metadata.name}`} style={{ margin: 0 }}>{plan.spec.description}</Tag> }
+          </>}
         />
         <div>
           <Text type='secondary'>Created {created}</Text>

--- a/ui/lib/components/teams/cluster/ClusterBuildForm.js
+++ b/ui/lib/components/teams/cluster/ClusterBuildForm.js
@@ -179,7 +179,7 @@ class ClusterBuildForm extends React.Component {
           wrappedComponentRef={inst => this.clusterOptionsForm = inst}
         />
         <Form.Item style={{ marginTop: '20px' }}>
-          <Button type="primary" htmlType="submit" loading={submitting}>
+          <Button id="save" type="primary" htmlType="submit" loading={submitting}>
             {this.state.submitButtonText}
           </Button>
         </Form.Item>

--- a/ui/lib/components/teams/cluster/ClustersTab.js
+++ b/ui/lib/components/teams/cluster/ClustersTab.js
@@ -91,7 +91,7 @@ class ClustersTab extends React.Component {
     } catch (err) {
       if (err.statusCode === 409 && err.dependents) {
         return Modal.warning({
-          title: 'The cluster can not be deleted',
+          title: 'The cluster cannot be deleted',
           content: (
             <div>
               <Paragraph strong>Error: {err.message}</Paragraph>
@@ -170,7 +170,9 @@ class ClustersTab extends React.Component {
                     propsResourceDataKey="cluster"
                     resourceApiRequest={async () => await (await KoreApi.client()).GetCluster(team.metadata.name, cluster.metadata.name)}
                   />
-                  {clusterNamespaceClaims.length > 0 && this.clusterResourceList({ resources: clusterNamespaceClaims, resourceDisplayPropertyPath: 'spec.name', title: 'Namespaces' })}
+                  <div id={`cluster_namespaces_${cluster.metadata.name}`}>
+                    {clusterNamespaceClaims.length > 0 && this.clusterResourceList({ resources: clusterNamespaceClaims, resourceDisplayPropertyPath: 'spec.name', title: 'Namespaces' })}
+                  </div>
                   {idx < clusters.length - 1 && <Divider />}
                 </React.Fragment>
               )

--- a/ui/lib/components/teams/namespace/NamespaceClaim.js
+++ b/ui/lib/components/teams/namespace/NamespaceClaim.js
@@ -55,18 +55,18 @@ class NamespaceClaim extends AutoRefreshComponent {
             okText="Yes"
             cancelText="No"
           >
-            <a><Icon type="delete" /></a>
+            <a id={`namespace_delete_${namespaceClaim.spec.name}`}><Icon type="delete" /></a>
           </Popconfirm>
         )
         actions.push(deleteAction)
       }
-      actions.push(<ResourceStatusTag resourceStatus={namespaceClaim.status} />)
+      actions.push(<ResourceStatusTag id={`namespace_status_${namespaceClaim.spec.name}`} resourceStatus={namespaceClaim.status} />)
       return actions
     }
 
     return (
-      <List.Item style={{ paddingTop: 0 }} actions={actions()}>
-        <List.Item.Meta style={{ marginLeft: '5px' }} title={namespaceClaim.spec.name} />
+      <List.Item className="namespace" id={`namespace_${namespaceClaim.spec.name}`} style={{ paddingTop: 0 }} actions={actions()}>
+        <List.Item.Meta style={{ marginLeft: '5px' }} title={<span>{namespaceClaim.spec.name}</span>} />
         <div>
           <Text type='secondary'>Created {created}</Text>
           {deleted && <Text type='secondary'><br/>Deleted {deleted}</Text>}

--- a/ui/lib/components/teams/namespace/NamespaceClaimForm.js
+++ b/ui/lib/components/teams/namespace/NamespaceClaimForm.js
@@ -106,7 +106,7 @@ class NamespaceClaimForm extends React.Component {
           )}
         </Form.Item>
         <Form.Item>
-          <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
+          <Button id="save" type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
           <Button type="link" onClick={this.cancel}>Cancel</Button>
         </Form.Item>
       </Form>

--- a/ui/lib/components/teams/namespace/NamespacesTab.js
+++ b/ui/lib/components/teams/namespace/NamespacesTab.js
@@ -142,7 +142,7 @@ class NamespacesTab extends React.Component {
     } catch (err) {
       if (err.statusCode === 409 && err.dependents) {
         return Modal.warning({
-          title: 'The namespace can not be deleted',
+          title: 'The namespace cannot be deleted',
           content: (
             <div>
               <Paragraph strong>Error: {err.message}</Paragraph>
@@ -233,7 +233,7 @@ class NamespacesTab extends React.Component {
           <Icon type="loading" />
         ) : (
           <>
-            {!hasNamespaces && <Paragraph type="secondary">No namespaces found for this team</Paragraph>}
+            {!hasNamespaces && <Paragraph type="secondary">No namespaces found for this cluster</Paragraph>}
 
             {namespaceClaims.map((namespaceClaim, idx) => {
               const filteredServiceCredentials = (serviceCredentials || []).filter(sc => sc.spec.clusterNamespace === namespaceClaim.spec.name)

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,9 @@
     "dev": "nodemon",
     "test": "jest --verbose --testPathPattern __tests__/unit",
     "test-watch": "npm test -- --watch",
-    "test-e2e": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/*.test.js",
+    "test-e2e": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/*.test.js --testPathIgnorePatterns nightly",
+    "test-e2e-nightly-gke": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/nightly/gke.test.js",
+    "test-e2e-nightly-eks": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/nightly/eks.test.js",
     "build": "next build",
     "start": "NODE_ENV=production node server/index.js",
     "lint": "eslint ."

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
     "test-e2e": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/*.test.js --testPathIgnorePatterns nightly",
     "test-e2e-nightly-gke": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/nightly/gke.test.js",
     "test-e2e-nightly-eks": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/nightly/eks.test.js",
+    "test-e2e-nightly-aks": "jest --verbose --preset jest-puppeteer --testSequencer ./__tests__/e2e/sequencer.js --runInBand --testMatch **/__tests__/e2e/nightly/aks.test.js",
     "build": "next build",
     "start": "NODE_ENV=production node server/index.js",
     "lint": "eslint ."

--- a/ui/pages/teams/[name]/clusters/[cluster]/[tab].js
+++ b/ui/pages/teams/[name]/clusters/[cluster]/[tab].js
@@ -190,7 +190,7 @@ class ClusterPage extends React.Component {
               <List.Item.Meta
                 className="large-list-item"
                 avatar={<img src={clusterProviderIconSrcMap[cluster.spec.kind]} />}
-                title={<Text style={{ marginTop: '15px', display: 'block' }}>{cluster.metadata.name}</Text>}
+                title={<Text id="cluster_name" style={{ marginTop: '15px', display: 'block' }}>{cluster.metadata.name}</Text>}
                 description={
                   <div>
                     <Text type='secondary'>Created {created}</Text>
@@ -205,7 +205,7 @@ class ClusterPage extends React.Component {
           </Col>
           <Col span={24} xl={12} style={{ marginTop: '14px' }}>
             <Collapse style={{ marginTop: '12px', marginBottom: '20px' }}>
-              <Collapse.Panel header="Detailed Cluster Status" extra={(<ResourceStatusTag resourceStatus={cluster.status} />)}>
+              <Collapse.Panel header="Detailed Cluster Status" extra={(<ResourceStatusTag id="cluster_status" resourceStatus={cluster.status} />)}>
                 <ComponentStatusTree team={team} user={user} component={cluster} />
               </Collapse.Panel>
             </Collapse>

--- a/ui/pages/teams/new.js
+++ b/ui/pages/teams/new.js
@@ -111,7 +111,7 @@ class NewTeamPage extends React.Component {
           handleTeamCreated={this.handleTeamCreated}
         />
         {team ? (
-          <div>
+          <div id="created_team">
             <Alert
               message={
                 <div>

--- a/ui/server/services/org.js
+++ b/ui/server/services/org.js
@@ -103,14 +103,18 @@ class OrgService {
   async hasTeamCredentials(team, requestingIdToken) {
     try {
       const api = await this.getApiClient(requestingIdToken)
-      const [ gkeCredentialsList, gcpOrgList, eksCredentialsList ] = await Promise.all([
+      const [ gkeCredentialsList, gcpOrgList, eksCredentialsList, awsOrgList, aksCredentialsList ] = await Promise.all([
         api.ListGKECredentials(team),
         api.ListGCPOrganizations(team),
-        api.ListEKSCredentials(team)
+        api.ListEKSCredentials(team),
+        api.ListAWSOrganizations(team),
+        api.ListAKSCredentials(team)
       ])
       return gkeCredentialsList.items.length !== 0 ||
         gcpOrgList.items.length !== 0 ||
-        eksCredentialsList.items.length !== 0
+        eksCredentialsList.items.length !== 0 ||
+        awsOrgList.items.length !== 0 ||
+        aksCredentialsList.items.length !== 0
     } catch (err) {
       console.error('Error checking for team credentials from API', err)
       return Promise.reject(err)


### PR DESCRIPTION
## Summary

UI E2E tests to be run nightly, or as requested.

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1021

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~

## Changes

Adding E2E tests for the UI, broken down by cluster provider.
Triggered along with the API E2E tests
Added as part of the prereqs for publishing a release

## Screenshots

<img width="1317" alt="Screen Shot 2020-08-05 at 21 28 30" src="https://user-images.githubusercontent.com/1334068/89460866-e95a5680-d762-11ea-80ed-af697c388a74.png">

