### PR TITLE
Login Fix

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"errors"
 	"io"
 
 	"github.com/appvia/kore/pkg/kore"
@@ -148,10 +147,10 @@ func (c *Config) AddAuthInfo(name string, auth *AuthInfo) {
 // HasValidProfile checks we have a current context
 func (c *Config) HasValidProfile(name string) error {
 	if name == "" {
-		return errors.New("no profile selected")
+		return ErrNoProfileSelected
 	}
 	if !c.HasServer(c.Profiles[name].Server) {
-		return errors.New("profile does not have a server endpoint")
+		return ErrNoProfileEndpoint
 	}
 
 	return nil

--- a/pkg/client/config/errors.go
+++ b/pkg/client/config/errors.go
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import "errors"
+
+var (
+	// ErrNoProfileSelected indicates the current profile is empty
+	ErrNoProfileSelected = errors.New("no profile selected")
+	// ErrNoProfileEndpoint indicates the profile does not have a endpoint
+	ErrNoProfileEndpoint = errors.New("profile does not have a server endpoint")
+)


### PR DESCRIPTION
## Summary

- fixing the kore login command when the configuration is empty

```shell
[jest@starfury kore]$ kore login -a http://localhost:10080 local
Unable to authenticate: no profile selected
You may need to reconfigure your profile via $ kore profile configure
Error: invalid profile

Afterward

[jest@starfury kore]$ kore login -a http://localhost:10080 local
Attempting to authenticate to Kore: http://localhost:10080 [local]
Successfully authenticated to local
```

**Which issue(s) this PR resolves**:

Resolves BUG

## Checklist

 - [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): NA

## Changes

On empty configuration we were throwing an error and not allowing it through without a full: `kore profile configure`

## Testing

Empty your configuration, build off master and try `kore login -a http://<api> <name>`

Then build off the branch and retry

## Follow-up stories

https://github.com/appvia/kore-planning/issues/143
