### PR TITLE
Respect node pool/group field immutable flags on the UI and field visibility changes

### DIFF
--- a/ui/lib/components/plans/PlanOption.js
+++ b/ui/lib/components/plans/PlanOption.js
@@ -21,10 +21,10 @@ export default class PlanOption extends PlanOptionBase {
   }
 
   render() {
-    const { resourceType, kind, name, property, value, editable, hideNonEditable, disableCustom } = this.props
+    const { resourceType, kind, name, property, value, editable, forceShow, disableCustom } = this.props
     const { onChange, displayName, help, valueOrDefault, id } = this.prepCommonProps(this.props)
 
-    if (!editable && hideNonEditable) {
+    if (!editable && !forceShow) {
       return null
     }
 

--- a/ui/lib/components/plans/PlanOption.js
+++ b/ui/lib/components/plans/PlanOption.js
@@ -82,21 +82,21 @@ export default class PlanOption extends PlanOptionBase {
           switch(property.type) {
           case 'string': {
             if (property.format === 'multiline') {
-              return <TextArea id={id} value={valueOrDefault} readOnly={!editable} onChange={(e) => onChange(name, e.target.value)} rows='20' />
+              return <TextArea id={id} value={valueOrDefault} disabled={!editable} onChange={(e) => onChange(name, e.target.value)} rows='20' />
             } else if (property.enum) {
               return <ConstrainedDropdown id={id} readOnly={!editable} value={valueOrDefault} allowedValues={property.enum} onChange={(e) => onChange(name, e)} />
             } else {
-              return <Input id={id} value={valueOrDefault} readOnly={!editable} pattern={property.pattern} onChange={(e) => onChange(name, e.target.value)} />
+              return <Input id={id} value={valueOrDefault} disabled={!editable} pattern={property.pattern} onChange={(e) => onChange(name, e.target.value)} />
             }
           }
           case 'boolean': {
             return <Switch id={id} checked={valueOrDefault} disabled={!editable} onChange={(v) => onChange(name, v)} checkedChildren={<Icon type="check" />} unCheckedChildren={<Icon type="close" />} />
           }
           case 'number': {
-            return <InputNumber id={id} value={valueOrDefault} readOnly={!editable} onChange={(v) => onChange(name, v)} />
+            return <InputNumber id={id} value={valueOrDefault} disabled={!editable} onChange={(v) => onChange(name, v)} />
           }
           case 'integer': {
-            return <InputNumber id={id} value={valueOrDefault} readOnly={!editable} onChange={(v) => onChange(name, v)} />
+            return <InputNumber id={id} value={valueOrDefault} disabled={!editable} onChange={(v) => onChange(name, v)} />
           }
           case 'array': {
             const values = valueOrDefault ? valueOrDefault : []

--- a/ui/lib/components/plans/PlanOptionBase.js
+++ b/ui/lib/components/plans/PlanOptionBase.js
@@ -106,13 +106,12 @@ export default class PlanOptionBase extends React.Component {
     const id = props.id || `plan_input_${name}`
     return { onChange, displayName, help, defaultValue, valueOrDefault, id }
   }
-
-  isEditable(name) {
+  isEditable(property) {
     // quick return if the property is not editable
+    // this is in case of checking an array property and the parent property is set to not-editable
     if (!this.props.editable) {
       return false
     }
-    const property = this.props.property.items.properties[name]
     const { manage, mode } = this.props
     return mode !== 'view' &&
       (property.const === undefined || property.const === null) &&

--- a/ui/lib/components/plans/PlanOptionBase.js
+++ b/ui/lib/components/plans/PlanOptionBase.js
@@ -13,7 +13,7 @@ export default class PlanOptionBase extends React.Component {
     property: PropTypes.object.isRequired,
     value: PropTypes.any,
     editable: PropTypes.bool,
-    hideNonEditable: PropTypes.bool,
+    forceShow: PropTypes.bool,
     onChange: PropTypes.func,
     displayName: PropTypes.string,
     validationErrors: PropTypes.array,
@@ -106,6 +106,7 @@ export default class PlanOptionBase extends React.Component {
     const id = props.id || `plan_input_${name}`
     return { onChange, displayName, help, defaultValue, valueOrDefault, id }
   }
+
   isEditable(property) {
     // quick return if the property is not editable
     // this is in case of checking an array property and the parent property is set to not-editable

--- a/ui/lib/components/plans/PlanOptionBase.js
+++ b/ui/lib/components/plans/PlanOptionBase.js
@@ -9,6 +9,7 @@ export default class PlanOptionBase extends React.Component {
     kind: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     plan: PropTypes.object.isRequired,
+    originalPlan: PropTypes.object,
     property: PropTypes.object.isRequired,
     value: PropTypes.any,
     editable: PropTypes.bool,

--- a/ui/lib/components/plans/PlanOptionBase.js
+++ b/ui/lib/components/plans/PlanOptionBase.js
@@ -105,4 +105,16 @@ export default class PlanOptionBase extends React.Component {
     const id = props.id || `plan_input_${name}`
     return { onChange, displayName, help, defaultValue, valueOrDefault, id }
   }
+
+  isEditable(name) {
+    // quick return if the property is not editable
+    if (!this.props.editable) {
+      return false
+    }
+    const property = this.props.property.items.properties[name]
+    const { manage, mode } = this.props
+    return mode !== 'view' &&
+      (property.const === undefined || property.const === null) &&
+      (mode === 'create' || manage || !property.immutable)
+  }
 }

--- a/ui/lib/components/plans/PlanViewEdit.js
+++ b/ui/lib/components/plans/PlanViewEdit.js
@@ -2,7 +2,9 @@ import * as React from 'react'
 import PropTypes from 'prop-types'
 import { Switch, Typography } from 'antd'
 const { Paragraph, Text } = Typography
+
 import PlanOption from './PlanOption'
+import IconTooltip from '../utils/IconTooltip'
 
 /**
  * PlanViewEdit is the underlying component which handles all plan viewing and editing. Most likely, you
@@ -25,25 +27,25 @@ export default class PlanViewEdit extends React.Component {
 
   constructor(props) {
     super(props)
-    this.state = { showAll: props.manage === true }
+    this.state = { showReadOnly: props.manage === true }
   }
 
   componentDidUpdate(prevProps) {
     if (this.props.mode !== prevProps.mode) {
-      this.setState({ showAll: this.props.manage === true })
+      this.setState({ showReadOnly: this.props.manage === true })
     }
   }
 
   render() {
     const { resourceType, mode, manage, team, kind, plan, originalPlan, schema, editableParams, onPlanValueChange, validationErrors } = this.props
-    const showAll = this.state.showAll
+    const showReadOnly = this.state.showReadOnly
 
     return (
       <>
         {manage ? null : (
           <Paragraph>
-            <Text strong style={{ marginRight: '10px' }}>Show all parameters</Text>
-            <Switch checked={showAll} onChange={(showAll) => this.setState({ showAll })} />
+            <Text strong style={{ marginRight: '10px' }}>Show read-only parameters <IconTooltip text="Parameters may be read-only as defined by the plan policy or may only be editable on cluster creation. Turn this on to see these parameters." icon="info-circle" /></Text>
+            <Switch checked={showReadOnly} onChange={(showReadOnly) => this.setState({ showReadOnly })} />
           </Paragraph>
         )}
 
@@ -53,8 +55,8 @@ export default class PlanViewEdit extends React.Component {
             (schema.properties[name].const === undefined || schema.properties[name].const === null) &&
             (mode === 'create' || manage || !schema.properties[name].immutable) // Disallow editing of params which can only be set at create time when in 'use' mode
           // always show properties that are editable according to the policy, even when in view mode
-          // properties not editable by the policy can be shown by enabling showAll
-          const forceShow = showAll || (mode === 'view' && (editableParams.includes('*') || editableParams.includes(name)))
+          // properties not editable by the policy can be shown by enabling showReadOnly
+          const forceShow = showReadOnly || (mode === 'view' && (editableParams.includes('*') || editableParams.includes(name)))
 
           return (
             <PlanOption

--- a/ui/lib/components/plans/PlanViewEdit.js
+++ b/ui/lib/components/plans/PlanViewEdit.js
@@ -15,6 +15,7 @@ export default class PlanViewEdit extends React.Component {
     team: PropTypes.object,
     kind: PropTypes.string.isRequired,
     plan: PropTypes.object.isRequired,
+    originalPlan: PropTypes.object,
     schema: PropTypes.object.isRequired,
     editableParams: PropTypes.array.isRequired,
     onPlanValueChange: PropTypes.func,
@@ -39,7 +40,7 @@ export default class PlanViewEdit extends React.Component {
   }
 
   render() {
-    const { resourceType, mode, manage, team, kind, plan, schema, editableParams, onPlanValueChange, validationErrors } = this.props
+    const { resourceType, mode, manage, team, kind, plan, originalPlan, schema, editableParams, onPlanValueChange, validationErrors } = this.props
     const { showReadOnly } = this.state
     return (
       <>
@@ -63,6 +64,7 @@ export default class PlanViewEdit extends React.Component {
               resourceType={resourceType}
               kind={kind}
               plan={plan}
+              originalPlan={originalPlan}
               key={name}
               name={name}
               property={schema.properties[name]}

--- a/ui/lib/components/plans/UsePlanForm.js
+++ b/ui/lib/components/plans/UsePlanForm.js
@@ -20,6 +20,7 @@ class UsePlanForm extends React.Component {
     kind: PropTypes.string.isRequired,
     plan: PropTypes.string.isRequired,
     planValues: PropTypes.object,
+    originalPlanValues: PropTypes.object,
     onPlanValuesChange: PropTypes.func,
     validationErrors: PropTypes.array,
     mode: PropTypes.oneOf(['create', 'edit', 'view']).isRequired,
@@ -145,6 +146,7 @@ class UsePlanForm extends React.Component {
           team={this.props.team}
           kind={this.props.kind}
           plan={this.state.planValues}
+          originalPlan={this.props.originalPlanValues}
           schema={this.state.schema}
           editableParams={this.state.editableParams}
           onPlanValueChange={(n, v) => this.onValueChange(n, v)}

--- a/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
+++ b/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
@@ -111,6 +111,14 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
     return actions
   }
 
+  isEditable = (name) => {
+    // always allow editing if the node pool is not part of the original pre-edited plan
+    if (this.props.originalPlan && !this.props.originalPlan.nodePools[this.state.selectedIndex]) {
+      return true
+    }
+    return super.isEditable(name)
+  }
+
   render() {
     const { name, editable, property, plan } = this.props
     const { displayName, valueOrDefault } = this.prepCommonProps(this.props, [])

--- a/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
+++ b/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
@@ -8,6 +8,7 @@ import ConstrainedDropdown from './ConstrainedDropdown'
 import PlanOption from '../PlanOption'
 import PlanOptionClusterMachineType from './PlanOptionClusterMachineType'
 import NodePoolCost from '../../costs/NodePoolCost'
+import IconTooltip from '../../utils/IconTooltip'
 
 const imageTypes = [
   { value: 'Linux', display: 'Linux' },
@@ -123,7 +124,7 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
   render() {
     const { name, editable, property, plan, manage } = this.props
     const { displayName, valueOrDefault } = this.prepCommonProps(this.props, [])
-    const { selectedIndex, prices, showAll } = this.state
+    const { selectedIndex, prices, showReadOnly } = this.state
     const id_prefix = 'plan_nodepool'
     const selected = selectedIndex >= 0 ? valueOrDefault[selectedIndex] : null
     const description = manage ? 'Default node pools for clusters created from this plan' : null
@@ -168,13 +169,13 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
             <>
               {manage ? null : (
                 <Paragraph>
-                  <Text strong style={{ marginRight: '10px' }}>Show all parameters</Text>
-                  <Switch checked={showAll} onChange={(showAll) => this.setState({ showAll })} />
+                  <Text strong style={{ marginRight: '10px' }}>Show read-only parameters <IconTooltip text="Parameters may be read-only as defined by the plan policy or may be editable on cluster creation only. Turn this on to see these parameters." icon="info-circle" placement="bottom" /></Text>
+                  <Switch checked={showReadOnly} onChange={(showReadOnly) => this.setState({ showReadOnly })} />
                 </Paragraph>
               )}
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, versions, sizing)">
-                  {this.isEditable(property.items.properties.name) || showAll ? (
+                  {this.isEditable(property.items.properties.name) || showReadOnly ? (
                     <Form.Item label="Name" help="Unique name for this group within the cluster">
                       <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
                       {this.validationErrors(`${name}[${selectedIndex}].name`)}
@@ -183,16 +184,16 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
                     </Form.Item>
                   ) : null}
 
-                  {this.isEditable(property.items.properties.mode) || showAll ? (
+                  {this.isEditable(property.items.properties.mode) || showReadOnly ? (
                     <Form.Item label="Mode" help="Type of the node pool. System node pools serve the primary purpose of hosting critical system pods such as CoreDNS and tunnelfront. User node pools serve the primary purpose of hosting your application pods.">
                       <ConstrainedDropdown id={`${id_prefix}_mode`} allowedValues={modes} value={selected.mode} readOnly={!this.isEditable(property.items.properties.mode)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'mode', v)} />
                       {this.validationErrors(`${name}[${selectedIndex}].mode`)}
                     </Form.Item>
                   ) : null}
 
-                  <PlanOption id={`${id_prefix}_version`} {...this.props} forceShow={showAll} displayName="Version" name={`${name}[${selectedIndex}].version`} property={property.items.properties.version} value={selected.version} disabled={!this.isEditable(property.items.properties.version)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'version', v)} />
+                  <PlanOption id={`${id_prefix}_version`} {...this.props} forceShow={showReadOnly} displayName="Version" name={`${name}[${selectedIndex}].version`} property={property.items.properties.version} value={selected.version} disabled={!this.isEditable(property.items.properties.version)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'version', v)} />
 
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} forceShow={showAll} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} disabled={!this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} forceShow={showReadOnly} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} disabled={!this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Pool size">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
@@ -210,21 +211,21 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
                     </Descriptions>
                   </Form.Item>
                   <NodePoolCost prices={prices} nodePool={selected} help="Adjust pool size and machine type to see the cost impacts" />
-                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} forceShow={showAll} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable(property.items.properties.maxPodsPerNode)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
+                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} forceShow={showReadOnly} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable(property.items.properties.maxPodsPerNode)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (image type, machine type, disk size)">
-                  {this.isEditable(property.items.properties.imageType) || showAll ? (
+                  {this.isEditable(property.items.properties.imageType) || showReadOnly ? (
                     <Form.Item label="Image Type" help="The image type used by the nodes">
                       <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} readOnly={!this.isEditable(property.items.properties.imageType)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
                       {this.validationErrors(`${name}[${selectedIndex}].imageType`)}
                     </Form.Item>
                   ) : null}
-                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} forceShow={showAll} editable={this.isEditable(property.items.properties.machineType)} displayName="Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} forceShow={showReadOnly} editable={this.isEditable(property.items.properties.machineType)} displayName="Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
                   <PlanOption id={`${id_prefix}_diskSize`} {...this.props} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Labels & Taints">
-                  <PlanOption id={`${id_prefix}_labels`} {...this.props} forceShow={showAll} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption id={`${id_prefix}_taints`} {...this.props} forceShow={showAll} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable(property.items.properties.taints)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
+                  <PlanOption id={`${id_prefix}_labels`} {...this.props} forceShow={showReadOnly} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption id={`${id_prefix}_taints`} {...this.props} forceShow={showReadOnly} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable(property.items.properties.taints)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item style={{ marginTop: '20px' }}>

--- a/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
+++ b/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
@@ -111,12 +111,12 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
     return actions
   }
 
-  isEditable = (name) => {
+  isEditable = (property) => {
     // always allow editing if the node pool is not part of the original pre-edited plan
     if (this.props.originalPlan && !this.props.originalPlan.nodePools[this.state.selectedIndex]) {
       return true
     }
-    return super.isEditable(name)
+    return super.isEditable(property)
   }
 
   render() {
@@ -168,50 +168,50 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, versions, sizing)">
                   <Form.Item label="Name" help="Unique name for this group within the cluster">
-                    <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable('name')} />
+                    <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
                     {this.validationErrors(`${name}[${selectedIndex}].name`)}
                     {!ngNameClash ? null : <Alert type="error" message="This name is already used by another node pool, it must be changed." />}
                     {selected.name && selected.name.match(property.items.properties.name.pattern) ? null : <Alert type="error" message="Name must be minimum 2, maximum 40 alpha-numeric characters and hyphens" />}
                   </Form.Item>
 
                   <Form.Item label="Mode" help="Type of the node pool. System node pools serve the primary purpose of hosting critical system pods such as CoreDNS and tunnelfront. User node pools serve the primary purpose of hosting your application pods.">
-                    <ConstrainedDropdown id={`${id_prefix}_mode`} allowedValues={modes} value={selected.mode} readOnly={!this.isEditable('mode')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'mode', v)} />
+                    <ConstrainedDropdown id={`${id_prefix}_mode`} allowedValues={modes} value={selected.mode} readOnly={!this.isEditable(property.items.properties.mode)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'mode', v)} />
                     {this.validationErrors(`${name}[${selectedIndex}].mode`)}
                   </Form.Item>
 
-                  <PlanOption id={`${id_prefix}_version`} {...this.props} hideNonEditable={false} displayName="Version" name={`${name}[${selectedIndex}].version`} property={property.items.properties.version} value={selected.version} disabled={!this.isEditable('version')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'version', v)} />
+                  <PlanOption id={`${id_prefix}_version`} {...this.props} hideNonEditable={false} displayName="Version" name={`${name}[${selectedIndex}].version`} property={property.items.properties.version} value={selected.version} disabled={!this.isEditable(property.items.properties.version)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'version', v)} />
 
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} disabled={!this.isEditable('enableAutoscaler')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} disabled={!this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Pool size">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
-                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable('minSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
+                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable(property.items.properties.minSize)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].minSize`)}
                       </Descriptions.Item>}
                       <Descriptions.Item label={selected.enableAutoscaler ? 'Initial size' : null}>
-                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} disabled={!this.isEditable('size')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
+                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} disabled={!this.isEditable(property.items.properties.size)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].size`)}
                       </Descriptions.Item>
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Maximum">
-                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} disabled={!this.isEditable('maxSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
+                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} disabled={!this.isEditable(property.items.properties.maxSize)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].maxSize`)}
                       </Descriptions.Item>}
                     </Descriptions>
                   </Form.Item>
                   <NodePoolCost prices={prices} nodePool={selected} help="Adjust pool size and machine type to see the cost impacts" />
-                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} hideNonEditable={false} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable('maxPodsPerNode')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
+                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} hideNonEditable={false} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable(property.items.properties.maxPodsPerNode)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (image type, machine type, disk size)">
                   <Form.Item label="Image Type" help="The image type used by the nodes">
-                    <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} readOnly={!this.isEditable('imageType')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
+                    <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} readOnly={!this.isEditable(property.items.properties.imageType)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
                     {this.validationErrors(`${name}[${selectedIndex}].imageType`)}
                   </Form.Item>
-                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} editable={this.isEditable('machineType')} displayName="Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable('diskSize')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} editable={this.isEditable(property.items.properties.machineType)} displayName="Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Labels & Taints">
-                  <PlanOption id={`${id_prefix}_labels`} {...this.props} hideNonEditable={false} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable('labels')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption id={`${id_prefix}_taints`} {...this.props} hideNonEditable={false} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable('taints')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
+                  <PlanOption id={`${id_prefix}_labels`} {...this.props} hideNonEditable={false} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption id={`${id_prefix}_taints`} {...this.props} hideNonEditable={false} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable(property.items.properties.taints)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item>

--- a/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
+++ b/ui/lib/components/plans/custom/PlanOptionAKSNodePools.js
@@ -160,50 +160,50 @@ export default class PlanOptionAKSNodePools extends PlanOptionBase {
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, versions, sizing)">
                   <Form.Item label="Name" help="Unique name for this group within the cluster">
-                    <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} readOnly={!editable} />
+                    <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable('name')} />
                     {this.validationErrors(`${name}[${selectedIndex}].name`)}
                     {!ngNameClash ? null : <Alert type="error" message="This name is already used by another node pool, it must be changed." />}
                     {selected.name && selected.name.match(property.items.properties.name.pattern) ? null : <Alert type="error" message="Name must be minimum 2, maximum 40 alpha-numeric characters and hyphens" />}
                   </Form.Item>
 
                   <Form.Item label="Mode" help="Type of the node pool. System node pools serve the primary purpose of hosting critical system pods such as CoreDNS and tunnelfront. User node pools serve the primary purpose of hosting your application pods.">
-                    <ConstrainedDropdown id={`${id_prefix}_mode`} allowedValues={modes} value={selected.mode} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'mode', v)} />
+                    <ConstrainedDropdown id={`${id_prefix}_mode`} allowedValues={modes} value={selected.mode} readOnly={!this.isEditable('mode')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'mode', v)} />
                     {this.validationErrors(`${name}[${selectedIndex}].mode`)}
                   </Form.Item>
 
-                  <PlanOption id={`${id_prefix}_version`} {...this.props} displayName="Version" name={`${name}[${selectedIndex}].version`} property={property.items.properties.version} value={selected.version} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'version', v)} />
+                  <PlanOption id={`${id_prefix}_version`} {...this.props} hideNonEditable={false} displayName="Version" name={`${name}[${selectedIndex}].version`} property={property.items.properties.version} value={selected.version} disabled={!this.isEditable('version')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'version', v)} />
 
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} disabled={!this.isEditable('enableAutoscaler')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Pool size">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
-                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} readOnly={!editable} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
+                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable('minSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].minSize`)}
                       </Descriptions.Item>}
                       <Descriptions.Item label={selected.enableAutoscaler ? 'Initial size' : null}>
-                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} readOnly={!editable} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
+                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} disabled={!this.isEditable('size')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].size`)}
                       </Descriptions.Item>
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Maximum">
-                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} readOnly={!editable} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
+                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} disabled={!this.isEditable('maxSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].maxSize`)}
                       </Descriptions.Item>}
                     </Descriptions>
                   </Form.Item>
                   <NodePoolCost prices={prices} nodePool={selected} help="Adjust pool size and machine type to see the cost impacts" />
-                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
+                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} hideNonEditable={false} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable('maxPodsPerNode')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (image type, machine type, disk size)">
                   <Form.Item label="Image Type" help="The image type used by the nodes">
-                    <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
+                    <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} readOnly={!this.isEditable('imageType')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
                     {this.validationErrors(`${name}[${selectedIndex}].imageType`)}
                   </Form.Item>
-                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} displayName="Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} editable={this.isEditable('machineType')} displayName="Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable('diskSize')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Labels & Taints">
-                  <PlanOption id={`${id_prefix}_labels`} {...this.props} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption id={`${id_prefix}_taints`} {...this.props} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
+                  <PlanOption id={`${id_prefix}_labels`} {...this.props} hideNonEditable={false} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable('labels')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption id={`${id_prefix}_taints`} {...this.props} hideNonEditable={false} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable('taints')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item>

--- a/ui/lib/components/plans/custom/PlanOptionClusterMachineType.js
+++ b/ui/lib/components/plans/custom/PlanOptionClusterMachineType.js
@@ -187,9 +187,13 @@ export default class PlanOptionClusterMachineType extends PlanOptionBase {
   }
 
   render() {
-    const { name, editable, nodePriceSet } = this.props
+    const { name, editable, nodePriceSet, forceShow } = this.props
     const { displayName, valueOrDefault, id } = this.prepCommonProps(this.props)
     const { types, typeIndex, priceIndex, loadingInstances, noRegion, extInfo } = this.state
+
+    if (!editable && !forceShow) {
+      return null
+    }
 
     if (loadingInstances) {
       return <Icon type="loading" />

--- a/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
+++ b/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { Form, Icon, List, Button, Drawer, Input, Descriptions, InputNumber, Checkbox, Collapse, Radio, Modal, Alert } from 'antd'
+import { Form, Icon, List, Button, Drawer, Input, Descriptions, InputNumber, Checkbox, Collapse, Radio, Modal, Alert, Switch, Typography } from 'antd'
+const { Paragraph, Text } = Typography
 
 import PlanOptionBase from '../PlanOptionBase'
 import PlanOption from '../PlanOption'
@@ -8,10 +9,6 @@ import NodePoolCost from '../../costs/NodePoolCost'
 import PlanOptionClusterMachineType from './PlanOptionClusterMachineType'
 
 export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
-  constructor(props) {
-    super(props)
-  }
-
   static AMI_TYPE_GENERAL = 'AL2_x86_64'
   static AMI_TYPE_GPU = 'AL2_x86_64_GPU'
 
@@ -138,12 +135,12 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
   }
 
   render() {
-    const { name, editable, property, plan } = this.props
+    const { name, editable, property, plan, manage } = this.props
     const { displayName, valueOrDefault } = this.prepCommonProps(this.props, [])
-    const { selectedIndex } = this.state
+    const { selectedIndex, showAll } = this.state
     const id_prefix = 'plan_nodegroup'
     const selected = selectedIndex >= 0 ? valueOrDefault[selectedIndex] : null
-    const description = this.props.manage ? 'Set default node groups for clusters created from this plan' : 'Manage node groups for this cluster'
+    const description = manage ? 'Set default node groups for clusters created from this plan' : 'Manage node groups for this cluster'
 
     let amiType = null
     let releaseVersionSet = false, ngNameClash = false, nodeGroupCloseable = true, instanceTypeFilter = null
@@ -187,15 +184,23 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
         >
           {!selected ? null : (
             <>
+              {manage ? null : (
+                <Paragraph>
+                  <Text strong style={{ marginRight: '10px' }}>Show all parameters</Text>
+                  <Switch checked={showAll} onChange={(showAll) => this.setState({ showAll })} />
+                </Paragraph>
+              )}
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, sizing)">
-                  <Form.Item label="Name" help="Unique name for this group within the cluster">
-                    <Input id={`${id_prefix}_name`} value={selected.name} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
-                    {this.validationErrors(`${name}[${selectedIndex}].name`)}
-                    {!ngNameClash ? null : <Alert type="error" message="This name is already used by another node group, it must be changed." />}
-                    {selected.name && selected.name.length > 0 ? null : <Alert type="error" message="Name must be set" />}
-                  </Form.Item>
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  {this.isEditable(property.items.properties.name) || showAll ? (
+                    <Form.Item label="Name" help="Unique name for this group within the cluster">
+                      <Input id={`${id_prefix}_name`} value={selected.name} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
+                      {this.validationErrors(`${name}[${selectedIndex}].name`)}
+                      {!ngNameClash ? null : <Alert type="error" message="This name is already used by another node group, it must be changed." />}
+                      {selected.name && selected.name.length > 0 ? null : <Alert type="error" message="Name must be set" />}
+                    </Form.Item>
+                  ) : null}
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} forceShow={showAll} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Group Size">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
@@ -215,31 +220,35 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
                   <NodePoolCost prices={this.state.prices} nodePool={selected} help="Adjust group size and instance type to see the cost impacts" />
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (instance type, GPU or regular workload)">
-                  <Form.Item label={property.items.properties.amiType.title} help={property.items.properties.amiType.description}>
-                    <Radio.Group id={`${id_prefix}_amiType`} value={amiType} onChange={(v) => this.setAmiType(selectedIndex, v.target.value)} disabled={!this.isEditable(property.items.properties.amiType)}>
-                      <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GENERAL}>General Purpose</Radio>
-                      <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GPU}>GPU</Radio>
-                    </Radio.Group>
-                    {this.validationErrors(`${name}[${selectedIndex}].amiType`)}
-                  </Form.Item>
-                  <Form.Item label="AWS AMI Version" help={!releaseVersionSet ? undefined : <><b>Must</b> be for Kubernetes <b>{plan.version}</b> and <b>{amiType === PlanOptionEKSNodeGroups.AMI_TYPE_GPU ? 'GPU' : 'general'}</b> workloads. Find <a target="_blank" rel="noopener noreferrer" href="https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html">supported versions</a> in AWS documentation.</>}>
-                    <Checkbox id={`${id_prefix}_releaseVersion_latest`} checked={!releaseVersionSet} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(v) => this.onReleaseVersionChecked(selectedIndex, v.target.checked)}/> Use latest (<b>recommended</b>)
-                    {!releaseVersionSet ? null : <Input id={`${id_prefix}_releaseVersion_custom`} value={selected.releaseVersion} placeholder={this.describe(property.items.properties.releaseVersion)} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'releaseVersion', e.target.value)} />}
-                    {this.validationErrors(`${name}[${selectedIndex}].releaseVersion`)}
-                  </Form.Item>
-                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} editable={this.isEditable(property.items.properties.instanceType)} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
+                  {this.isEditable(property.items.properties.amiType) || showAll ? (
+                    <Form.Item label={property.items.properties.amiType.title} help={property.items.properties.amiType.description}>
+                      <Radio.Group id={`${id_prefix}_amiType`} value={amiType} onChange={(v) => this.setAmiType(selectedIndex, v.target.value)} disabled={!this.isEditable(property.items.properties.amiType)}>
+                        <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GENERAL}>General Purpose</Radio>
+                        <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GPU}>GPU</Radio>
+                      </Radio.Group>
+                      {this.validationErrors(`${name}[${selectedIndex}].amiType`)}
+                    </Form.Item>
+                  ) : null}
+                  {this.isEditable(property.items.properties.releaseVersion) || showAll ? (
+                    <Form.Item label="AWS AMI Version" help={!releaseVersionSet ? undefined : <><b>Must</b> be for Kubernetes <b>{plan.version}</b> and <b>{amiType === PlanOptionEKSNodeGroups.AMI_TYPE_GPU ? 'GPU' : 'general'}</b> workloads. Find <a target="_blank" rel="noopener noreferrer" href="https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html">supported versions</a> in AWS documentation.</>}>
+                      <Checkbox id={`${id_prefix}_releaseVersion_latest`} checked={!releaseVersionSet} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(v) => this.onReleaseVersionChecked(selectedIndex, v.target.checked)}/> Use latest (<b>recommended</b>)
+                      {!releaseVersionSet ? null : <Input id={`${id_prefix}_releaseVersion_custom`} value={selected.releaseVersion} placeholder={this.describe(property.items.properties.releaseVersion)} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'releaseVersion', e.target.value)} />}
+                      {this.validationErrors(`${name}[${selectedIndex}].releaseVersion`)}
+                    </Form.Item>
+                  ) : null}
+                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} forceShow={showAll} editable={this.isEditable(property.items.properties.instanceType)} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Metadata (labels, tags, etc)">
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} editable={this.isEditable(property.items.properties.tags)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
+                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} editable={this.isEditable(property.items.properties.tags)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="ssh" header="SSH Connectivity (keys, security groups)">
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} editable={this.isEditable(property.items.properties.eC2SSHKey)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} editable={this.isEditable(property.items.properties.sshSourceSecurityGroups)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
+                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} editable={this.isEditable(property.items.properties.eC2SSHKey)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
+                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} editable={this.isEditable(property.items.properties.sshSourceSecurityGroups)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
                 </Collapse.Panel>
               </Collapse>
-              <Form.Item>
+              <Form.Item style={{ marginTop: '20px' }}>
                 <Button type="primary" id={`${id_prefix}_close`} disabled={!nodeGroupCloseable} onClick={() => this.closeNodeGroup()}>{nodeGroupCloseable ? 'Close' : 'Node group not valid - correct errors'}</Button>
               </Form.Item>
             </>

--- a/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
+++ b/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
@@ -182,24 +182,24 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, sizing)">
                   <Form.Item label="Name" help="Unique name for this group within the cluster">
-                    <Input id={`${id_prefix}_name`} value={selected.name} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'name', e.target.value)} readOnly={!editable} />
+                    <Input id={`${id_prefix}_name`} value={selected.name} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable('name')} />
                     {this.validationErrors(`${name}[${selectedIndex}].name`)}
                     {!ngNameClash ? null : <Alert type="error" message="This name is already used by another node group, it must be changed." />}
                     {selected.name && selected.name.length > 0 ? null : <Alert type="error" message="Name must be set" />}
                   </Form.Item>
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable('enableAutoscaler')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Group Size">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
-                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} readOnly={!editable} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'minSize', v)} />
+                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable('minSize')} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'minSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].minSize`)}
                       </Descriptions.Item>}
                       <Descriptions.Item label={selected.enableAutoscaler ? 'Initial size' : null}>
-                        <InputNumber id={`${id_prefix}_desiredSize`} value={selected.desiredSize} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : undefined} readOnly={!editable} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'desiredSize', v)} />
+                        <InputNumber id={`${id_prefix}_desiredSize`} value={selected.desiredSize} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : undefined} disabled={!this.isEditable('desiredSize')} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'desiredSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].desiredSize`)}
                       </Descriptions.Item>
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Maximum">
-                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} readOnly={!editable} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'maxSize', v)} />
+                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} editable={this.isEditable('maxSize')} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'maxSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].maxSize`)}
                       </Descriptions.Item>}
                     </Descriptions>

--- a/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
+++ b/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
@@ -129,6 +129,14 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
     return actions
   }
 
+  isEditable = (name) => {
+    // always allow editing if the node pool is not part of the original pre-edited plan
+    if (this.props.originalPlan && !this.props.originalPlan.nodeGroups[this.state.selectedIndex]) {
+      return true
+    }
+    return super.isEditable(name)
+  }
+
   render() {
     const { name, editable, property, plan } = this.props
     const { displayName, valueOrDefault } = this.prepCommonProps(this.props, [])
@@ -208,27 +216,27 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (instance type, GPU or regular workload)">
                   <Form.Item label={property.items.properties.amiType.title} help={property.items.properties.amiType.description}>
-                    <Radio.Group id={`${id_prefix}_amiType`} value={amiType} onChange={(v) => this.setAmiType(selectedIndex, v.target.value)}>
+                    <Radio.Group id={`${id_prefix}_amiType`} value={amiType} onChange={(v) => this.setAmiType(selectedIndex, v.target.value)} disabled={!this.isEditable('amiType')}>
                       <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GENERAL}>General Purpose</Radio>
                       <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GPU}>GPU</Radio>
                     </Radio.Group>
                     {this.validationErrors(`${name}[${selectedIndex}].amiType`)}
                   </Form.Item>
                   <Form.Item label="AWS AMI Version" help={!releaseVersionSet ? undefined : <><b>Must</b> be for Kubernetes <b>{plan.version}</b> and <b>{amiType === PlanOptionEKSNodeGroups.AMI_TYPE_GPU ? 'GPU' : 'general'}</b> workloads. Find <a target="_blank" rel="noopener noreferrer" href="https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html">supported versions</a> in AWS documentation.</>}>
-                    <Checkbox id={`${id_prefix}_releaseVersion_latest`} disabled={!editable} checked={!releaseVersionSet} onChange={(v) => this.onReleaseVersionChecked(selectedIndex, v.target.checked)}/> Use latest (<b>recommended</b>)
-                    {!releaseVersionSet ? null : <Input id={`${id_prefix}_releaseVersion_custom`} value={selected.releaseVersion} placeholder={this.describe(property.items.properties.releaseVersion)} readOnly={!editable} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'releaseVersion', e.target.value)} />}
+                    <Checkbox id={`${id_prefix}_releaseVersion_latest`} checked={!releaseVersionSet} disabled={!this.isEditable('releaseVersion')} onChange={(v) => this.onReleaseVersionChecked(selectedIndex, v.target.checked)}/> Use latest (<b>recommended</b>)
+                    {!releaseVersionSet ? null : <Input id={`${id_prefix}_releaseVersion_custom`} value={selected.releaseVersion} placeholder={this.describe(property.items.properties.releaseVersion)} disabled={!this.isEditable('releaseVersion')} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'releaseVersion', e.target.value)} />}
                     {this.validationErrors(`${name}[${selectedIndex}].releaseVersion`)}
                   </Form.Item>
-                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption {...this.props} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} editable={this.isEditable('instanceType')} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable('diskSize')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Metadata (labels, tags, etc)">
-                  <PlanOption {...this.props} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption {...this.props} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable('labels')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} editable={this.isEditable('tags')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="ssh" header="SSH Connectivity (keys, security groups)">
-                  <PlanOption {...this.props} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
-                  <PlanOption {...this.props} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} editable={this.isEditable('eC2SSHKey')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} editable={this.isEditable('sshSourceSecurityGroups')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item>

--- a/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
+++ b/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
@@ -7,6 +7,7 @@ import PlanOption from '../PlanOption'
 import copy from '../../../utils/object-copy'
 import NodePoolCost from '../../costs/NodePoolCost'
 import PlanOptionClusterMachineType from './PlanOptionClusterMachineType'
+import IconTooltip from '../../utils/IconTooltip'
 
 export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
   static AMI_TYPE_GENERAL = 'AL2_x86_64'
@@ -137,7 +138,7 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
   render() {
     const { name, editable, property, plan, manage } = this.props
     const { displayName, valueOrDefault } = this.prepCommonProps(this.props, [])
-    const { selectedIndex, showAll } = this.state
+    const { selectedIndex, showReadOnly } = this.state
     const id_prefix = 'plan_nodegroup'
     const selected = selectedIndex >= 0 ? valueOrDefault[selectedIndex] : null
     const description = manage ? 'Set default node groups for clusters created from this plan' : 'Manage node groups for this cluster'
@@ -186,13 +187,13 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
             <>
               {manage ? null : (
                 <Paragraph>
-                  <Text strong style={{ marginRight: '10px' }}>Show all parameters</Text>
-                  <Switch checked={showAll} onChange={(showAll) => this.setState({ showAll })} />
+                  <Text strong style={{ marginRight: '10px' }}>Show read-only parameters <IconTooltip text="Parameters may be read-only as defined by the plan policy or may be editable on cluster creation only. Turn this on to see these parameters." icon="info-circle" placement="bottom" /></Text>
+                  <Switch checked={showReadOnly} onChange={(showReadOnly) => this.setState({ showReadOnly })} />
                 </Paragraph>
               )}
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, sizing)">
-                  {this.isEditable(property.items.properties.name) || showAll ? (
+                  {this.isEditable(property.items.properties.name) || showReadOnly ? (
                     <Form.Item label="Name" help="Unique name for this group within the cluster">
                       <Input id={`${id_prefix}_name`} value={selected.name} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
                       {this.validationErrors(`${name}[${selectedIndex}].name`)}
@@ -200,7 +201,7 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
                       {selected.name && selected.name.length > 0 ? null : <Alert type="error" message="Name must be set" />}
                     </Form.Item>
                   ) : null}
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} forceShow={showAll} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} forceShow={showReadOnly} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Group Size">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
@@ -220,7 +221,7 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
                   <NodePoolCost prices={this.state.prices} nodePool={selected} help="Adjust group size and instance type to see the cost impacts" />
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (instance type, GPU or regular workload)">
-                  {this.isEditable(property.items.properties.amiType) || showAll ? (
+                  {this.isEditable(property.items.properties.amiType) || showReadOnly ? (
                     <Form.Item label={property.items.properties.amiType.title} help={property.items.properties.amiType.description}>
                       <Radio.Group id={`${id_prefix}_amiType`} value={amiType} onChange={(v) => this.setAmiType(selectedIndex, v.target.value)} disabled={!this.isEditable(property.items.properties.amiType)}>
                         <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GENERAL}>General Purpose</Radio>
@@ -229,23 +230,23 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
                       {this.validationErrors(`${name}[${selectedIndex}].amiType`)}
                     </Form.Item>
                   ) : null}
-                  {this.isEditable(property.items.properties.releaseVersion) || showAll ? (
+                  {this.isEditable(property.items.properties.releaseVersion) || showReadOnly ? (
                     <Form.Item label="AWS AMI Version" help={!releaseVersionSet ? undefined : <><b>Must</b> be for Kubernetes <b>{plan.version}</b> and <b>{amiType === PlanOptionEKSNodeGroups.AMI_TYPE_GPU ? 'GPU' : 'general'}</b> workloads. Find <a target="_blank" rel="noopener noreferrer" href="https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html">supported versions</a> in AWS documentation.</>}>
                       <Checkbox id={`${id_prefix}_releaseVersion_latest`} checked={!releaseVersionSet} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(v) => this.onReleaseVersionChecked(selectedIndex, v.target.checked)}/> Use latest (<b>recommended</b>)
                       {!releaseVersionSet ? null : <Input id={`${id_prefix}_releaseVersion_custom`} value={selected.releaseVersion} placeholder={this.describe(property.items.properties.releaseVersion)} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'releaseVersion', e.target.value)} />}
                       {this.validationErrors(`${name}[${selectedIndex}].releaseVersion`)}
                     </Form.Item>
                   ) : null}
-                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} forceShow={showAll} editable={this.isEditable(property.items.properties.instanceType)} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} forceShow={showReadOnly} editable={this.isEditable(property.items.properties.instanceType)} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption {...this.props} forceShow={showReadOnly} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Metadata (labels, tags, etc)">
-                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} editable={this.isEditable(property.items.properties.tags)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
+                  <PlanOption {...this.props} forceShow={showReadOnly} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption {...this.props} forceShow={showReadOnly} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} editable={this.isEditable(property.items.properties.tags)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="ssh" header="SSH Connectivity (keys, security groups)">
-                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} editable={this.isEditable(property.items.properties.eC2SSHKey)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
-                  <PlanOption {...this.props} forceShow={showAll} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} editable={this.isEditable(property.items.properties.sshSourceSecurityGroups)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
+                  <PlanOption {...this.props} forceShow={showReadOnly} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} editable={this.isEditable(property.items.properties.eC2SSHKey)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
+                  <PlanOption {...this.props} forceShow={showReadOnly} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} editable={this.isEditable(property.items.properties.sshSourceSecurityGroups)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item style={{ marginTop: '20px' }}>

--- a/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
+++ b/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
@@ -129,12 +129,12 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
     return actions
   }
 
-  isEditable = (name) => {
-    // always allow editing if the node pool is not part of the original pre-edited plan
+  isEditable = (property) => {
+    // always allow editing if the node group is not part of the original pre-edited plan
     if (this.props.originalPlan && !this.props.originalPlan.nodeGroups[this.state.selectedIndex]) {
       return true
     }
-    return super.isEditable(name)
+    return super.isEditable(property)
   }
 
   render() {
@@ -190,24 +190,24 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, sizing)">
                   <Form.Item label="Name" help="Unique name for this group within the cluster">
-                    <Input id={`${id_prefix}_name`} value={selected.name} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable('name')} />
+                    <Input id={`${id_prefix}_name`} value={selected.name} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
                     {this.validationErrors(`${name}[${selectedIndex}].name`)}
                     {!ngNameClash ? null : <Alert type="error" message="This name is already used by another node group, it must be changed." />}
                     {selected.name && selected.name.length > 0 ? null : <Alert type="error" message="Name must be set" />}
                   </Form.Item>
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable('enableAutoscaler')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Group Size">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
-                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable('minSize')} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'minSize', v)} />
+                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable(property.items.properties.minSize)} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'minSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].minSize`)}
                       </Descriptions.Item>}
                       <Descriptions.Item label={selected.enableAutoscaler ? 'Initial size' : null}>
-                        <InputNumber id={`${id_prefix}_desiredSize`} value={selected.desiredSize} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : undefined} disabled={!this.isEditable('desiredSize')} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'desiredSize', v)} />
+                        <InputNumber id={`${id_prefix}_desiredSize`} value={selected.desiredSize} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : undefined} disabled={!this.isEditable(property.items.properties.desiredSize)} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'desiredSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].desiredSize`)}
                       </Descriptions.Item>
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Maximum">
-                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} editable={this.isEditable('maxSize')} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'maxSize', v)} />
+                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} editable={this.isEditable(property.items.properties.maxSize)} onChange={(v) => this.setNodeGroupProperty(selectedIndex, 'maxSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].maxSize`)}
                       </Descriptions.Item>}
                     </Descriptions>
@@ -216,27 +216,27 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (instance type, GPU or regular workload)">
                   <Form.Item label={property.items.properties.amiType.title} help={property.items.properties.amiType.description}>
-                    <Radio.Group id={`${id_prefix}_amiType`} value={amiType} onChange={(v) => this.setAmiType(selectedIndex, v.target.value)} disabled={!this.isEditable('amiType')}>
+                    <Radio.Group id={`${id_prefix}_amiType`} value={amiType} onChange={(v) => this.setAmiType(selectedIndex, v.target.value)} disabled={!this.isEditable(property.items.properties.amiType)}>
                       <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GENERAL}>General Purpose</Radio>
                       <Radio value={PlanOptionEKSNodeGroups.AMI_TYPE_GPU}>GPU</Radio>
                     </Radio.Group>
                     {this.validationErrors(`${name}[${selectedIndex}].amiType`)}
                   </Form.Item>
                   <Form.Item label="AWS AMI Version" help={!releaseVersionSet ? undefined : <><b>Must</b> be for Kubernetes <b>{plan.version}</b> and <b>{amiType === PlanOptionEKSNodeGroups.AMI_TYPE_GPU ? 'GPU' : 'general'}</b> workloads. Find <a target="_blank" rel="noopener noreferrer" href="https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html">supported versions</a> in AWS documentation.</>}>
-                    <Checkbox id={`${id_prefix}_releaseVersion_latest`} checked={!releaseVersionSet} disabled={!this.isEditable('releaseVersion')} onChange={(v) => this.onReleaseVersionChecked(selectedIndex, v.target.checked)}/> Use latest (<b>recommended</b>)
-                    {!releaseVersionSet ? null : <Input id={`${id_prefix}_releaseVersion_custom`} value={selected.releaseVersion} placeholder={this.describe(property.items.properties.releaseVersion)} disabled={!this.isEditable('releaseVersion')} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'releaseVersion', e.target.value)} />}
+                    <Checkbox id={`${id_prefix}_releaseVersion_latest`} checked={!releaseVersionSet} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(v) => this.onReleaseVersionChecked(selectedIndex, v.target.checked)}/> Use latest (<b>recommended</b>)
+                    {!releaseVersionSet ? null : <Input id={`${id_prefix}_releaseVersion_custom`} value={selected.releaseVersion} placeholder={this.describe(property.items.properties.releaseVersion)} disabled={!this.isEditable(property.items.properties.releaseVersion)} onChange={(e) => this.setNodeGroupProperty(selectedIndex, 'releaseVersion', e.target.value)} />}
                     {this.validationErrors(`${name}[${selectedIndex}].releaseVersion`)}
                   </Form.Item>
-                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} editable={this.isEditable('instanceType')} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable('diskSize')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} editable={this.isEditable(property.items.properties.instanceType)} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Metadata (labels, tags, etc)">
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable('labels')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} editable={this.isEditable('tags')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_tags`} displayName="Tags" help="AWS tags to apply to the node group" name={`${name}[${selectedIndex}].tags`} property={property.items.properties.tags} value={selected.tags} editable={this.isEditable(property.items.properties.tags)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'tags', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="ssh" header="SSH Connectivity (keys, security groups)">
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} editable={this.isEditable('eC2SSHKey')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
-                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} editable={this.isEditable('sshSourceSecurityGroups')} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_eC2SSHKey`} displayName="EC2 SSH Key" name={`${name}[${selectedIndex}].eC2SSHKey`} property={property.items.properties.eC2SSHKey} value={selected.eC2SSHKey} editable={this.isEditable(property.items.properties.eC2SSHKey)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'eC2SSHKey', v)} />
+                  <PlanOption {...this.props} hideNonEditable={false} id={`${id_prefix}_sshSourceSecurityGroups`} displayName="SSH Security Groups" name={`${name}[${selectedIndex}].sshSourceSecurityGroups`} property={property.items.properties.sshSourceSecurityGroups} value={selected.sshSourceSecurityGroups} editable={this.isEditable(property.items.properties.sshSourceSecurityGroups)} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'sshSourceSecurityGroups', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item>

--- a/ui/lib/components/plans/custom/PlanOptionGKENodePools.js
+++ b/ui/lib/components/plans/custom/PlanOptionGKENodePools.js
@@ -111,12 +111,12 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
     return actions
   }
 
-  isEditable = (name) => {
+  isEditable = (property) => {
     // always allow editing if the node pool is not part of the original pre-edited plan
     if (this.props.originalPlan && !this.props.originalPlan.nodePools[this.state.selectedIndex]) {
       return true
     }
-    return super.isEditable(name)
+    return super.isEditable(property)
   }
 
   render() {
@@ -174,7 +174,7 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, versions, sizing)">
                   <Form.Item label="Name" help="Unique name for this group within the cluster">
-                    <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable('name')} />
+                    <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
                     {this.validationErrors(`${name}[${selectedIndex}].name`)}
                     {!ngNameClash ? null : <Alert type="error" message="This name is already used by another node pool, it must be changed." />}
                     {selected.name && selected.name.match(property.items.properties.name.pattern) ? null : <Alert type="error" message="Name must be minimum 2, maximum 40 alpha-numeric characters and hyphens" />}
@@ -186,31 +186,31 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                   ) : (
                     <>
                       <Form.Item label="Auto-upgrade" help="Allow GCP to automatically upgrade nodes in this pool (recommended)">
-                        <Switch id={`${id_prefix}_enableAutoupgrade`} checked={selected.enableAutoupgrade} disabled={!this.isEditable('enableAutoupgrade') || followingReleaseChannel} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'enableAutoupgrade', v)} checkedChildren={<Icon type="check" />} unCheckedChildren={<Icon type="close" />} />
+                        <Switch id={`${id_prefix}_enableAutoupgrade`} checked={selected.enableAutoupgrade} disabled={!this.isEditable(property.items.properties.enableAutoupgrade) || followingReleaseChannel} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'enableAutoupgrade', v)} checkedChildren={<Icon type="check" />} unCheckedChildren={<Icon type="close" />} />
                       </Form.Item>
                       <Form.Item label="Version" help="Set the Kubernetes version for this node pool">
-                        <Checkbox id={`${id_prefix}_versionFollowMaster`} checked={versionFollowMaster} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.checked ? '' : plan.version)} disabled={!this.isEditable('version')} /> Same as master (recommended)
+                        <Checkbox id={`${id_prefix}_versionFollowMaster`} checked={versionFollowMaster} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.checked ? '' : plan.version)} disabled={!this.isEditable(property.items.properties.version)} /> Same as master (recommended)
                         {versionFollowMaster ? null : (
                           <>
-                            <Input id={`${id_prefix}_version`} pattern={property.items.properties.version.pattern} value={selected.version} disabled={!this.isEditable('version')} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.value)} />
+                            <Input id={`${id_prefix}_version`} pattern={property.items.properties.version.pattern} value={selected.version} disabled={!this.isEditable(property.items.properties.version)} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.value)} />
                           </>
                         )}
                       </Form.Item>
                     </>
                   )}
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable('enableAutoscaler')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} hideNonEditable={false} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Pool size per zone">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
-                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable('minSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
+                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable(property.items.properties.minSize)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].minSize`)}
                       </Descriptions.Item>}
                       <Descriptions.Item label={selected.enableAutoscaler ? 'Initial size' : null}>
-                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} disabled={!this.isEditable('size')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
+                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} disabled={!this.isEditable(property.items.properties.size)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].size`)}
                       </Descriptions.Item>
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Maximum">
-                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} disabled={!this.isEditable('maxSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
+                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} disabled={!this.isEditable(property.items.properties.maxSize)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].maxSize`)}
                       </Descriptions.Item>}
                     </Descriptions>
@@ -222,17 +222,17 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                     zoneMultiplier={3}
                     priceType={selected.preemptible ? 'PreEmptible' : null}
                   />
-                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} hideNonEditable={false} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable('maxPodsPerNode')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
+                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} hideNonEditable={false} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable(property.items.properties.maxPodsPerNode)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (machine type, disk size, image type, auto-repair)">
                   <Form.Item label="Image Type" help={<>For help choosing an image type, see <a target="_blank" rel="noopener noreferrer" href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images">the GCP documentation</a></>}>
-                    <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} readOnly={!this.isEditable('imageType')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
+                    <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} readOnly={!this.isEditable(property.items.properties.imageType)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
                   </Form.Item>
-                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} editable={this.isEditable('machineType')} displayName="GCP Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} hideNonEditable={false} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable('diskSize')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
-                  <PlanOption id={`${id_prefix}_enableAutorepair`} {...this.props} hideNonEditable={false} displayName="Auto-repair" name={`${name}[${selectedIndex}].enableAutorepair`} property={property.items.properties.enableAutorepair} value={selected.enableAutorepair} editable={this.isEditable('enableAutorepair')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutorepair', v)} />
-                  <PlanOption id={`${id_prefix}_preemptible`} {...this.props} hideNonEditable={false} displayName="Pre-emptible" name={`${name}[${selectedIndex}].preemptible`} property={property.items.properties.preemptible} value={selected.preemptible} editable={this.isEditable('preemptible')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'preemptible', v)} />
-                  {selected.preemptible && this.isEditable('preemptible') ? (
+                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} editable={this.isEditable(property.items.properties.machineType)} displayName="GCP Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} hideNonEditable={false} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutorepair`} {...this.props} hideNonEditable={false} displayName="Auto-repair" name={`${name}[${selectedIndex}].enableAutorepair`} property={property.items.properties.enableAutorepair} value={selected.enableAutorepair} editable={this.isEditable(property.items.properties.enableAutorepair)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutorepair', v)} />
+                  <PlanOption id={`${id_prefix}_preemptible`} {...this.props} hideNonEditable={false} displayName="Pre-emptible" name={`${name}[${selectedIndex}].preemptible`} property={property.items.properties.preemptible} value={selected.preemptible} editable={this.isEditable(property.items.properties.preemptible)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'preemptible', v)} />
+                  {!selected.preemptible ? null : (
                     <Alert type="warning" message={
                       <>
                         Pre-emptible nodes deliver significant cost savings but <b>can and will be destroyed</b> at any time, at
@@ -244,11 +244,11 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                         Ensure you understand the impact of this on your workloads before enabling.
                       </>
                     }/>
-                  ): null}
+                  )}
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Labels & Taints">
-                  <PlanOption id={`${id_prefix}_labels`} {...this.props} hideNonEditable={false} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable('labels')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption id={`${id_prefix}_taints`} {...this.props} hideNonEditable={false} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable('taints')} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
+                  <PlanOption id={`${id_prefix}_labels`} {...this.props} hideNonEditable={false} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption id={`${id_prefix}_taints`} {...this.props} hideNonEditable={false} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable(property.items.properties.taints)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item>

--- a/ui/lib/components/plans/custom/PlanOptionGKENodePools.js
+++ b/ui/lib/components/plans/custom/PlanOptionGKENodePools.js
@@ -112,15 +112,11 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
   }
 
   isEditable = (name) => {
-    // quick return if the whole nodePool property is not editable
-    if (!this.props.editable) {
-      return false
+    // always allow editing if the node pool is not part of the original pre-edited plan
+    if (this.props.originalPlan && !this.props.originalPlan.nodePools[this.state.selectedIndex]) {
+      return true
     }
-    const property = this.props.property.items.properties[name]
-    const { manage, mode } = this.props
-    return mode !== 'view' &&
-      (property.const === undefined || property.const === null) &&
-      (mode === 'create' || manage || !property.immutable)
+    return super.isEditable(name)
   }
 
   render() {
@@ -196,7 +192,7 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                         <Checkbox id={`${id_prefix}_versionFollowMaster`} checked={versionFollowMaster} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.checked ? '' : plan.version)} disabled={!this.isEditable('version')} /> Same as master (recommended)
                         {versionFollowMaster ? null : (
                           <>
-                            <Input id={`${id_prefix}_version`} pattern={property.items.properties.version.pattern} value={selected.version} readOnly={!this.isEditable('version')} disabled={!this.isEditable('version')} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.value)} />
+                            <Input id={`${id_prefix}_version`} pattern={property.items.properties.version.pattern} value={selected.version} disabled={!this.isEditable('version')} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.value)} />
                           </>
                         )}
                       </Form.Item>
@@ -206,15 +202,15 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                   <Form.Item label="Pool size per zone">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
-                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} readOnly={!this.isEditable('minSize')} disabled={!this.isEditable('minSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
+                        <InputNumber id={`${id_prefix}_minSize`} value={selected.minSize} size="small" min={property.items.properties.minSize.minimum} max={selected.maxSize} disabled={!this.isEditable('minSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'minSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].minSize`)}
                       </Descriptions.Item>}
                       <Descriptions.Item label={selected.enableAutoscaler ? 'Initial size' : null}>
-                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} readOnly={!this.isEditable('size')} disabled={!this.isEditable('size')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
+                        <InputNumber id={`${id_prefix}_size`} value={selected.size} size="small" min={selected.enableAutoscaler ? selected.minSize : 1} max={selected.enableAutoscaler ? selected.maxSize : 99999} disabled={!this.isEditable('size')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'size', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].size`)}
                       </Descriptions.Item>
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Maximum">
-                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} readOnly={!this.isEditable('maxSize')} disabled={!this.isEditable('maxSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
+                        <InputNumber id={`${id_prefix}_maxSize`} value={selected.maxSize} size="small" min={selected.minSize} disabled={!this.isEditable('maxSize')} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'maxSize', v)} />
                         {this.validationErrors(`${name}[${selectedIndex}].maxSize`)}
                       </Descriptions.Item>}
                     </Descriptions>

--- a/ui/lib/components/plans/custom/PlanOptionGKENodePools.js
+++ b/ui/lib/components/plans/custom/PlanOptionGKENodePools.js
@@ -8,6 +8,7 @@ import ConstrainedDropdown from './ConstrainedDropdown'
 import PlanOption from '../PlanOption'
 import PlanOptionClusterMachineType from './PlanOptionClusterMachineType'
 import NodePoolCost from '../../costs/NodePoolCost'
+import IconTooltip from '../../utils/IconTooltip'
 
 // @TODO: Pull these from GCP
 const imageTypes = [
@@ -123,7 +124,7 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
   render() {
     const { name, editable, property, plan, manage } = this.props
     const { displayName, valueOrDefault } = this.prepCommonProps(this.props, [])
-    const { selectedIndex, prices, showAll } = this.state
+    const { selectedIndex, prices, showReadOnly } = this.state
     const id_prefix = 'plan_nodepool'
     const selected = selectedIndex >= 0 ? valueOrDefault[selectedIndex] : null
     const description = manage ? 'Default node pools for clusters created from this plan' : null
@@ -174,13 +175,13 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
             <>
               {manage ? null : (
                 <Paragraph>
-                  <Text strong style={{ marginRight: '10px' }}>Show all parameters</Text>
-                  <Switch checked={showAll} onChange={(showAll) => this.setState({ showAll })} />
+                  <Text strong style={{ marginRight: '10px' }}>Show read-only parameters <IconTooltip text="Parameters may be read-only as defined by the plan policy or may be editable on cluster creation only. Turn this on to see these parameters." icon="info-circle" placement="bottom" /></Text>
+                  <Switch checked={showReadOnly} onChange={(showReadOnly) => this.setState({ showReadOnly })} />
                 </Paragraph>
               )}
               <Collapse defaultActiveKey={['basics','compute','metadata']}>
                 <Collapse.Panel key="basics" header="Basic Configuration (name, versions, sizing)">
-                  {this.isEditable(property.items.properties.name) || showAll ? (
+                  {this.isEditable(property.items.properties.name) || showReadOnly ? (
                     <Form.Item label="Name" help="Unique name for this group within the cluster">
                       <Input id={`${id_prefix}_name`} pattern={property.items.properties.name.pattern} value={selected.name} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'name', e.target.value)} disabled={!this.isEditable(property.items.properties.name)} />
                       {this.validationErrors(`${name}[${selectedIndex}].name`)}
@@ -194,12 +195,12 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                     </Form.Item>
                   ) : (
                     <>
-                      {this.isEditable(property.items.properties.enableAutoupgrade) || showAll ? (
+                      {this.isEditable(property.items.properties.enableAutoupgrade) || showReadOnly ? (
                         <Form.Item label="Auto-upgrade" help="Allow GCP to automatically upgrade nodes in this pool (recommended)">
                           <Switch id={`${id_prefix}_enableAutoupgrade`} checked={selected.enableAutoupgrade} disabled={!this.isEditable(property.items.properties.enableAutoupgrade) || followingReleaseChannel} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'enableAutoupgrade', v)} checkedChildren={<Icon type="check" />} unCheckedChildren={<Icon type="close" />} />
                         </Form.Item>
                       ) : null}
-                      {this.isEditable(property.items.properties.version) || showAll ? (
+                      {this.isEditable(property.items.properties.version) || showReadOnly ? (
                         <Form.Item label="Version" help="Set the Kubernetes version for this node pool">
                           <Checkbox id={`${id_prefix}_versionFollowMaster`} checked={versionFollowMaster} onChange={(e) => this.setNodePoolProperty(selectedIndex, 'version', e.target.checked ? '' : plan.version)} disabled={!this.isEditable(property.items.properties.version)} /> Same as master (recommended)
                           {versionFollowMaster ? null : (
@@ -211,7 +212,7 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                       ) : null}
                     </>
                   )}
-                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} forceShow={showAll} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutoscaler`} {...this.props} forceShow={showReadOnly} displayName="Auto-scale" name={`${name}[${selectedIndex}].enableAutoscaler`} property={property.items.properties.enableAutoscaler} value={selected.enableAutoscaler} editable={this.isEditable(property.items.properties.enableAutoscaler)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutoscaler', v)} />
                   <Form.Item label="Pool size per zone">
                     <Descriptions layout="horizontal" size="small">
                       {!selected.enableAutoscaler ? null : <Descriptions.Item label="Minimum">
@@ -235,18 +236,18 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                     zoneMultiplier={3}
                     priceType={selected.preemptible ? 'PreEmptible' : null}
                   />
-                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} forceShow={showAll} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable(property.items.properties.maxPodsPerNode)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
+                  <PlanOption id={`${id_prefix}_maxPodsPerNode`} {...this.props} forceShow={showReadOnly} displayName="Max pods per node" name={`${name}[${selectedIndex}].maxPodsPerNode`} property={property.items.properties.maxPodsPerNode} value={selected.maxPodsPerNode} editable={this.isEditable(property.items.properties.maxPodsPerNode)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'maxPodsPerNode', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="compute" header="Compute Configuration (machine type, disk size, image type, auto-repair)">
-                  {this.isEditable(property.items.properties.imageType) || showAll ? (
+                  {this.isEditable(property.items.properties.imageType) || showReadOnly ? (
                     <Form.Item label="Image Type" help={<>For help choosing an image type, see <a target="_blank" rel="noopener noreferrer" href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images">the GCP documentation</a></>}>
                       <ConstrainedDropdown id={`${id_prefix}_imageType`} allowedValues={imageTypes} value={selected.imageType} readOnly={!this.isEditable(property.items.properties.imageType)} onChange={(v) => this.setNodePoolProperty(selectedIndex, 'imageType', v)} />
                     </Form.Item>
                   ) : null}
-                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} forceShow={showAll} editable={this.isEditable(property.items.properties.machineType)} displayName="GCP Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} forceShow={showAll} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
-                  <PlanOption id={`${id_prefix}_enableAutorepair`} {...this.props} forceShow={showAll} displayName="Auto-repair" name={`${name}[${selectedIndex}].enableAutorepair`} property={property.items.properties.enableAutorepair} value={selected.enableAutorepair} editable={this.isEditable(property.items.properties.enableAutorepair)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutorepair', v)} />
-                  <PlanOption id={`${id_prefix}_preemptible`} {...this.props} forceShow={showAll} displayName="Pre-emptible" name={`${name}[${selectedIndex}].preemptible`} property={property.items.properties.preemptible} value={selected.preemptible} editable={this.isEditable(property.items.properties.preemptible)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'preemptible', v)} />
+                  <PlanOptionClusterMachineType id={`${id_prefix}_machineType`} {...this.props} forceShow={showReadOnly} editable={this.isEditable(property.items.properties.machineType)} displayName="GCP Machine Type" name={`${name}[${selectedIndex}].machineType`} property={property.items.properties.machineType} value={selected.machineType} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'machineType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
+                  <PlanOption id={`${id_prefix}_diskSize`} {...this.props} forceShow={showReadOnly} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} editable={this.isEditable(property.items.properties.diskSize)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOption id={`${id_prefix}_enableAutorepair`} {...this.props} forceShow={showReadOnly} displayName="Auto-repair" name={`${name}[${selectedIndex}].enableAutorepair`} property={property.items.properties.enableAutorepair} value={selected.enableAutorepair} editable={this.isEditable(property.items.properties.enableAutorepair)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'enableAutorepair', v)} />
+                  <PlanOption id={`${id_prefix}_preemptible`} {...this.props} forceShow={showReadOnly} displayName="Pre-emptible" name={`${name}[${selectedIndex}].preemptible`} property={property.items.properties.preemptible} value={selected.preemptible} editable={this.isEditable(property.items.properties.preemptible)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'preemptible', v)} />
                   {!selected.preemptible ? null : (
                     <Alert type="warning" message={
                       <>
@@ -262,8 +263,8 @@ export default class PlanOptionGKENodePools extends PlanOptionBase {
                   )}
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Labels & Taints">
-                  <PlanOption id={`${id_prefix}_labels`} {...this.props} forceShow={showAll} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
-                  <PlanOption id={`${id_prefix}_taints`} {...this.props} forceShow={showAll} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable(property.items.properties.taints)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
+                  <PlanOption id={`${id_prefix}_labels`} {...this.props} forceShow={showReadOnly} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} editable={this.isEditable(property.items.properties.labels)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'labels', v)} />
+                  <PlanOption id={`${id_prefix}_taints`} {...this.props} forceShow={showReadOnly} displayName="Taints" help="Taints help kubernetes make scheduling decisions against nodepools" name={`${name}[${selectedIndex}].taints`} property={property.items.properties.taints} value={selected.taints} editable={this.isEditable(property.items.properties.taints)} onChange={(_, v) => this.setNodePoolProperty(selectedIndex, 'taints', v)} />
                 </Collapse.Panel>
               </Collapse>
               <Form.Item style={{ marginTop: '20px' }}>

--- a/ui/lib/components/utils/IconTooltip.js
+++ b/ui/lib/components/utils/IconTooltip.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import { Icon, Tooltip } from 'antd'
 
-const IconTooltip = ({ icon, text, color, onClick }) => (
-  <Tooltip title={text}>
+const IconTooltip = ({ icon, text, color, placement, onClick }) => (
+  <Tooltip title={text} placement={placement}>
     {onClick ? <a style={{ marginLeft: '5px' }} onClick={onClick}><Icon type={icon} theme="twoTone" twoToneColor={color} /></a> : <Icon type={icon} theme="twoTone" twoToneColor={color} /> }
   </Tooltip>
 )
@@ -11,6 +11,7 @@ IconTooltip.propTypes = {
   icon: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   color: PropTypes.string,
+  placement: PropTypes.string,
   onClick: PropTypes.func
 }
 

--- a/ui/pages/teams/[name]/clusters/[cluster]/[tab].js
+++ b/ui/pages/teams/[name]/clusters/[cluster]/[tab].js
@@ -249,6 +249,7 @@ class ClusterPage extends React.Component {
                 kind={cluster.spec.kind}
                 plan={cluster.spec.plan}
                 planValues={this.state.clusterParams}
+                originalPlanValues={cluster.spec.configuration}
                 mode={this.state.editMode ? 'edit' : 'view'}
                 validationErrors={this.state.validationErrors}
                 onPlanValuesChange={this.onClusterConfigChanged}


### PR DESCRIPTION
## Summary

Adding functionality for GKE, EKS and AKS node pools/groups
Simplifying plan field visibility, for plan and node pools

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1146 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~

## Changes

Field with `immutable=true` cannot be edited once the cluster is created
These fields are not shown on the drawer render, along with any fields that are not-editable according to the policy
I've introduced a switch on the node pool drawer, `Show all parameters`, which will display, in disabled mode, the non-editable and immutable field.
If a new node pool/group is created those fields will always be editable, until it's saved
The `Show read-only parameters` checkbox for a cluster plan has been changed to a switch, `Show all parameters` which will simply show the non-editable and immutable (if created) fields.

### Additional changes

* changing some fields on the top level plan render to be disabled when not editable, rather than read-only as this makes them more consistent across the plan
* removing unused `setPrices` function

## Screenshots

**Plan**

<img width="1060" alt="Screen Shot 2020-08-10 at 10 57 35" src="https://user-images.githubusercontent.com/1334068/89771545-633e6700-daf8-11ea-82b0-aeefc1d701db.png">

**Node pool**

<img width="1048" alt="Screen Shot 2020-08-10 at 10 57 53" src="https://user-images.githubusercontent.com/1334068/89771548-65082a80-daf8-11ea-80c1-fb4c4100a599.png">

## Testing

* create/edit cluster plans for all clouds
* edit created cluster node pools, except the immutable fields
* check ability to add new node pools to existing clusters
* show all switch revealing/hiding non-editable and immutable fields on plan and node pools

