### PR TITLE
Allow more time for cluster to load before trying to delete

### DIFF
--- a/ui/__tests__/e2e/page-objects/teams/index.js
+++ b/ui/__tests__/e2e/page-objects/teams/index.js
@@ -32,7 +32,7 @@ export class TeamPage extends BasePage {
   }
 
   async deleteCluster(name) {
-    expect(this.p).toClick(`#cluster_delete_${name}`)
+    expect(this.p).toClick(`#cluster_delete_${name}`, { timeout: 10000 })
   }
 
   async deleteClusterConfirm() {


### PR DESCRIPTION
Minor tweak to try to fix the latest failures.

The theory being that this timeout led to the errors showing in the logs
- team not deleted
- browser disconnected