### PR TITLE
Enhancements for UI e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,8 @@ jobs:
             NODE_ENV: development
           command: |
             make test-e2e
+      - store_artifacts:
+          path: ./ui/__tests__/e2e/screenshots
 
   release-ui:
     environment:

--- a/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
+++ b/ui/__tests__/e2e/02-configure-cloud-gcp.test.js
@@ -4,6 +4,7 @@ const { ConfigureCloudGCPProjects } = require('./page-objects/configure/cloud/GC
 const { ConfigureCloudGCPClusterPlans } = require('./page-objects/configure/cloud/GCP/cluster-plans')
 const { ConfigureCloudGCPClusterPolicies } = require('./page-objects/configure/cloud/GCP/cluster-policies')
 const { ConfigureCloudClusterPoliciesBase } = require('./page-objects/configure/cloud/cluster-policies-base')
+const { retry } = require('./page-objects/utils')
 
 const page = global.page
 
@@ -232,8 +233,10 @@ describe('Configure Cloud - GCP', () => {
     })
 
     it('allows copying of a plan', async() => {
-      await clusterPlansPage.copy('gke-development')
-      await expect(page).toMatch('New GKE plan')
+      await retry(async () => {
+        await clusterPlansPage.copy('gke-development')
+        await expect(page).toMatch('New GKE plan')
+      })
       await expect(page).toMatch('Copy of plan "GKE Development Cluster"')
       await clusterPlansPage.save()
       await expect(page).toMatch('GKE plan created successfully')
@@ -324,8 +327,10 @@ describe('Configure Cloud - GCP', () => {
     })
 
     it('allows copying of a policy', async() => {
-      await policiesPage.copy('default-gke')
-      await expect(page).toMatch('New GKE policy')
+      await retry(async () => {
+        await policiesPage.copy('default-gke')
+        await expect(page).toMatch('New GKE policy')
+      })
       await expect(page).toMatch('Copy of policy "Default plan policy for GKE clusters"')
       await policiesPage.save()
       await expect(page).toMatch('Policy created successfully')

--- a/ui/__tests__/e2e/03-configure-cloud-aws.test.js
+++ b/ui/__tests__/e2e/03-configure-cloud-aws.test.js
@@ -3,6 +3,7 @@ const { ConfigureCloudAWSAccounts } = require('./page-objects/configure/cloud/AW
 const { ConfigureCloudAWSClusterPlans } = require('./page-objects/configure/cloud/AWS/cluster-plans')
 const { ConfigureCloudAWSClusterPolicies } = require('./page-objects/configure/cloud/AWS/cluster-policies')
 const { ConfigureCloudClusterPoliciesBase } = require('./page-objects/configure/cloud/cluster-policies-base')
+const { retry } = require('./page-objects/utils')
 
 const page = global.page
 
@@ -160,8 +161,10 @@ describe('Configure Cloud - AWS', () => {
     })
 
     it('allows copying of a plan', async() => {
-      await awsClusterPlansPage.copy('eks-development')
-      await expect(page).toMatch('New EKS plan')
+      await retry(async () => {
+        await awsClusterPlansPage.copy('eks-development')
+        await expect(page).toMatch('New EKS plan')
+      })
       await expect(page).toMatch('Copy of plan "EKS Development Cluster"')
       await awsClusterPlansPage.save()
       await expect(page).toMatch('EKS plan created successfully')
@@ -252,8 +255,10 @@ describe('Configure Cloud - AWS', () => {
     })
 
     it('allows copying of a policy', async() => {
-      await policiesPage.copy('default-eks')
-      await expect(page).toMatch('New EKS policy')
+      await retry(async () => {
+        await policiesPage.copy('default-eks')
+        await expect(page).toMatch('New EKS policy')
+      })
       await expect(page).toMatch('Copy of policy "Default plan policy for EKS clusters"')
       await policiesPage.save()
       await expect(page).toMatch('Policy created successfully')

--- a/ui/__tests__/e2e/04-configure-cloud-azure.test.js
+++ b/ui/__tests__/e2e/04-configure-cloud-azure.test.js
@@ -3,6 +3,7 @@ const { ConfigureCloudAzureSubscriptions } = require('./page-objects/configure/c
 const { ConfigureCloudAzureClusterPlans } = require('./page-objects/configure/cloud/Azure/cluster-plans')
 const { ConfigureCloudAzureClusterPolicies } = require('./page-objects/configure/cloud/Azure/cluster-policies')
 const { ConfigureCloudClusterPoliciesBase } = require('./page-objects/configure/cloud/cluster-policies-base')
+const { retry } = require('./page-objects/utils')
 
 const page = global.page
 
@@ -164,8 +165,10 @@ describe('Configure Cloud - Azure', () => {
     })
 
     it('allows copying of a plan', async() => {
-      await azureClusterPlansPage.copy('aks-development')
-      await expect(page).toMatch('New AKS plan')
+      await retry(async () => {
+        await azureClusterPlansPage.copy('aks-development')
+        await expect(page).toMatch('New AKS plan')
+      })
       await expect(page).toMatch('Copy of plan "AKS Development Cluster"')
       await azureClusterPlansPage.save()
       await expect(page).toMatch('AKS plan created successfully')
@@ -256,8 +259,10 @@ describe('Configure Cloud - Azure', () => {
     })
 
     it('allows copying of a policy', async() => {
-      await policiesPage.copy('default-aks')
-      await expect(page).toMatch('New AKS policy')
+      await retry(async () => {
+        await policiesPage.copy('default-aks')
+        await expect(page).toMatch('New AKS policy')
+      })
       await expect(page).toMatch('Copy of policy "Default plan policy for AKS clusters"')
       await policiesPage.save()
       await expect(page).toMatch('Policy created successfully')

--- a/ui/__tests__/e2e/page-objects/base.js
+++ b/ui/__tests__/e2e/page-objects/base.js
@@ -17,13 +17,6 @@ export class BasePage {
     return this.pagePath.replace('/', '').replace(/\//g,'-')
   }
 
-  async screenshot(filename) {
-    await this.p.screenshot({
-      fullPage: true,
-      path: `__tests__/e2e/screenshots/${filename}.png`
-    })
-  }
-
   verifyPageURL() {
     expect(this.p.url()).toBe(`${testUrl}${this.pagePath}`)
   }
@@ -55,24 +48,12 @@ export class BasePage {
   }
 
   async visitPage(query = '') {
-    try {
-      await this.p.goto(`${testUrl}${this.pagePath}${query}`)
-      await this.p.waitForSelector('body')
-    } catch (error) {
-      const filename = this.getFileName()
-      console.log(`Exception caught in visitPage, taking screenshot ${filename}.png. Error is: ${error}`)
-      await this.screenshot(`failed-visit-${filename}`)
-    }
+    await this.p.goto(`${testUrl}${this.pagePath}${query}`)
+    await this.p.waitForSelector('body')
   }
 
   async getHeading() {
-    try {
-      return await this.p.$eval('h1', el => el.innerHTML)
-    } catch (error) {
-      const filename = `failed-getHeading-${this.getFileName()}`
-      console.log(`Exception caught in getHeading on ${this.p.url()}, taking screenshot ${filename}.png. Error is: ${error}`)
-      await this.screenshot(filename)
-    }
+    return await this.p.$eval('h1', el => el.innerHTML)
   }
 
   async clickPrimaryButton(options) {

--- a/ui/__tests__/e2e/page-objects/configure/cloud/cluster-plans-base.js
+++ b/ui/__tests__/e2e/page-objects/configure/cloud/cluster-plans-base.js
@@ -40,6 +40,10 @@ export class ConfigureCloudClusterPlansBase extends ConfigureCloudPage {
   }
 
   async viewPlanConfig() {
+    await Promise.all([
+      this.p.waitForSelector('#plan_summary'),
+      this.p.waitForSelector('#plan_config')
+    ])
     await this.p.evaluate(() => {
       document.querySelector('#plan_config').scrollIntoView()
     })

--- a/ui/__tests__/e2e/page-objects/utils.js
+++ b/ui/__tests__/e2e/page-objects/utils.js
@@ -71,3 +71,15 @@ export async function popConfirmYes(pg, textToCheck) {
 export async function waitForDrawerOpenClose(pg) {
   await pg.waitFor(drawerOpenClosePause)
 }
+
+/**
+ * Retry the passing in async function once if it fails
+ * @param func
+ */
+export async function retry(func) {
+  try {
+    await func()
+  } catch (e) {
+    await func()
+  }
+}

--- a/ui/__tests__/reporter.js
+++ b/ui/__tests__/reporter.js
@@ -1,0 +1,23 @@
+const page = global.page
+
+async function takeScreenshot(name) {
+  await page.screenshot({
+    fullPage: true,
+    path: `__tests__/e2e/screenshots/${name}.png`
+  })
+}
+
+const reporter = {
+  specDone: async (result) => {
+    if (result.status === 'failed') {
+      try {
+        await takeScreenshot(result.fullName)
+      } catch (e) {
+        // just don't take a screenshot
+      }
+    }
+  },
+}
+
+/* eslint-disable no-undef */
+jasmine.getEnv().addReporter(reporter)

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   setupFiles: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/__tests__/reporter.js'],
   testPathIgnorePatterns: [
     '<rootDir>/.next/',
     '<rootDir>/node_modules/',


### PR DESCRIPTION
Fix for flakey plan/policy copy tests
* for some reason the drawer was not always showing
* the code shows that only the content of the drawer is conditional so this should be ok
* hack fix was to click the copy icon again if it failed

Attempted fix for `scrollIntoView` issues
* wait for the `#plan_config` and `#plan_summary` selectors before trying to scroll

Take screenshots of failed tests
* using the jasmine reporter
* uploading screenshots as artifacts on the CircleCI build
* example build with artifacts: https://app.circleci.com/pipelines/github/appvia/kore/4754/workflows/35284672-18f7-40bc-80e6-fe406d1b8716/jobs/21293/artifacts