### PR TITLE
Allow to run the Kore API Server using HTTPS

### DIFF
--- a/charts/kore/templates/ingress.yaml
+++ b/charts/kore/templates/ingress.yaml
@@ -15,7 +15,7 @@ spec:
       paths:
       - backend:
           serviceName: {{ include "kore.name" . }}-apiserver
-          servicePort: 10080
+          servicePort: {{ .Values.api.port }}
         path: /
   {{- if .Values.api.ingress.tls_secret }}
   tls:

--- a/charts/kore/templates/kore.yml
+++ b/charts/kore/templates/kore.yml
@@ -78,11 +78,13 @@ spec:
           httpGet:
             path: /healthz
             port: 10080
+            scheme: {{ if .Values.api.tls.enabled }}HTTPS{{ else }}HTTP{{ end}}
           initialDelaySeconds: 30
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10080
+            scheme: {{ if .Values.api.tls.enabled }}HTTPS{{ else }}HTTP{{ end}}
           initialDelaySeconds: 30
         env:
           {{- if .Values.api.images.auth_proxy }}
@@ -98,9 +100,9 @@ spec:
           - name: KUBE_IN_CLUSTER
             value: "true"
           - name: KORE_CERTIFICATE_AUTHORITY
-            value: /ca/ca.pem
+            value: /secrets/ca/ca.pem
           - name: KORE_CERTIFICATE_AUTHORITY_KEY
-            value: /ca/ca-key.pem
+            value: /secrets/ca/ca-key.pem
           - name: KORE_API_PUBLIC_URL
             {{- if and (eq .Values.api.serviceType "LoadBalancer") .Values.api.endpoint.detect}}
             valueFrom:
@@ -139,10 +141,21 @@ spec:
             value: "{{ .Values.api.enable_metrics }}"
           - name: METRICS_PORT
             value: "{{ .Values.api.metrics_port }}"
+          {{- if .Values.api.tls.enabled }}
+          - name: TLS_CERT
+            value: /secrets/tls/server.cert
+          - name: TLS_KEY
+            value: /secrets/tls/server.key
+          {{- end }}
         volumeMounts:
         - name: ca
           readOnly: true
-          mountPath: /ca
+          mountPath: /secrets/ca
+        {{- if .Values.api.tls.enabled }}
+        - name: tls
+          readOnly: true
+          mountPath: /secrets/tls
+        {{- end }}
         {{ if eq .Values.api.version "dev" -}}
         - name: kore
           mountPath: /go/src/github.com/appvia/kore
@@ -153,6 +166,11 @@ spec:
       - name: ca
         secret:
           secretName: {{ .Values.ca.secretName }}
+      {{- if .Values.api.tls.enabled }}
+      - name: tls
+        secret:
+          secretName: {{ default .Values.api.tls.secretName (printf "%s-%s" (include "kore.name" . ) "api-tls") }}
+      {{- end}}
       {{ if eq .Values.api.version "dev" -}}
       - name: kore
         hostPath:

--- a/charts/kore/templates/portal.yml
+++ b/charts/kore/templates/portal.yml
@@ -71,7 +71,7 @@ spec:
           value: {{ .Values.ui.endpoint.url }}
           {{- end }}
         - name: KORE_API_URL
-          value: http://{{ include "kore.name" . }}-apiserver:10080/api/v1alpha1
+          value: {{ if .Values.api.tls.enabled }}https{{ else }}http{{ end }}://{{ include "kore.name" . }}-apiserver:{{ .Values.api.port }}/api/v1alpha1
         {{- if .Values.ui.show_prototypes }}
         - name: KORE_UI_SHOW_PROTOTYPES
           value: "{{ .Values.ui.show_prototypes }}"
@@ -98,21 +98,38 @@ spec:
         - name: KORE_FEATURE_GATES
           value: "{{ join "," .Values.ui.feature_gates }}"
         {{- end }}
+        {{- if .Values.api.tls.enabled }}
+        - name: NODE_EXTRA_CA_CERTS
+          value: /secrets/tls/ca.cert
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "kore.name" . }}-idp
-        {{ if eq .Values.ui.version "dev" -}}
         volumeMounts:
+        {{ if eq .Values.ui.version "dev" -}}
         - name: kore
           mountPath: /go/src/github.com/appvia/kore
         {{- end }}
-      {{ if eq .Values.ui.version "dev" -}}
+        {{- if .Values.api.tls.enabled }}
+        - name: tls
+          readOnly: true
+          mountPath: /secrets/tls
+        {{- end }}
       volumes:
+      {{ if eq .Values.ui.version "dev" -}}
       - name: kore
         hostPath:
           path: /go/src/github.com/appvia/kore
           type: Directory
       {{- end }}
+      {{- if .Values.api.tls.enabled }}
+      - name: tls
+        secret:
+          secretName: {{ default .Values.api.tls.secretName (printf "%s-%s" (include "kore.name" . ) "api-tls") }}
+          items:
+            - key: ca.cert
+              path: ca.cert
+      {{- end}}
 
 ---
 apiVersion: v1

--- a/charts/kore/templates/secret.yaml
+++ b/charts/kore/templates/secret.yaml
@@ -16,6 +16,30 @@ data:
   ca-key.pem: {{ .Key | b64enc }}
   {{- end }}
 {{- end }}
+
+{{- if and .Values.api.tls.enabled (not .Values.api.tls.secretName) }}
+{{- if not (lookup "v1" "Secret" .Release.Namespace (printf "%s%s" (include "kore.name" .) "-api-tls")) }}
+{{ $ca := genCA "svc-cat-ca" 3650 }}
+{{ $dn := printf "kore-apiserver.%s.svc.cluster.local" .Release.Namespace }}
+{{ $server := genSignedCert "" (list "127.0.0.1") (list "localhost" "kore-apiserver" $dn) 365 $ca }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kore.name" . }}-api-tls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+  labels:
+{{ include "kore.labels" . | indent 4}}
+type: Opaque
+data:
+  ca.cert: {{ $ca.Cert | b64enc }}
+  server.cert: {{ $server.Cert | b64enc }}
+  server.key: {{ $server.Key | b64enc }}
+{{- end }}
+{{- end }}
+
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/kore/values.yaml
+++ b/charts/kore/values.yaml
@@ -53,6 +53,9 @@ api:
     - openid
   auth_plugin_config: {}
   replicas: 2
+  tls:
+    enabled: false
+    secretName: ""
 ui:
   feature_gates: []
   endpoint:

--- a/cmd/kore-apiserver/server.go
+++ b/cmd/kore-apiserver/server.go
@@ -62,6 +62,8 @@ func invoke(ctx *cli.Context) error {
 			MetricsPort:     ctx.Int("metrics-port"),
 			ProfilingPort:   ctx.Int("profiling-port"),
 			SwaggerUIPath:   "./swagger-ui",
+			TLSCert:         ctx.String("tls-cert"),
+			TLSKey:          ctx.String("tls-key"),
 		},
 		Kubernetes: kubernetes.KubernetesAPI{
 			InCluster:    ctx.Bool("in-cluster"),

--- a/doc/development/api-enable-tls.md
+++ b/doc/development/api-enable-tls.md
@@ -1,0 +1,42 @@
+## Enable TLS in the Kore API server
+
+These instructions assume you will use 10443 as your HTTPS port. You can still use 10080.
+
+### Prerequisites
+
+Add `https://localhost:10443/oauth/callback` to the allowed callback URL list in your IDP.
+
+### When using Helm
+
+You have to set the following Helm variables in `my_values.yaml`:
+
+```
+api:
+  endpoint:
+    url: https://localhost:10443
+  port: 10443
+  hostPort: 10443
+  tls:
+    enabled: true
+```
+
+### When using local up
+
+```
+kore alpha local up \
+  --set="api.endpoint.url=https://localhost:10443" \
+  --set="api.port=10443" \
+  --set="api.hostPort=10443"\
+   --set="api.tls.enabled=true"
+```
+
+### Setting the CA certificate in the Kore CLI configuration
+
+Run `kore login` or `kore profiles configure` to automatically import a local CA certificate
+
+E.g.:
+```
+kore login -a https://localhost:10443 local -f
+```
+
+The CA certificate will be stored in `.kore/config` with the server configuration.

--- a/doc/local-quick-start.md
+++ b/doc/local-quick-start.md
@@ -119,7 +119,7 @@ Give the application a name and choose `Regular Web Applications`
 Once provisioned click on the `Settings` tab and scroll down to `Allowed Callback URLs`.
 These are the permitted redirects for the applications. Since we are running the application locally off the laptop set
 ```
-http://localhost:10080/oauth/callback,http://localhost:3000/auth/callback
+http://localhost:10080/oauth/callback,https://localhost:10443/oauth/callback,http://localhost:3000/auth/callback
 ```
 
 Please make a note of the [__*Domain, Client ID, and Client Secret*__].
@@ -184,7 +184,7 @@ You now have to login to be able to create teams and provision environments.
 This will use our Auth0 set up for IDP. As you're the only user, you'll be assigned Admin privileges.
 
 ```shell script
-./kore login -a http//localhost:10080 local
+./kore login -a http://localhost:10080 local
 # Attempting to authenticate to Kore: http://127.0.0.1:10080 [local]
 # Successfully authenticated
 ```

--- a/pkg/client/config/types.go
+++ b/pkg/client/config/types.go
@@ -94,7 +94,8 @@ type Profile struct {
 // Server defines an endpoint for the api server
 type Server struct {
 	// Endpoint the url for the api endpoint of kore
-	Endpoint string `json:"server,omitempty" yaml:"server,omitempty"`
+	Endpoint      string `json:"server,omitempty" yaml:"server,omitempty"`
+	CACertificate string `json:"caCertificate,omitempty" yaml:"caCertificate,omitempty"`
 }
 
 // RefreshResponse is the response returned when a token is refreshed

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -21,18 +21,12 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"net/http"
 
 	"github.com/appvia/kore/pkg/client"
 )
 
 // Request creates a request instance
 func (f *fake) Request() client.RestInterface {
-	return f
-}
-
-// HTTPClient sets the http client
-func (f *fake) HTTPClient(*http.Client) client.Interface {
 	return f
 }
 

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -24,8 +24,6 @@ import (
 
 // Interface is the api client interface
 type Interface interface {
-	// HTTPClient sets the http client
-	HTTPClient(*http.Client) Interface
 	// Request creates a request instance
 	Request() RestInterface
 	// CurrentProfile returns the current profile

--- a/pkg/cmd/kore/local/helm.go
+++ b/pkg/cmd/kore/local/helm.go
@@ -147,6 +147,9 @@ func DefaultHelmValues() map[string]interface{} {
 
 	return map[string]interface{}{
 		"api": map[string]interface{}{
+			"endpoint": map[string]interface{}{
+				"url": "http://localhost:10080",
+			},
 			"feature_gates": features,
 			"hostPort":      10080,
 			"replicas":      1,

--- a/pkg/cmd/kore/local/providers/kind/kind.go
+++ b/pkg/cmd/kore/local/providers/kind/kind.go
@@ -68,6 +68,9 @@ nodes:
   - containerPort: 10080
     hostPort: 10080
     protocol: TCP
+  - containerPort: 10443
+    hostPort: 10443
+    protocol: TCP
 `
 )
 

--- a/scripts/kind_dev.sh
+++ b/scripts/kind_dev.sh
@@ -42,6 +42,9 @@ nodes:
       - containerPort: 10080
         hostPort: 10080
         protocol: TCP
+      - containerPort: 10443
+        hostPort: 10443
+        protocol: TCP
     extraMounts:
       - hostPath: $PROJECT_DIR
         containerPath: /go/src/github.com/appvia/kore

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -4,3 +4,6 @@ node_modules
 # config
 dev.env
 demo.env
+
+# node configuration
+node_extra_ca_certs.pem

--- a/ui/scripts/run-with-env.sh
+++ b/ui/scripts/run-with-env.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." >/dev/null 2>&1 && pwd )"
+
 for idpvar in KORE_IDP_CLIENT_ID KORE_IDP_CLIENT_SECRET KORE_IDP_SERVER_URL KORE_IDP_USER_CLAIMS KORE_IDP_CLIENT_SCOPES; do
   export ${idpvar}=$(kubectl --context kind-kore -n kore get secret kore-idp -o json | jq -r ".data.${idpvar}" | base64 --decode)
 done
@@ -10,5 +12,19 @@ export KORE_API_TOKEN=$(kubectl --context kind-kore -n kore get secret kore-api 
 
 export KORE_FEATURE_GATES="services=true,application_services=true,monitoring_services=true"
 export KORE_UI_SHOW_PROTOTYPES=true
+
+KORE_API_URL=$(kubectl --context kind-kore -n kore get deployment kore-apiserver -o=jsonpath="{.spec.template.spec.containers[?(.name=='kore-apiserver')].env[?(.name == 'KORE_API_PUBLIC_URL')].value}")
+
+export KORE_API_PUBLIC_URL=${KORE_API_URL}
+export KORE_API_URL=${KORE_API_URL}/api/v1alpha1
+
+set +e
+CA_CERT=$( kubectl --context kind-kore get secret -n kore kore-api-tls -o=jsonpath='{.data.ca\.cert}' | base64 -D)
+set -e
+
+if [ -n "${CA_CERT}" ]; then
+  echo "${CA_CERT}" > "${ROOT_DIR}/ui/node_extra_ca_certs.pem"
+  export NODE_EXTRA_CA_CERTS="${ROOT_DIR}/ui/node_extra_ca_certs.pem"
+fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

This adds full https support to the kore API server. I've made changes to the Helm chart and the local run scripts, so the UI works with an untrusted CA in both cases.

The only case where we skip the certificate check is when `kore alpha local up` waits for the API server's `/healtz` endpoint, otherwise we always use the provided CA certificate.

## Changes

 * Generate a separate CA and server certificate for TLS
 * Add `api.tls.enabled` and `api.tls.secretName` variables to Helm
 * Bugfix: properly set the `TLSCert` and `TLSKey` config values from the API server CLI params.
 * The CLI config can store an optional CA certificate for the API
 * For https localhost API server URLs the `kore` CLI will automatically save the CA certificate when using `kore profiles configure` or `kore login`
 * open port 10443 in kind (both local dev and `kore alpha local`)

## Testing

These instructions assume you will use 10443 as your HTTPS port. You can still use 10080.

I've built all required Docker images with the `https_support` tag.

### Prerequisites

Add `https://localhost:10443/oauth/callback` to the allowed callback URL list in your IDP.

### Local development ###

Change your **my_values.yaml**:
```
api:
  endpoint:
    url: https://localhost:10443
  port: 10443
  hostPort: 10443
  tls:
    enabled: true
```

Run kore with `make kind-dev` and the ui with `make run` from the ui directory.

Run login from the CLI: `kore login -a https://localhost:10443 local -f` (this is needed so we fetch the generated CA certificate) + test the UI (login + some simple functionality).

### Kore local up ###

```
kore alpha local up \
  --version https_support \
  --release ./charts/kore \
  --set="api.endpoint.url=https://localhost:10443" \
  --set="api.port=10443" \
  --set="api.hostPort=10443"\
   --set="api.tls.enabled=true"
```

Run login from the CLI: `kore login -a https://localhost:10443 local -f` (this is needed so we fetch the generated CA certificate) + test the UI (login + some simple functionality).
