### PR TITLE
Plan duplication

### DIFF
--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -231,6 +231,13 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch(`${testPlan.name} plan deleted`)
     })
 
+    it('allows copying of a plan', async() => {
+      await clusterPlansPage.copy('gke-development')
+      await expect(page).toMatch('New GKE plan')
+      await expect(page).toMatch('Copy of plan "GKE Development Cluster"')
+      await clusterPlansPage.save()
+      await expect(page).toMatch('GKE plan created successfully')
+    })
   })
 
   describe('Cluster Policies', () => {
@@ -316,6 +323,13 @@ describe('Configure Cloud - GCP', () => {
       await expect(page).toMatch('Policy Updated Policy Description deleted')
     })
 
+    it('allows copying of a policy', async() => {
+      await policiesPage.copy('default-gke')
+      await expect(page).toMatch('New GKE policy')
+      await expect(page).toMatch('Copy of policy "Default plan policy for GKE clusters"')
+      await policiesPage.save()
+      await expect(page).toMatch('Policy created successfully')
+    })
   })
 
 })

--- a/ui/__tests__/e2e/03-configure-cloud-aws.test.js
+++ b/ui/__tests__/e2e/03-configure-cloud-aws.test.js
@@ -158,6 +158,14 @@ describe('Configure Cloud - AWS', () => {
       await awsClusterPlansPage.confirmDelete()
       await expect(page).toMatch(`${testPlan.name} plan deleted`)
     })
+
+    it('allows copying of a plan', async() => {
+      await awsClusterPlansPage.copy('eks-development')
+      await expect(page).toMatch('New EKS plan')
+      await expect(page).toMatch('Copy of plan "EKS Development Cluster"')
+      await awsClusterPlansPage.save()
+      await expect(page).toMatch('EKS plan created successfully')
+    })
   })
 
   describe('Cluster Policies', () => {
@@ -243,6 +251,13 @@ describe('Configure Cloud - AWS', () => {
       await expect(page).toMatch('Policy Updated Policy Description deleted')
     })
 
+    it('allows copying of a policy', async() => {
+      await policiesPage.copy('default-eks')
+      await expect(page).toMatch('New EKS policy')
+      await expect(page).toMatch('Copy of policy "Default plan policy for EKS clusters"')
+      await policiesPage.save()
+      await expect(page).toMatch('Policy created successfully')
+    })
   })
 
 })

--- a/ui/__tests__/e2e/04-configure-cloud-azure.test.js
+++ b/ui/__tests__/e2e/04-configure-cloud-azure.test.js
@@ -162,6 +162,14 @@ describe('Configure Cloud - Azure', () => {
       await azureClusterPlansPage.confirmDelete()
       await expect(page).toMatch(`${testPlan.name} plan deleted`)
     })
+
+    it('allows copying of a plan', async() => {
+      await azureClusterPlansPage.copy('aks-development')
+      await expect(page).toMatch('New AKS plan')
+      await expect(page).toMatch('Copy of plan "AKS Development Cluster"')
+      await azureClusterPlansPage.save()
+      await expect(page).toMatch('AKS plan created successfully')
+    })
   })
 
   describe('Cluster Policies', () => {
@@ -247,6 +255,13 @@ describe('Configure Cloud - Azure', () => {
       await expect(page).toMatch('Policy Updated Policy Description deleted')
     })
 
+    it('allows copying of a policy', async() => {
+      await policiesPage.copy('default-aks')
+      await expect(page).toMatch('New AKS policy')
+      await expect(page).toMatch('Copy of policy "Default plan policy for AKS clusters"')
+      await policiesPage.save()
+      await expect(page).toMatch('Policy created successfully')
+    })
   })
 
 })

--- a/ui/__tests__/e2e/page-objects/configure/cloud/cluster-plans-base.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/cluster-plans-base.js
@@ -16,6 +16,11 @@ export class ConfigureCloudClusterPlansBase extends ConfigureCloudPage {
     await waitForDrawerOpenClose(this.p)
   }
 
+  async copy(name) {
+    await this.p.click(`a#plans_copy_${name}`)
+    await waitForDrawerOpenClose(this.p)
+  }
+
   async delete(name) {
     await this.p.click(`a#plans_delete_${name}`)
   }

--- a/ui/__tests__/e2e/page-objects/configure/cloud/cluster-policies-base.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/cluster-policies-base.js
@@ -16,6 +16,11 @@ export class ConfigureCloudClusterPoliciesBase extends ConfigureCloudPage {
     await waitForDrawerOpenClose(this.p)
   }
 
+  async copy(name) {
+    await this.p.click(`a#policy_copy_${name}`)
+    await waitForDrawerOpenClose(this.p)
+  }
+
   async delete(name) {
     await this.p.click(`a#policy_delete_${name}`)
   }

--- a/ui/lib/components/credentials/AWSOrganization.js
+++ b/ui/lib/components/credentials/AWSOrganization.js
@@ -33,8 +33,25 @@ class AWSOrganization extends AutoRefreshComponent {
     }
   }
 
+  actions = () => {
+    const { organization, editOrganization, deleteOrganization } = this.props
+    return [
+      <ResourceVerificationStatus key="verification_status" resourceStatus={organization.status} />,
+      <Text key="delete_org">
+        <Tooltip title="Delete this organization">
+          <a id={`awsorg_del_${organization.metadata.name}`}  onClick={deleteOrganization(organization)}><Icon type="delete" /></a>
+        </Tooltip>
+      </Text>,
+      <Text key="edit">
+        <Tooltip title="Edit this organization">
+          <a id={`awsorg_edit_${organization.metadata.name}`} onClick={editOrganization(organization)}><Icon type="edit" /></a>
+        </Tooltip>
+      </Text>
+    ]
+  }
+
   render() {
-    const { organization, editOrganization, deleteOrganization, allTeams } = this.props
+    const { organization, allTeams } = this.props
     const created = moment(organization.metadata.creationTimestamp).fromNow()
 
     const displayAllocations = () => {
@@ -46,11 +63,7 @@ class AWSOrganization extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item id={`awsorg_${organization.metadata.name}`} key={organization.metadata.name} actions={[
-        <ResourceVerificationStatus key="verification_status" resourceStatus={organization.status} />,
-        <Text key="delete_org"><a id={`awsorg_del_${organization.metadata.name}`}  onClick={deleteOrganization(organization)}><Icon type="delete" theme="filled"/> Delete</a></Text>,
-        <Text key="edit"><a id={`awsorg_edit_${organization.metadata.name}`} onClick={editOrganization(organization)}><Icon type="edit" theme="filled"/> Edit</a></Text>
-      ]}>
+      <List.Item id={`awsorg_${organization.metadata.name}`} key={organization.metadata.name} actions={this.actions()}>
         <List.Item.Meta
           avatar={<Avatar icon="cloud" />}
           title={

--- a/ui/lib/components/credentials/Credentials.js
+++ b/ui/lib/components/credentials/Credentials.js
@@ -38,8 +38,25 @@ class Credentials extends AutoRefreshComponent {
     }
   }
 
+  actions = () => {
+    const { provider, credentials, editCredential, deleteCredential } = this.props
+    return [
+      <ResourceVerificationStatus key="verification_status" resourceStatus={credentials.status} />,
+      <Text key="delete_creds">
+        <Tooltip title="Delete this credential">
+          <a id={`${provider.toLowerCase()}creds_del_${credentials.metadata.name}`} onClick={deleteCredential(credentials)}><Icon type="delete" /></a>
+        </Tooltip>
+      </Text>,
+      <Text key="show_creds">
+        <Tooltip title="Edit this credential">
+          <a id={`${provider.toLowerCase()}creds_edit_${credentials.metadata.name}`} onClick={editCredential(credentials)}><Icon type="edit" /></a>
+        </Tooltip>
+      </Text>
+    ]
+  }
+
   render() {
-    const { provider, identifierKey, credentials, editCredential, deleteCredential, allTeams } = this.props
+    const { provider, identifierKey, credentials, allTeams } = this.props
     const created = moment(credentials.metadata.creationTimestamp).fromNow()
 
     const displayAllocations = () => {
@@ -51,11 +68,7 @@ class Credentials extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item id={`${provider.toLowerCase()}creds_${credentials.metadata.name}`} key={credentials.metadata.name} actions={[
-        <ResourceVerificationStatus key="verification_status" resourceStatus={credentials.status} />,
-        <Text key="delete_creds"><a id={`${provider.toLowerCase()}creds_del_${credentials.metadata.name}`} onClick={deleteCredential(credentials)}><Icon type="delete" theme="filled"/> Delete</a></Text>,
-        <Text key="show_creds"><a id={`${provider.toLowerCase()}creds_edit_${credentials.metadata.name}`} onClick={editCredential(credentials)}><Icon type="edit" theme="filled"/> Edit</a></Text>
-      ]}>
+      <List.Item id={`${provider.toLowerCase()}creds_${credentials.metadata.name}`} key={credentials.metadata.name} actions={this.actions()}>
         <List.Item.Meta
           avatar={<Avatar icon="project" />}
           title={

--- a/ui/lib/components/credentials/GCPOrganization.js
+++ b/ui/lib/components/credentials/GCPOrganization.js
@@ -33,8 +33,25 @@ class GCPOrganization extends AutoRefreshComponent {
     }
   }
 
+  actions = () => {
+    const { organization, editOrganization, deleteOrganization } = this.props
+    return [
+      <ResourceVerificationStatus key="verification_status" resourceStatus={organization.status} />,
+      <Text key="delete_org">
+        <Tooltip title="Delete this organization">
+          <a id={`gcporg_del_${organization.metadata.name}`}  onClick={deleteOrganization(organization)}><Icon type="delete" /></a>
+        </Tooltip>
+      </Text>,
+      <Text key="edit">
+        <Tooltip title="Edit this organization">
+          <a id={`gcporg_edit_${organization.metadata.name}`} onClick={editOrganization(organization)}><Icon type="edit" /></a>
+        </Tooltip>
+      </Text>
+    ]
+  }
+
   render() {
-    const { organization, editOrganization, deleteOrganization, allTeams } = this.props
+    const { organization, allTeams } = this.props
     const created = moment(organization.metadata.creationTimestamp).fromNow()
 
     const displayAllocations = () => {
@@ -46,11 +63,7 @@ class GCPOrganization extends AutoRefreshComponent {
     }
 
     return (
-      <List.Item id={`gcporg_${organization.metadata.name}`} key={organization.metadata.name} actions={[
-        <ResourceVerificationStatus key="verification_status" resourceStatus={organization.status} />,
-        <Text key="delete_org"><a id={`gcporg_del_${organization.metadata.name}`}  onClick={deleteOrganization(organization)}><Icon type="delete" theme="filled"/> Delete</a></Text>,
-        <Text key="edit"><a id={`gcporg_edit_${organization.metadata.name}`} onClick={editOrganization(organization)}><Icon type="edit" theme="filled"/> Edit</a></Text>
-      ]}>
+      <List.Item id={`gcporg_${organization.metadata.name}`} key={organization.metadata.name} actions={this.actions()}>
         <List.Item.Meta
           avatar={<Avatar icon="cloud" />}
           title={

--- a/ui/lib/components/plans/ManageClusterPlanForm.js
+++ b/ui/lib/components/plans/ManageClusterPlanForm.js
@@ -133,6 +133,18 @@ class ManageClusterPlanForm extends ManagePlanForm {
     )
   }
 
+  copyPlanAlert = (data) => {
+    return (
+      <Alert
+        message={`Copy of plan "${data.copiedFrom}"`}
+        description="Change the plan values below as required and click Save to create"
+        type="info"
+        showIcon
+        style={{ marginBottom: '20px' }}
+      />
+    )
+  }
+
   formHeader = (formErrorMessage, mode, data) => {
     const { displayUnassociatedPlanWarning } = this.props
     return (
@@ -148,6 +160,8 @@ class ManageClusterPlanForm extends ManagePlanForm {
             style={{ marginBottom: '20px' }}
           />
         )}
+
+        {mode === 'create' && data ? this.copyPlanAlert(data) : null}
 
         {this.defaultFormHeader(formErrorMessage, mode, data)}
 

--- a/ui/lib/components/plans/PlanItem.js
+++ b/ui/lib/components/plans/PlanItem.js
@@ -16,6 +16,7 @@ class PlanItem extends React.Component {
     viewPlan: PropTypes.func.isRequired,
     editPlan: PropTypes.func.isRequired,
     deletePlan: PropTypes.func.isRequired,
+    copyPlan: PropTypes.func.isRequired,
     displayUnassociatedPlanWarning: PropTypes.bool.isRequired
   }
 
@@ -27,22 +28,30 @@ class PlanItem extends React.Component {
     if (this.props.displayUnassociatedPlanWarning) {
       actions.push(<IconTooltip key="warning" icon="warning" color="orange" text={`This plan not associated with any ${this.cloudInfo.cloud} automated ${pluralize(this.cloudInfo.accountNoun)} and will not be available for teams to use. Edit this plan or go to ${titleize(this.cloudInfo.accountNoun)} automation settings to review this.`}/>)
     }
-    actions.push(<Text key="view_plan"><a id={`plans_view_${this.props.plan.metadata.name}`} onClick={this.props.viewPlan(this.props.plan)}><Icon type="eye" theme="filled"/> View</a></Text>)
-    actions.push(
+
+    return [
+      ...actions,
+      <Text key="view_plan">
+        <Tooltip title="View this plan">
+          <a id={`plans_view_${this.props.plan.metadata.name}`} onClick={this.props.viewPlan(this.props.plan)}><Icon type="eye" /></a>
+        </Tooltip>
+      </Text>,
       <Text key="edit_plan">
         <Tooltip title="Edit this plan">
-          <a id={`plans_edit_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only. Create a new plan if this built-in plan does not meet your needs.' }) : this.props.editPlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
+          <a id={`plans_edit_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only. Create a new plan if this built-in plan does not meet your needs.' }) : this.props.editPlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" /></a>
         </Tooltip>
-      </Text>
-    )
-    actions.push(
+      </Text>,
       <Text key="delete_plan">
         <Tooltip title="Delete this plan">
-          <a id={`plans_delete_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only and cannot be deleted. To prevent teams using this plan, remove the allocation.' }) : this.props.deletePlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
+          <a id={`plans_delete_${this.props.plan.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This plan is read-only and cannot be deleted. To prevent teams using this plan, remove the allocation.' }) : this.props.deletePlan(this.props.plan)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" /></a>
+        </Tooltip>
+      </Text>,
+      <Text key="copy_plan">
+        <Tooltip title="Copy this plan">
+          <a id={`plans_copy_${this.props.plan.metadata.name}`} onClick={this.props.copyPlan(this.props.plan)}><Icon type="copy" /></a>
         </Tooltip>
       </Text>
-    )
-    return actions
+    ]
   }
 
   render() {

--- a/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
+++ b/ui/lib/components/plans/custom/PlanOptionEKSNodeGroups.js
@@ -220,7 +220,7 @@ export default class PlanOptionEKSNodeGroups extends PlanOptionBase {
                     {this.validationErrors(`${name}[${selectedIndex}].releaseVersion`)}
                   </Form.Item>
                   <PlanOptionClusterMachineType filterCategories={instanceTypeFilter} id={`${id_prefix}_instanceType`} {...this.props} displayName="AWS Instance Type" name={`${name}[${selectedIndex}].instanceType`} property={property.items.properties.instanceType} value={selected.instanceType} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'instanceType', v )} nodePriceSet={(prices) => this.setState({ prices })} />
-                  <PlanOption {...this.props} id={`${id_prefix}_instanceType`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
+                  <PlanOption {...this.props} id={`${id_prefix}_diskSize`} displayName="Instance Root Disk Size (GiB)" name={`${name}[${selectedIndex}].diskSize`} property={property.items.properties.diskSize} value={selected.diskSize} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'diskSize', v)} />
                 </Collapse.Panel>
                 <Collapse.Panel key="metadata" header="Metadata (labels, tags, etc)">
                   <PlanOption {...this.props} id={`${id_prefix}_labels`} displayName="Labels" help="Labels help kubernetes workloads find this group" name={`${name}[${selectedIndex}].labels`} property={property.items.properties.labels} value={selected.labels} onChange={(_, v) => this.setNodeGroupProperty(selectedIndex, 'labels', v)} />

--- a/ui/lib/components/policies/PolicyForm.js
+++ b/ui/lib/components/policies/PolicyForm.js
@@ -15,7 +15,8 @@ class PolicyForm extends React.Component {
     policy: PropTypes.object,
     allocatedTeams: PropTypes.array,
     kind: PropTypes.string.isRequired,
-    handleSubmit: PropTypes.func.isRequired
+    handleSubmit: PropTypes.func.isRequired,
+    creating: PropTypes.bool
   }
 
   state = {
@@ -98,7 +99,7 @@ class PolicyForm extends React.Component {
   fieldError = fieldKey => this.props.form.isFieldTouched(fieldKey) && this.props.form.getFieldError(fieldKey)
 
   render() {
-    const { form } = this.props
+    const { form, creating } = this.props
     const { submitting, policy, formErrorMessage } = this.state
     const { getFieldDecorator, getFieldsError } = form
 
@@ -118,6 +119,16 @@ class PolicyForm extends React.Component {
 
     return (
       <Form {...formConfig} onSubmit={this.handleSubmit}>
+
+        {creating && policy.copiedFrom ? (
+          <Alert
+            message={`Copy of policy "${policy.copiedFrom}"`}
+            description="Change the policy values below as required and click Save to create"
+            type="info"
+            showIcon
+            style={{ marginBottom: '20px' }}
+          />
+        ) : null}
 
         <FormErrorMessage message={formErrorMessage} />
 

--- a/ui/lib/components/policies/PolicyList.js
+++ b/ui/lib/components/policies/PolicyList.js
@@ -65,15 +65,19 @@ class PolicyList extends ResourceList {
     const readonly = isReadOnlyCRD(policy)
     return (
       <List.Item key={policy.metadata.name} actions={[
-        <Text key="view_policy"><a id={`policy_view_${policy.metadata.name}`} onClick={this.view(policy)}><Icon type="eye" theme="filled"/> View</a></Text>,
+        <Text key="view_policy">
+          <Tooltip title="Edit this policy">
+            <a id={`policy_view_${policy.metadata.name}`} onClick={this.view(policy)}><Icon type="eye" /></a>
+          </Tooltip>
+        </Text>,
         <Text key="edit_policy">
           <Tooltip title="Edit this policy">
-            <a id={`policy_edit_${policy.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This policy is read-only. Create a new policy to further restrict or allow changes.' }) : this.edit(policy)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" theme="filled"/> Edit</a>
+            <a id={`policy_edit_${policy.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This policy is read-only. Create a new policy to further restrict or allow changes.' }) : this.edit(policy)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="edit" /></a>
           </Tooltip>
         </Text>,
         <Text key="delete_policy">
           <Tooltip title="Delete this policy">
-            <a id={`policy_delete_${policy.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This policy is read-only and cannot be deleted. Create a new policy to further restrict or allow changes.' }) : this.delete(policy)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" theme="filled"/> Delete</a>
+            <a id={`policy_delete_${policy.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This policy is read-only and cannot be deleted. Create a new policy to further restrict or allow changes.' }) : this.delete(policy)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" /></a>
           </Tooltip>
         </Text>
       ]}>

--- a/ui/lib/components/policies/PolicyList.js
+++ b/ui/lib/components/policies/PolicyList.js
@@ -94,7 +94,7 @@ class PolicyList extends ResourceList {
         </Text>,
         <Text key="copy_policy">
           <Tooltip title="Copy this policy">
-            <a id={`plans_copy_${policy.metadata.name}`} onClick={this.copyPolicy(policy)}><Icon type="copy" /></a>
+            <a id={`policy_copy_${policy.metadata.name}`} onClick={this.copyPolicy(policy)}><Icon type="copy" /></a>
           </Tooltip>
         </Text>
       ]}>

--- a/ui/lib/components/policies/PolicyList.js
+++ b/ui/lib/components/policies/PolicyList.js
@@ -11,6 +11,7 @@ import Policy from './Policy'
 import PolicyForm from './PolicyForm'
 import AllocationHelpers from '../../utils/allocation-helpers'
 import { isReadOnlyCRD } from '../../utils/crd-helpers'
+import copy from '../../utils/object-copy'
 import { successMessage, warningMessage } from '../../utils/message'
 
 class PolicyList extends ResourceList {
@@ -60,6 +61,17 @@ class PolicyList extends ResourceList {
     return <>This policy applies to: <span style={{ fontWeight: 'bold' }}>{allocation.spec.teams.join(', ')}</span></>
   }
 
+  copyPolicy = (policy) => () => {
+    const policyCopy = copy(policy)
+    delete policyCopy.allocation
+    delete policyCopy.metadata
+    delete policyCopy.status
+    policyCopy.copiedFrom = policyCopy.spec.summary
+    policyCopy.spec.summary += ' COPY'
+    console.log('policyCopy', policyCopy)
+    this.add(policyCopy)()
+  }
+
   policyItem = (policy) => {
     const created = moment(policy.metadata.creationTimestamp).fromNow()
     const readonly = isReadOnlyCRD(policy)
@@ -78,6 +90,11 @@ class PolicyList extends ResourceList {
         <Text key="delete_policy">
           <Tooltip title="Delete this policy">
             <a id={`policy_delete_${policy.metadata.name}`} onClick={readonly ? () => warningMessage('Read Only', { description: 'This policy is read-only and cannot be deleted. Create a new policy to further restrict or allow changes.' }) : this.delete(policy)} style={{ color: readonly ? 'lightgray' : null }}><Icon type="delete" /></a>
+          </Tooltip>
+        </Text>,
+        <Text key="copy_policy">
+          <Tooltip title="Copy this policy">
+            <a id={`plans_copy_${policy.metadata.name}`} onClick={this.copyPolicy(policy)}><Icon type="copy" /></a>
           </Tooltip>
         </Text>
       ]}>
@@ -139,7 +156,8 @@ class PolicyList extends ResourceList {
           {!add ? null : 
             <PolicyForm
               kind={this.props.kind}
-              policy={{ spec: { kind: this.props.kind, properties: [] } }}
+              policy={typeof add === 'object' ? add : { spec: { kind: this.props.kind, properties: [] } }}
+              creating={true}
               handleSubmit={this.handleAddSave}
             />
           }


### PR DESCRIPTION
## Summary

Adding copy cluster plan functionality, along with the same for cluster policies for good measure 

**Which issue(s) this PR resolves**:
<!--
Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
If you don't want the issue to be auto-closed when the PR is merged, leave out "Resolves" and simply link the issue.
-->
Resolves #1015 

## Checklist

~- [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK~

## Changes

* adding a copy plan icon
* coping opens the new plan drawer with pre-filled data, which must be amended as required and saved
* an info alert informs the user what has happened

### Additional changes

* amending edit/delete icons for resources, to be more consistent, with tooltips
* removing unused `processPlanCreateEdit` function in `PlanList` component

## Screenshots

![clusterplan-copy](https://user-images.githubusercontent.com/1334068/89798098-abbf4a00-db23-11ea-855b-77d4604eb4ed.gif)

## Testing

Copying cluster plans and policies

## Follow-up stories

If you've created any related stories which should be done in the future (but not as part of this PR), please record it here.
