### PR TITLE
Defaulting to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ parameters:
 
 environment: &SERVICES_ENV
   DEBIAN_FRONTEND: "noninteractive"
+  FORCE_IMAGE_PUSH: "true"
   KORE_ADMIN_PASS: "password"
   KORE_ADMIN_TOKEN: "password"
   KORE_API_PUBLIC_URL: "http://localhost:10080"

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ auth-proxy-image: golang
 
 auth-proxy-image-release: auth-proxy-image
 	@echo "--> Pushing auth image"
+	@hack/verify-release-images.sh
 	docker push ${REGISTRY}/${AUTHOR}/auth-proxy:${VERSION}
 
 kore-apiserver: golang
@@ -133,6 +134,7 @@ kind-image-dev:
 
 push-images:
 	@echo "--> Pushing docker images"
+	@hack/verify-release-images.sh
 	@for name in ${DOCKER_IMAGES}; do \
 		echo "--> Pushing docker image $${name}" ; \
 		docker push ${REGISTRY}/${AUTHOR}/$${name}:${VERSION} ; \

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,8 @@ ifeq ($(USE_GIT_VERSION),true)
 	VERSION ?= $(CURRENT_TAG)
 	endif
 else
-	# case of local build - must find upstream images
-	# - note the version reported by --version always includes the git SHA
-	VERSION ?= $(GIT_LAST_TAG)
+	# else you have to specify the tag
+	VERSION ?= latest
 endif
 LFLAGS ?= -X github.com/appvia/kore/pkg/version.Tag=${GIT_LAST_TAG} -X github.com/appvia/kore/pkg/version.GitSHA=${GIT_SHA} -X github.com/appvia/kore/pkg/version.Compiled=${BUILD_TIME} -X github.com/appvia/kore/pkg/version.Release=${VERSION}
 CLI_PLATFORMS=darwin linux windows

--- a/hack/verify-release-images.sh
+++ b/hack/verify-release-images.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Appvia Ltd <info@appvia.io>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+FORCE_IMAGE_PUSH=${FORCE_IMAGE_PUSH:-false}
+VERSION=${VERSION:-latest}
+
+# Used by CI to push without confirmation
+if [[ ${FORCE_IMAGE_PUSH} == true ]]; then
+  echo "Force image push detected, skipping checks"
+  exit 0
+fi
+
+if [[ "${VERSION}" == "latest" ]]; then
+  if [[ ${BRANCH} != "master" ]]; then
+    echo "Refusing to push latest on none master branch"
+    exit 1
+  fi
+
+  echo "Are you REALLY sure you want to push image latest? (y/n)"
+  read -n1 choice
+  if [[ ! "${choice}" =~ ^[Yy]$ ]]; then
+    echo "exitting without pushing images"
+    exit 1
+  fi
+fi

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -6,7 +6,7 @@ OPENAPIGEN_VERSION=v4.3.1
 
 default: build
 
-deps: 
+deps:
 	@echo "--> Preparing"
 	npm install
 
@@ -113,6 +113,7 @@ check-kore-models:
 
 docker-release:
 	@echo "--> Building a release image"
+	@../hack/verify-release-images.sh
 	@$(MAKE) docker
 	@docker push ${REGISTRY}/${AUTHOR}/${NAME}:${VERSION}
 


### PR DESCRIPTION
## Summary

The issue with having this set to the latest tag is those build of master SHOULD get master/latest else you can end up with weird edge cases due to the fact the tag is carried through to things like the images versions and the github release. This change should make it work as as expected i.e. if you build the binaries off master you get latest images and if you pull from a release it's tagged with an actual release version. 

Issue was hit by some people whom were trying out Kore, building binaries off master and hitting issues.

**Which issue(s) this PR resolves**:

Resolves BUG

## Checklist

 - [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): NONE

## Changes

When building from master you get latest images. CircleCI passes the tag into the build and so binaries built from a tag trigger will have the version embedded.

## Follow-up stories

NA