### PR TITLE
Kore Costs Key

### DIFF
--- a/pkg/controllers/korefeatures/costsfeature.go
+++ b/pkg/controllers/korefeatures/costsfeature.go
@@ -54,7 +54,7 @@ func (c *Controller) getCostsServices(ctx kore.Context, config *configv1.KoreFea
 			service.Spec.ConfigurationFrom,
 			config.Spec.Configuration["gcp_credentials"],
 			"secrets.gcp_credentials",
-			"key")
+			"service_account_key")
 	}
 
 	if config.Spec.Configuration["aws_credentials"] != "" {

--- a/pkg/controllers/secrets/gcp/reconcile.go
+++ b/pkg/controllers/secrets/gcp/reconcile.go
@@ -42,7 +42,7 @@ var (
 	// ErrMultipleOrganizations indicates the service account as multiple orgs associated
 	ErrMultipleOrganizations = errors.New("multiple gcp organizations associated to service account")
 	// ErrMissingServiceAccountKey indicates the service account is missing
-	ErrMissingServiceAccountKey = errors.New("secret does not have a 'key' field holding the service account")
+	ErrMissingServiceAccountKey = errors.New("secret does not have a 'service_account_key' field holding the service account")
 )
 
 // Reconcile ensures the clusters roles across all the managed clusters
@@ -87,7 +87,7 @@ func (a ctrl) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 		secret.Status.Verified = utils.BoolPtr(false)
 
 		// @step: check the key is set
-		sa, found := copied.Spec.Data["key"]
+		sa, found := copied.Spec.Data["service_account_key"]
 		if !found {
 			return reconcile.Result{}, ErrMissingServiceAccountKey
 		}

--- a/ui/lib/components/credentials/GCPOrganizationForm.js
+++ b/ui/lib/components/credentials/GCPOrganizationForm.js
@@ -19,7 +19,7 @@ class GCPOrganizationForm extends VerifiedAllocatedResourceForm {
     const secretName = resourceName
     const teamResources = KoreApi.resources().team(this.props.team)
     if (!this.props.data || this.state.replaceKey) {
-      const secretData = { key: btoa(values.account) }
+      const secretData = { service_account_key: btoa(values.account) }
       const secretResource = teamResources.generateSecretResource(secretName, 'gcp-org', `GCP admin project Service Account for ${values.parentID}`, secretData)
       await api.UpdateTeamSecret(this.props.team, secretName, secretResource)
     }


### PR DESCRIPTION
## Summary

The credentials for gke were renamed at some point it's not longer 'key' but 'service_account_key'

**Which issue(s) this PR resolves**:

Resolves BUG

## Checklist

 - [ ] I've created a PR to update the [documentation](https://github.com/appvia/kore-docs): PR LINK

## Testing

Tested using 'kore alpha local up' and adding the korefeature as documented

Was getting the below before changing in the secret 
```
{"controller":"services","error":"key \"key\" does not exist in secret kore-admin/appvia","file":"/go/src/github.com/appvia/kore/pkg/controllers/services/reconcile.go:104","func":"github.com/appvia/kore/pkg/controllers/services.(*Controller).Reconcile","level":"error","msg":"failed to reconcile the service","name":"kore-costs","namespace":"kore-admin","time":"2020-08-19T12:06:06Z"}
{"controller":"korefeatures","error":"\"kore-costs\" admin service has an error status","file":"/go/src/github.com/appvia/kore/pkg/controllers/korefeatures/reconcile.go:113","func":"github.com/appvia/kore/pkg/controllers/korefeatures.(*Controller).Reconcile","level":"error","msg":"failed to reconcile the feature","name":"kore-costs","namespace":"kore","time":"2020-08-19T12:06:06Z"}
```
