### PR TITLE
Adding cluster view/edit cost estimates

### DIFF
--- a/ui/lib/components/costs/CostEstimate.js
+++ b/ui/lib/components/costs/CostEstimate.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 import { Alert } from 'antd'
-import { debounce } from 'lodash'
+import { debounce, isEqual } from 'lodash'
 
 import KoreApi from '../../kore-api'
 import CostBreakdown from './CostBreakdown'
@@ -40,7 +40,7 @@ export default class CostEstimate extends React.Component {
     }
 
     // Update the estimate (with a debounce) when the plan values change
-    if (!prevProps || prevProps.planValues !== this.props.planValues) {
+    if (!prevProps || !isEqual(prevProps.planValues, this.props.planValues)) {
       if (!this.state.estimating) {
         this.setState({ estimating: true })
       }

--- a/ui/lib/components/plans/custom/PlanOptionVersion.js
+++ b/ui/lib/components/plans/custom/PlanOptionVersion.js
@@ -64,7 +64,6 @@ export default class PlanOptionVersion extends PlanOptionBase {
         minorVersions.push(v.split('.').filter((e, i) => i <= 2).join('.').replace(/[^0-9.]+/g, ''))
       }
     })
-    console.log('expanding versions', minorVersions)
     return uniq([ ...minorVersions, ...versions ]).sort()
   }
 

--- a/ui/pages/teams/[name]/clusters/[cluster]/[tab].js
+++ b/ui/pages/teams/[name]/clusters/[cluster]/[tab].js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types'
 import Router from 'next/router'
 import moment from 'moment'
 import {
-  Typography,
-  Collapse,
-  Row,
-  Col,
-  List,
   Button,
+  Col,
+  Collapse,
   Form,
-  Tabs
+  List,
+  Row,
+  Tabs,
+  Typography,
 } from 'antd'
 const { Text } = Typography
 const { TabPane } = Tabs
@@ -30,6 +30,7 @@ import { isReadOnlyCRD } from '../../../../../lib/utils/crd-helpers'
 import ServicesTab from '../../../../../lib/components/teams/service/ServicesTab'
 import NamespacesTab from '../../../../../lib/components/teams/namespace/NamespacesTab'
 import TextWithCount from '../../../../../lib/components/utils/TextWithCount'
+import CostEstimate from '../../../../../lib/components/costs/CostEstimate'
 
 class ClusterPage extends React.Component {
   static propTypes = {
@@ -67,20 +68,8 @@ class ClusterPage extends React.Component {
     return { team, cluster, tabActiveKey }
   }
 
-  fetchCommonData = async () => {
-    if (featureEnabled(KoreFeatures.SERVICES)) {
-      const serviceKinds = await (await KoreApi.client()).ListServiceKinds()
-      return { serviceKinds: serviceKinds.items }
-    }
-
-    return {}
-  }
-
   componentDidMount() {
     this.startRefreshing()
-    this.fetchCommonData().then(data => {
-      this.setState({ ...data })
-    })
   }
 
   componentDidUpdate() {
@@ -230,6 +219,16 @@ class ClusterPage extends React.Component {
           )}
 
           <TabPane key="settings" tab="Settings" forceRender={true}>
+            <Collapse style={{ marginBottom: '20px' }}>
+              <Collapse.Panel header="Cost Estimate">
+                <CostEstimate
+                  planValues={this.state.clusterParams}
+                  resourceType="cluster"
+                  kind={cluster.spec.kind}
+                />
+              </Collapse.Panel>
+            </Collapse>
+
             <Form {...editClusterFormConfig} onSubmit={(e) => this.onSubmit(e)}>
               <FormErrorMessage message={this.state.formErrorMessage} />
               <Form.Item label="" colon={false}>


### PR DESCRIPTION
Adding cost estimates to already existing clusters

## Summary

Please provide a short summary about the changes in this PR.

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1050

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~

## Changes

* removing redundant API request for service kinds on cluster page
* fixing plan values equality check in `CostEstimate` component - to prevent a refresh every time the component is updated
* removing unwanted console.log

## Screenshots

<img width="1303" alt="Screen Shot 2020-08-06 at 11 38 56" src="https://user-images.githubusercontent.com/1334068/89522671-81932280-d7d9-11ea-8037-7a85175ffc03.png">

## Testing

Ensure kore is running with kore-costs feature enabled
Create a cluster, view the settings tab
See the costs
Edit some configuration eg add a node pool and see the cost estimate change

